### PR TITLE
Expose host capability negotiation

### DIFF
--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -1,0 +1,259 @@
+use awr_core::{Error, Result};
+use clap::Args;
+use serde::Serialize;
+use serde_json::json;
+use std::collections::BTreeSet;
+
+const PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Debug, Args)]
+pub struct CapabilitiesArgs {
+    /// Version of the capability negotiation contract, not the program version.
+    #[arg(long, default_value_t = PROTOCOL_VERSION)]
+    protocol_version: u32,
+    /// Require an available capability. Repeat for each prerequisite.
+    #[arg(long = "require")]
+    required: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct Capability {
+    id: &'static str,
+    available: bool,
+    commands: &'static [&'static str],
+    limitations: &'static [&'static str],
+}
+
+fn catalog() -> Vec<Capability> {
+    [
+        (
+            "source.read",
+            true,
+            &["source list", "source show"][..],
+            &["registered_sources_only", "bounded_body_reads"][..],
+        ),
+        (
+            "source.refresh",
+            true,
+            &["source scan", "source reindex", "source history"],
+            &["may_write_runtime", "partial_failure_requires_retry"],
+        ),
+        (
+            "intake.reviewed_draft",
+            true,
+            &["init", "intake inspect"],
+            &[
+                "explicit_accept",
+                "draft_fingerprint_checked",
+                "not_exact_write_inventory",
+            ],
+        ),
+        ("intake.exact_preview", false, &[], &["not_implemented"]),
+        (
+            "work.read",
+            true,
+            &["work show", "ready", "status"],
+            &["summaries_are_not_a_complete_catalog"],
+        ),
+        (
+            "object.read",
+            true,
+            &["object show", "decision show"],
+            &["explicit_object_reference", "bounded_body_reads"],
+        ),
+        ("project.catalog", false, &[], &["not_implemented"]),
+        (
+            "history.cursor",
+            true,
+            &["event history", "source history", "work history"],
+            &["revision_bound_cursor"],
+        ),
+        (
+            "context.compile",
+            true,
+            &["context compile"],
+            &["may_write_runtime", "incomplete_or_over_budget_is_failure"],
+        ),
+        (
+            "session.checkpoint",
+            true,
+            &["session checkpoint"],
+            &["explicit_session", "caller_supplied_digest"],
+        ),
+        (
+            "session.resume",
+            true,
+            &["session resume", "recovery inspect"],
+            &[
+                "inspect_is_separate_from_resume",
+                "not_native_client_resume",
+            ],
+        ),
+        (
+            "client.lifecycle.generic",
+            true,
+            &["client bind", "client progress", "client hook"],
+            &[
+                "documented_lifecycle_events_only",
+                "no_required_hook_installation",
+            ],
+        ),
+        (
+            "execution.external.register",
+            true,
+            &["execution register", "execution show"],
+            &["external_reference_unverified", "not_managed_execution"],
+        ),
+        (
+            "execution.managed",
+            true,
+            &["execution run", "execution inspect"],
+            &["local_supervisor", "project_scoped_operation_key"],
+        ),
+        (
+            "artifact.managed",
+            true,
+            &["artifact add", "artifact show", "artifact cat"],
+            &["add_copies_content", "bounded_authorized_reads"],
+        ),
+        (
+            "evidence.read_write",
+            true,
+            &["evidence add", "evidence show"],
+            &[
+                "registration_is_not_verification",
+                "command_field_is_not_executed",
+            ],
+        ),
+        (
+            "mutation.yaml.record",
+            true,
+            &["proposal create", "proposal apply"],
+            &[
+                "supported_fields_only",
+                "target_record_reserialized",
+                "state_requires_domain_action",
+                "single_file",
+            ],
+        ),
+        (
+            "mutation.yaml.lossless_fields",
+            false,
+            &[],
+            &["not_implemented"],
+        ),
+        ("mutation.work.create", false, &[], &["not_implemented"]),
+        ("mutation.markdown", false, &[], &["not_implemented"]),
+        ("mutation.human_save", false, &[], &["not_implemented"]),
+        ("mutation.multi_file", false, &[], &["not_implemented"]),
+        (
+            "completion.engineering",
+            true,
+            &["work complete"],
+            &[
+                "session_and_claim_required",
+                "source_sha_and_acceptance_evidence_required",
+            ],
+        ),
+        (
+            "completion.user_confirmation",
+            false,
+            &[],
+            &["not_implemented"],
+        ),
+    ]
+    .into_iter()
+    .map(|(id, available, commands, limitations)| Capability {
+        id,
+        available,
+        commands,
+        limitations,
+    })
+    .collect()
+}
+
+pub fn run(args: &CapabilitiesArgs, json_output: bool) -> Result<()> {
+    if args.protocol_version != PROTOCOL_VERSION {
+        return Err(Error::ProtocolUnsupported {
+            requested: args.protocol_version,
+            supported: vec![PROTOCOL_VERSION],
+        });
+    }
+    if args.required.len() > 100
+        || args.required.iter().any(|id| {
+            id.is_empty()
+                || id.len() > 128
+                || !id
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b"._-".contains(&b))
+        })
+    {
+        return Err(Error::InvalidInput(
+            "require accepts at most 100 capability IDs of 1..128 ASCII identifier characters"
+                .into(),
+        ));
+    }
+    let capabilities = catalog();
+    let mut unknown = Vec::new();
+    let mut unsupported = Vec::new();
+    for id in args.required.iter().collect::<BTreeSet<_>>() {
+        match capabilities.iter().find(|c| c.id == id) {
+            None => unknown.push(id.clone()),
+            Some(c) if !c.available => unsupported.push(id.clone()),
+            Some(_) => (),
+        }
+    }
+    if !unknown.is_empty() || !unsupported.is_empty() {
+        return Err(Error::CapabilityUnavailable {
+            unknown,
+            unsupported,
+        });
+    }
+    // Deliberately no project path, environment lookup, database open or source scan.
+    let value = json!({
+        "ok": true,
+        "protocol": {"name": "awr.host", "version": PROTOCOL_VERSION},
+        "program": {"name": "awr", "version": env!("CARGO_PKG_VERSION"),
+            "os": std::env::consts::OS, "arch": std::env::consts::ARCH},
+        "database": {"schema_version": awr_store::SCHEMA_VERSION,
+            "read_only_schema_versions": [awr_store::SCHEMA_VERSION],
+            "migrate_from_schema_versions": [1, 2],
+            "newer_schema_policy": "reject_without_migration",
+            "schema_validation_required": true},
+        "source_adapters": awr_source::SOURCE_ADAPTERS.iter().map(|id| json!({
+            "id": id, "read": true,
+            "write_mode": if *id == "yaml-ledger-v1" { "supported_record_reserialization" } else { "read_only" },
+            "lossless_field_write": false
+        })).collect::<Vec<_>>(),
+        "capabilities": capabilities,
+        "source_write_performed": false,
+        "runtime_write_performed": false,
+        "scope": "build_capabilities_not_project_authorization",
+        "transport": {"invocation": "argv", "json_flag": "--json",
+            "success_stream": "stdout", "error_stream": "stderr",
+            "exit_codes": {"success": 0, "runtime_error": 1, "usage_error": 2},
+            "partial_result_policy": "stdout_may_accompany_nonzero_exit",
+            "timeout_policy": "outcome_unknown_inspect_before_retry"}
+    });
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        println!(
+            "awr {} — host protocol {}",
+            env!("CARGO_PKG_VERSION"),
+            PROTOCOL_VERSION
+        );
+        for capability in capabilities {
+            println!(
+                "{}: {}",
+                capability.id,
+                if capability.available {
+                    "available"
+                } else {
+                    "unavailable"
+                }
+            );
+        }
+    }
+    Ok(())
+}

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -2,6 +2,7 @@ use awr_core::{Error, Result};
 use clap::{CommandFactory, Parser, Subcommand};
 use std::path::PathBuf;
 mod branch;
+mod capabilities;
 mod client;
 mod context;
 mod doctor;
@@ -36,6 +37,8 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Negotiate host capabilities without opening a project or its database.
+    Capabilities(capabilities::CapabilitiesArgs),
     /// Preview source authority mapping; --accept initializes using the reviewed mapping.
     Init(onboarding::InitArgs),
     /// Diagnose project organization and recheck readiness after source edits.
@@ -138,6 +141,7 @@ enum Command {
 
 fn run(cli: &Cli) -> Result<()> {
     match &cli.command {
+        Some(Command::Capabilities(args)) => capabilities::run(args, cli.json),
         Some(Command::Init(args)) => onboarding::run(&cli.project, args, cli.json),
         Some(Command::Intake { command }) => onboarding::inspect(&cli.project, command, cli.json),
         Some(Command::Client { command }) => client::run(&cli.project, command, cli.json),

--- a/crates/awr-cli/tests/host_capabilities.rs
+++ b/crates/awr-cli/tests/host_capabilities.rs
@@ -1,0 +1,164 @@
+use serde_json::Value;
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+};
+
+struct Host(PathBuf);
+impl Host {
+    fn new() -> Self {
+        let root = std::env::temp_dir().join(format!("awr 宿主 contract {}", awr_core::Id::new()));
+        fs::create_dir(&root).unwrap();
+        Self(root)
+    }
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_awr"))
+            .env_clear()
+            .current_dir(&self.0)
+            .stdin(Stdio::null())
+            .args(args)
+            .output()
+            .unwrap()
+    }
+    fn ok(&self, args: &[&str]) -> Value {
+        let result = self.run(args);
+        assert!(
+            result.status.success(),
+            "{}",
+            String::from_utf8_lossy(&result.stderr)
+        );
+        assert!(result.stderr.is_empty());
+        serde_json::from_slice(&result.stdout).unwrap()
+    }
+}
+impl Drop for Host {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn negotiation_needs_no_project_tty_model_or_environment() {
+    let host = Host::new();
+    let result = host.ok(&[
+        "capabilities",
+        "--json",
+        "--project",
+        "不存在的 project",
+        "--require",
+        "context.compile",
+    ]);
+    assert_eq!(result["protocol"]["version"], 1);
+    assert_eq!(result["program"]["version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(
+        result["database"]["schema_version"],
+        awr_store::SCHEMA_VERSION
+    );
+    assert_eq!(result["runtime_write_performed"], false);
+    assert_eq!(result["source_write_performed"], false);
+    assert_eq!(fs::read_dir(&host.0).unwrap().count(), 0);
+    // Stable discovery does not acquire a DB, emit timestamps or allocate identities.
+    assert_eq!(result, host.ok(&["--json", "capabilities"]));
+}
+
+#[test]
+fn callers_can_distinguish_unknown_from_known_unavailable_without_parsing_messages() {
+    let host = Host::new();
+    let result = host.run(&[
+        "capabilities",
+        "--json",
+        "--require",
+        "mutation.yaml.lossless_fields",
+        "--require",
+        "fictional.capability",
+        "--require",
+        "source.read",
+        "--require",
+        "fictional.capability",
+    ]);
+    assert_eq!(result.status.code(), Some(1));
+    assert!(result.stdout.is_empty());
+    let error: Value = serde_json::from_slice(&result.stderr).unwrap();
+    assert_eq!(error["code"], "CapabilityUnavailable");
+    assert_eq!(
+        error["details"]["unknown"],
+        serde_json::json!(["fictional.capability"])
+    );
+    assert_eq!(
+        error["details"]["unsupported"],
+        serde_json::json!(["mutation.yaml.lossless_fields"])
+    );
+    assert_eq!(error["details"]["runtime_write_performed"], false);
+    assert_eq!(fs::read_dir(&host.0).unwrap().count(), 0);
+}
+
+#[test]
+fn unsupported_protocol_and_invalid_usage_keep_distinct_error_codes() {
+    let host = Host::new();
+    let result = host.run(&["--json", "capabilities", "--protocol-version", "999"]);
+    assert_eq!(result.status.code(), Some(1));
+    assert!(result.stdout.is_empty());
+    let error: Value = serde_json::from_slice(&result.stderr).unwrap();
+    assert_eq!(error["code"], "ProtocolUnsupported");
+    assert_eq!(error["details"]["requested"], 999);
+    assert_eq!(error["details"]["supported"], serde_json::json!([1]));
+    let usage = host.run(&[
+        "--json",
+        "capabilities",
+        "--protocol-version",
+        "not-a-number",
+    ]);
+    assert_eq!(usage.status.code(), Some(2));
+    assert!(usage.stdout.is_empty());
+    assert_eq!(
+        serde_json::from_slice::<Value>(&usage.stderr).unwrap()["code"],
+        "InvalidInput"
+    );
+}
+
+#[test]
+fn source_read_support_does_not_advertise_lossless_or_markdown_writes() {
+    let host = Host::new();
+    let result = host.ok(&["--json", "capabilities"]);
+    let adapters = result["source_adapters"].as_array().unwrap();
+    for adapter in adapters {
+        assert_eq!(adapter["read"], true);
+        assert_eq!(adapter["lossless_field_write"], false);
+        if adapter["id"] == "yaml-ledger-v1" {
+            assert_eq!(adapter["write_mode"], "supported_record_reserialization");
+        } else {
+            assert_eq!(adapter["write_mode"], "read_only");
+        }
+    }
+    for id in [
+        "mutation.human_save",
+        "mutation.multi_file",
+        "completion.user_confirmation",
+        "project.catalog",
+        "intake.exact_preview",
+    ] {
+        let capability = result["capabilities"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["id"] == id)
+            .unwrap();
+        assert_eq!(capability["available"], false, "{id}");
+    }
+}
+
+#[test]
+fn discovery_does_not_open_or_migrate_an_existing_database() {
+    let host = Host::new();
+    fs::create_dir(host.0.join(".awr")).unwrap();
+    // Even malformed/future data is outside discovery's scope; opening would fail.
+    let db = host.0.join(".awr/state.db");
+    let config = host.0.join(".awr/project.toml");
+    fs::write(&db, b"opaque future database").unwrap();
+    fs::write(&config, b"future manifest").unwrap();
+    host.ok(&["--json", "capabilities"]);
+    assert_eq!(fs::read(db).unwrap(), b"opaque future database");
+    assert_eq!(fs::read(config).unwrap(), b"future manifest");
+    assert_eq!(fs::read_dir(host.0.join(".awr")).unwrap().count(), 2);
+}

--- a/crates/awr-core/src/error.rs
+++ b/crates/awr-core/src/error.rs
@@ -63,6 +63,13 @@ pub enum Error {
     InvalidInput(String),
     #[error("operation is not implemented: {0}")]
     Unsupported(String),
+    #[error("host protocol version {requested} is not supported")]
+    ProtocolUnsupported { requested: u32, supported: Vec<u32> },
+    #[error("required host capabilities are unavailable")]
+    CapabilityUnavailable {
+        unknown: Vec<String>,
+        unsupported: Vec<String>,
+    },
     #[error("storage error: {0}")]
     Storage(String),
     #[error(transparent)]
@@ -102,6 +109,8 @@ impl Error {
             Self::InvalidTransition(_) => "InvalidTransition",
             Self::InvalidInput(_) => "InvalidInput",
             Self::Unsupported(_) => "Unsupported",
+            Self::ProtocolUnsupported { .. } => "ProtocolUnsupported",
+            Self::CapabilityUnavailable { .. } => "CapabilityUnavailable",
             Self::Storage(_) => "Storage",
             Self::Io(_) => "Io",
             Self::Json(_) => "Json",
@@ -118,6 +127,14 @@ impl Error {
                 Self::BudgetExceeded { required, budget } => {
                     Some(serde_json::json!({"required": required, "budget": budget}))
                 }
+                Self::ProtocolUnsupported { requested, supported } => Some(serde_json::json!({
+                    "requested": requested, "supported": supported,
+                    "source_write_performed": false, "runtime_write_performed": false
+                })),
+                Self::CapabilityUnavailable { unknown, unsupported } => Some(serde_json::json!({
+                    "unknown": unknown, "unsupported": unsupported,
+                    "source_write_performed": false, "runtime_write_performed": false
+                })),
                 Self::CheckpointIncomplete { attempt_id, reason } => {
                     Some(serde_json::json!({"attempt_id":attempt_id,"reason":reason}))
                 }

--- a/crates/awr-source/src/lib.rs
+++ b/crates/awr-source/src/lib.rs
@@ -25,7 +25,9 @@ pub use ledger_mapping::LedgerMapping;
 pub use limits::{MARKDOWN_READ_CAP, YAML_READ_CAP, source_read_cap};
 pub use locator::{Locator, SourceSnapshot, fingerprint, read_capped, read_source_capped};
 mod safe_fs;
-pub use manifest::{ContextProfile, Manifest, ProjectConfig, SourceSpec, minimal_context};
+pub use manifest::{
+    ContextProfile, Manifest, ProjectConfig, SOURCE_ADAPTERS, SourceSpec, minimal_context,
+};
 pub use markdown::{
     MarkdownHeadingAdapter, MarkdownRulesAdapter, MarkdownSection, markdown_sections,
 };

--- a/crates/awr-source/src/manifest.rs
+++ b/crates/awr-source/src/manifest.rs
@@ -5,6 +5,15 @@ use std::{
     path::{Path, PathBuf},
 };
 
+/// Adapter identifiers accepted by source manifests in this build.
+pub const SOURCE_ADAPTERS: &[&str] = &[
+    "yaml-ledger-v1",
+    "markdown-ledger-v1",
+    "markdown-heading-v1",
+    "markdown-rules-v1",
+    "markdown-directory-v1",
+];
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Manifest {
@@ -110,15 +119,7 @@ impl Manifest {
                     source.domain, source.role
                 )));
             }
-            if ![
-                "yaml-ledger-v1",
-                "markdown-ledger-v1",
-                "markdown-heading-v1",
-                "markdown-rules-v1",
-                "markdown-directory-v1",
-            ]
-            .contains(&source.adapter.as_str())
-            {
+            if !SOURCE_ADAPTERS.contains(&source.adapter.as_str()) {
                 return Err(Error::Unsupported(format!(
                     "source adapter {}",
                     source.adapter

--- a/crates/awr-store/src/lib.rs
+++ b/crates/awr-store/src/lib.rs
@@ -40,7 +40,8 @@ pub use source_changes::{ProjectionChange, SourceState};
 use std::{path::Path, time::Duration};
 
 const APPLICATION_ID: i64 = 0x41575231;
-const SCHEMA_VERSION: i64 = 3;
+/// Schema written by this build. Exposed for offline host compatibility negotiation.
+pub const SCHEMA_VERSION: i64 = 3;
 const CATALOG_SQL: &str = include_str!("../migrations/001_catalog.sql");
 const DOMAIN_SQL: &str = include_str!("../migrations/002_domain.sql");
 const SEARCH_SQL: &str = include_str!("../migrations/003_search.sql");

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -1,0 +1,101 @@
+# Host application contract
+
+A host can invoke a pinned native `awr` binary with an argument array and separate
+stdout/stderr pipes. AWR does not require a visible terminal, model client, HTTP
+service or daemon. Pass the executable's absolute path; never interpolate project
+paths or user content into a shell command. A host owns its UI, client credentials,
+scheduling, notifications and knowledge processing. AWR owns the source-backed work
+projection, runtime records and its supported source mutations.
+
+## Discover before opening a project
+
+```text
+awr capabilities --json --protocol-version 1 --require source.read --require context.compile
+```
+
+This command neither opens a project nor reads, creates or migrates its database.
+It works before initialization and ignores the global `--project` argument. Its
+JSON contains:
+
+| Field | Meaning |
+| --- | --- |
+| `protocol.name`, `protocol.version` | `awr.host` capability negotiation contract, currently version 1 |
+| `program` | Build's program version and native OS/architecture, not proof of other platform releases |
+| `database` | Current schema, read-only compatible schemas, schemas eligible for migration and future-schema rejection policy |
+| `source_adapters` | Accepted adapter IDs and actual read/write limits |
+| `capabilities` | Stable IDs, availability, command entrypoints and coded limitations |
+| `scope` | Build capabilities only; never project-specific permission or readiness |
+| `source_write_performed`, `runtime_write_performed` | Both false for discovery |
+
+Hosts may ignore new fields and unrequested capabilities within protocol 1. Existing
+IDs keep their meaning; a materially different operation requires a new ID or protocol.
+The program version remains separate: pin the executable and its published checksum
+for the command schemas you consume. This negotiation version does not retroactively
+make every historical CLI result a new uniform envelope.
+
+Repeat `--require` to check all prerequisites. An unavailable required capability
+fails before project access. `CapabilityUnavailable.details.unknown` contains IDs
+this build does not recognize; `details.unsupported` contains recognized but
+unimplemented capabilities. Both lists are deterministic and deduplicated.
+`ProtocolUnsupported.details` returns the requested and supported protocol versions.
+Do not parse English messages to identify either condition.
+
+## Preserve CLI outcomes
+
+Use `--json` on operational commands. Successful JSON goes to stdout. Typed errors
+go to stderr as `{ "code": "...", "message": "...", "details": ... }`; optional
+details vary by error. Exit 0 means command success, 1 means a runtime/domain error,
+and 2 means usage/argument error. Help and version flags intentionally return text.
+
+A nonzero exit may accompany a useful partial stdout result, for example source
+refresh failures. Preserve both streams and the exit code. A parseable stdout object
+alone never means success or complete traversal. Timeouts or a lost pipe mean the
+write outcome is unknown: inspect the existing proposal/attempt/execution/session
+before retrying. Do not synthesize `source_write_performed: false` from a transport
+failure. Input paths and maximum sizes remain command-specific (`--input`, reviewed
+drafts, or documented lifecycle JSON on stdin); there is no universal JSON RPC wrapper.
+
+## Current read/write limits
+
+`source.read` and `object.read` operate on registered references with bounded body
+reads. Status, ready and summaries do not provide a complete project catalog. Consult
+`project.catalog` before relying on complete traversal. Queries that refresh source
+projections can write the runtime database; `read_only` and freshness fields are part
+of the result, not an inference from the command's name.
+
+`mutation.yaml.record` supports selected YAML fields through source-bound proposals;
+it reserializes the selected record. It preserves neither every comment nor its
+original quoting/formatting. Require `mutation.yaml.lossless_fields` if the host
+promises field-level preservation. Markdown adapters currently read sources; they do
+not authorize Markdown body or ledger writes. Unsupported capabilities are explicitly
+listed as unavailable, including human-save shortcuts, new tasks, multi-file writes
+and user-confirmed completion. Never route an unsupported operation through a generic
+status patch or a second writer.
+
+`work complete` retains the engineering contract: a real session/claim and evidence
+covering the source's acceptance criteria at the supplied source SHA. A source's raw
+completed status is a separate assertion. Registering evidence does not run its
+`command` field and does not itself verify the report.
+
+`execution.external.register` stores an external reference with an unverified outcome.
+It does not adopt a PID or create a managed supervisor. Native client resumption is
+not implied by `session.resume`. Generic lifecycle callbacks can save checkpoints
+without installing hooks; caller-provided summaries remain caller assertions. An
+artifact import copies content, while references in evidence/events keep their own
+documented read and verification rules.
+
+## Compatibility and recovery
+
+The schema declaration describes what this build can open, subject to ownership and
+integrity checks. A read-only open requires the current schema. A write-capable open
+may migrate eligible older schemas; discovery never does. A newer schema is rejected.
+Back up matching program version, original sources, manifest and SQLite runtime
+before an upgrade. Source projections are rebuildable; events and checkpoints are
+not reconstructed by reindexing source documents. A binary downgrade alone is not a
+database rollback procedure.
+
+One project keeps one source ledger. When replacing an existing host writer, switch
+only operations AWR actually supports, retain old runtime history as history, and
+compare stable references and counts before cutover. Do not turn imported completion
+claims into newly verified work. Host integration examples and local component checks
+are separate from actual native-client or full application acceptance.


### PR DESCRIPTION
Host applications currently have to infer CLI support from version strings or error text. This adds `awr capabilities --json` with protocol negotiation, required-capability checks, database compatibility and explicit source read/write limitations. Discovery never opens a project or migrates its database, and existing command output/exit behavior is preserved.

Validation: 5 host capability tests and 3 existing CLI output-contract tests passed; CLI/MCP compilation, formatting and public-tree checks passed. Tests cover no TTY/minimal environment, Unicode paths, structured negotiation failures and untouched existing databases. The host contract documents current unsupported operations; this does not add lossless editing, application migration or a new release.
