### PR TITLE
Bind project intake and source configuration to reviewed effects

### DIFF
--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -45,10 +45,25 @@ fn catalog() -> Vec<Capability> {
             &[
                 "explicit_accept",
                 "draft_fingerprint_checked",
-                "not_exact_write_inventory",
+                "effect_binding_requires_expected_preview",
             ],
         ),
-        ("intake.exact_preview", false, &[], &["not_implemented"]),
+        (
+            "intake.exact_preview",
+            true,
+            &["init"],
+            &["requires_expected_preview", "individual_files_only"],
+        ),
+        (
+            "source.configure",
+            true,
+            &["source configure", "source configure-status"],
+            &[
+                "existing_project_identity_preserved",
+                "requires_expected_preview",
+                "projection_can_partially_fail",
+            ],
+        ),
         (
             "work.read",
             true,

--- a/crates/awr-cli/src/intake_plan.rs
+++ b/crates/awr-cli/src/intake_plan.rs
@@ -1,0 +1,182 @@
+//! Read-only effect inventories used to bind host intake consent to source bytes.
+use awr_core::{Error, Result};
+use awr_source::{Manifest, fingerprint, source_adapter, source_read_cap};
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::{collections::BTreeMap, path::Path};
+
+pub const IGNORE_ENTRIES: &[&str] = &[
+    ".awr/state.db",
+    ".awr/state.db-*",
+    ".awr/artifacts/",
+    ".awr/mutations/",
+    ".awr/cache/",
+    ".awr/clients/",
+    ".awr/executions/",
+];
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FileEffect {
+    pub path: String,
+    pub action: &'static str,
+    pub before_fingerprint: Option<String>,
+    pub after_fingerprint: String,
+    pub after_text: String,
+}
+
+/// Read a bounded regular file without accepting a substituted symlink.
+pub fn current(root: &Path, relative: &str, cap: u64) -> Result<Option<Vec<u8>>> {
+    let path = root.join(relative);
+    match std::fs::symlink_metadata(&path) {
+        Ok(_) => Ok(Some(awr_source::read_source_capped(&path, cap)?)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub fn effect(root: &Path, path: &str, after_text: String) -> Result<FileEffect> {
+    let before = current(root, path, awr_source::YAML_READ_CAP)?;
+    let action = match &before {
+        None => "create",
+        Some(bytes) if *bytes == after_text.as_bytes() => "no_change",
+        Some(_) => "replace",
+    };
+    Ok(FileEffect {
+        path: path.into(),
+        action,
+        before_fingerprint: before.map(|b| fingerprint(&b)),
+        after_fingerprint: fingerprint(after_text.as_bytes()),
+        after_text,
+    })
+}
+
+pub fn ignore_effect(root: &Path) -> Result<FileEffect> {
+    let previous = current(root, ".gitignore", awr_source::YAML_READ_CAP)?;
+    let mut text = String::from_utf8(previous.clone().unwrap_or_default())
+        .map_err(|_| Error::InvalidInput(".gitignore must be UTF-8".into()))?;
+    let missing: Vec<_> = IGNORE_ENTRIES
+        .iter()
+        .filter(|entry| !text.lines().any(|line| line.trim() == **entry))
+        .collect();
+    if !missing.is_empty() {
+        if !text.is_empty() && !text.ends_with('\n') {
+            text.push('\n');
+        }
+        text.push_str("\n# AWR local runtime state\n");
+        for entry in missing {
+            text.push_str(entry);
+            text.push('\n');
+        }
+    }
+    effect(root, ".gitignore", text)
+}
+
+pub fn verify_file(root: &Path, effect: &FileEffect) -> Result<()> {
+    let actual =
+        current(root, &effect.path, awr_source::YAML_READ_CAP)?.map(|bytes| fingerprint(&bytes));
+    if actual != effect.before_fingerprint {
+        return Err(Error::SourceConflict(format!(
+            "{} changed after preview",
+            effect.path
+        )));
+    }
+    Ok(())
+}
+
+pub fn preview(
+    root: &Path,
+    manifest: &Manifest,
+    generated: &BTreeMap<String, String>,
+    configure: bool,
+) -> Result<Value> {
+    let mut writes = Vec::new();
+    let rendered =
+        toml::to_string_pretty(manifest).map_err(|e| Error::InvalidInput(e.to_string()))?;
+    let existing = current(root, ".awr/project.toml", 64 * 1024)?;
+    // Repeated initialization keeps the exact existing manifest, including comments.
+    let equivalent = existing.as_ref().is_some_and(|bytes| {
+        std::str::from_utf8(bytes)
+            .ok()
+            .and_then(|text| Manifest::parse(text).ok())
+            .is_some_and(|current| {
+                serde_json::to_value(&current).ok() == serde_json::to_value(manifest).ok()
+            })
+    });
+    let after = if (!configure || equivalent)
+        && let Some(ref bytes) = existing
+    {
+        String::from_utf8(bytes.clone())
+            .map_err(|_| Error::InvalidInput("manifest must be UTF-8".into()))?
+    } else {
+        rendered
+    };
+    writes.push(effect(root, ".awr/project.toml", after)?);
+    if !configure {
+        writes.push(ignore_effect(root)?);
+    }
+    for (path, body) in generated {
+        writes.push(effect(root, path, body.clone())?);
+    }
+    let mut snapshots = Vec::new();
+    let mut issues = Vec::new();
+    for spec in &manifest.sources {
+        if let Some(body) = spec
+            .path
+            .as_ref()
+            .and_then(|p| generated.get(&p.to_string_lossy().into_owned()))
+        {
+            snapshots.push(json!({"domain":spec.domain,"path":spec.path,"proposed":true,"fingerprint":fingerprint(body.as_bytes())}));
+            continue;
+        }
+        let adapter = source_adapter(&spec.adapter)?;
+        match adapter.discover(root, manifest, spec) {
+            Ok(locators) => {
+                for locator in locators {
+                    match locator.read(root, source_read_cap(&spec.adapter)?) {
+                        Ok(snapshot) => snapshots.push(json!({"domain":spec.domain,"locator":snapshot.locator,"fingerprint":snapshot.fingerprint})),
+                        Err(error) => issues.push(json!({"domain":spec.domain,"source":spec,"error":error.report()})),
+                    }
+                }
+            }
+            Err(error) => {
+                issues.push(json!({"domain":spec.domain,"source":spec,"error":error.report()}))
+            }
+        }
+    }
+    snapshots.sort_by_key(|s| s.to_string());
+    let mut runtime_effects = vec![
+        json!({"path":".awr/state.db","action":"create_or_refresh_and_migrate_if_compatible"}),
+        json!({"path":".awr/state.db-wal","action":"sqlite_wal_if_needed"}),
+        json!({"path":".awr/state.db-shm","action":"sqlite_shared_memory_if_needed"}),
+    ];
+    if configure {
+        runtime_effects.extend([
+            json!({"path_pattern":".awr/mutations/source-config-*/","action":"before_after_snapshots_and_durable_receipt"}),
+            json!({"path_pattern":".awr/mutations/*.lock","action":"configuration_writer_lock"}),
+            json!({"path_pattern":".awr/config-*.tmp","action":"temporary_atomic_replacement"}),
+        ]);
+    } else if !generated.is_empty() {
+        runtime_effects
+            .push(json!({"path_pattern":".awr/intake-*/","action":"temporary_intake_staging"}));
+    }
+    let mut plan = json!({
+        "version":1, "operation":if configure {"source.configure"} else {"init"},
+        "project_root":root, "authority_mapping":manifest, "writes":writes,
+        "source_snapshots":snapshots, "source_issues":issues,
+        "runtime_effects":runtime_effects,
+        "source_write_performed":false, "runtime_write_performed":false,
+        "atomicity":"individual_files_only; partial_initialization_can_remain_on_failure"
+    });
+    let digest = fingerprint(&serde_json::to_vec(&plan)?);
+    plan["fingerprint"] = json!(digest);
+    Ok(plan)
+}
+
+pub fn check_expected(plan: &Value, expected: Option<&str>) -> Result<()> {
+    if let Some(expected) = expected {
+        if plan["fingerprint"].as_str() != Some(expected) {
+            return Err(Error::SourceConflict("intake preview changed; refresh and review source/configuration/ignore effects before accepting".into()));
+        }
+    }
+    Ok(())
+}

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -9,6 +9,7 @@ mod doctor;
 mod drill;
 mod event_append;
 mod execution;
+mod intake_plan;
 mod mutation;
 mod onboarding;
 mod query;

--- a/crates/awr-cli/src/onboarding.rs
+++ b/crates/awr-cli/src/onboarding.rs
@@ -19,6 +19,9 @@ pub struct InitArgs {
     pub manifest: Option<PathBuf>,
     #[arg(long)]
     pub accept: bool,
+    /// Accept only the source/configuration/ignore effects with this preview fingerprint.
+    #[arg(long, requires = "accept")]
+    pub expected_preview: Option<String>,
     /// User-stated project goal; otherwise the initial work is to establish one.
     #[arg(long, conflicts_with = "manifest")]
     pub goal: Option<String>,
@@ -374,6 +377,7 @@ pub fn run(root: &Path, args: &InitArgs, json_output: bool) -> Result<()> {
             args.manifest.as_deref(),
             args.accept,
             json_output,
+            args.expected_preview.as_deref(),
         );
     }
     let mut candidate = if let Some(path) = &args.from_draft {
@@ -429,6 +433,19 @@ pub fn run(root: &Path, args: &InitArgs, json_output: bool) -> Result<()> {
         candidate.observations.push("Explicit ledger field/status mappings interpret source values without rewriting the original documents.".into());
     }
     awr_core::ensure_public_data(&candidate)?;
+    let mut generated = candidate.generated_files.clone();
+    generated.insert(
+        ".awr/intake/inventory.json".into(),
+        serde_json::to_string_pretty(&candidate)?,
+    );
+    generated.insert(
+        ".awr/intake/project.toml".into(),
+        toml::to_string_pretty(&candidate.authority_mapping)
+            .map_err(|e| Error::InvalidInput(e.to_string()))?,
+    );
+    let preview =
+        crate::intake_plan::preview(&root, &candidate.authority_mapping, &generated, false)?;
+    crate::intake_plan::check_expected(&preview, args.expected_preview.as_deref())?;
     if let Some(path) = &args.write_draft {
         let bytes = serde_json::to_vec_pretty(&candidate)?;
         let mut file = fs::OpenOptions::new()
@@ -468,7 +485,7 @@ pub fn run(root: &Path, args: &InitArgs, json_output: bool) -> Result<()> {
         println!(
             "{}",
             serde_json::to_string_pretty(
-                &json!({"status":"preview","requires_accept":true,"draft":candidate,"organization":organization,"ambiguous_domains":candidate.ambiguous_domains,"authority_mapping":if candidate.ambiguous_domains.is_empty(){Some(&candidate.authority_mapping)}else{None},"next_action":"Review the draft and organization actions. Use init --accept, or edit an external --write-draft before init --from-draft <file> --accept. Then run awr intake inspect."})
+                &json!({"status":"preview","requires_accept":true,"preview":preview,"draft":candidate,"organization":organization,"ambiguous_domains":candidate.ambiguous_domains,"authority_mapping":if candidate.ambiguous_domains.is_empty(){Some(&candidate.authority_mapping)}else{None},"next_action":"Review the draft and organization actions. Use init --accept, or edit an external --write-draft before init --from-draft <file> --accept. Then run awr intake inspect."})
             )?
         );
         return Ok(());
@@ -527,11 +544,19 @@ pub fn run(root: &Path, args: &InitArgs, json_output: bool) -> Result<()> {
             "project changed during intake; staged draft retained for inspection".into(),
         ));
     }
+    // Staging is inside the ignored runtime; published targets and sources must
+    // still match the effect inventory accepted by the host.
+    if args.expected_preview.is_some() {
+        let current =
+            crate::intake_plan::preview(&root, &candidate.authority_mapping, &generated, false)?;
+        crate::intake_plan::check_expected(&current, args.expected_preview.as_deref())?;
+    }
     fs::rename(&stage, runtime.join("intake"))?;
     crate::source::initialize(
         &root,
         Some(&runtime.join("intake/project.toml")),
         true,
         json_output,
+        None,
     )
 }

--- a/crates/awr-cli/src/source.rs
+++ b/crates/awr-cli/src/source.rs
@@ -12,6 +12,17 @@ use std::{
 
 #[derive(Debug, Subcommand)]
 pub enum SourceCommand {
+    /// Preview or apply an exact replacement source mapping while preserving project identity.
+    Configure {
+        #[arg(long)]
+        manifest: PathBuf,
+        #[arg(long)]
+        accept: bool,
+        #[arg(long, requires = "accept")]
+        expected_preview: Option<String>,
+    },
+    /// Inspect a configuration receipt without applying or reindexing anything.
+    ConfigureStatus { preview_fingerprint: String },
     /// Read one registered source by ID, unambiguous domain or exact locator.
     Show(crate::drill::SourceRead),
     /// Read source lifecycle/change summaries, including retired source IDs.
@@ -33,6 +44,11 @@ pub enum SourceCommand {
 
 pub(crate) fn runtime_dir(root: &Path, create: bool) -> Result<PathBuf> {
     let root = root.canonicalize()?;
+    if create && root.metadata()?.permissions().readonly() {
+        return Err(Error::RuleViolation(
+            "project directory is read-only".into(),
+        ));
+    }
     let path = root.join(".awr");
     if create && !path.exists() {
         fs::create_dir(&path)?;
@@ -53,6 +69,7 @@ pub fn initialize(
     manifest_path: Option<&Path>,
     accept: bool,
     json_output: bool,
+    expected_preview: Option<&str>,
 ) -> Result<()> {
     let root = root.canonicalize()?;
     if !root.is_dir() {
@@ -93,8 +110,12 @@ pub fn initialize(
             .map(toml::to_string_pretty)
             .transpose()
             .map_err(|e| Error::InvalidInput(e.to_string()))?;
+        let effects = candidate
+            .as_ref()
+            .map(|m| crate::intake_plan::preview(&root, m, &BTreeMap::new(), false))
+            .transpose()?;
         let preview = json!({"status":"preview","configuration_exists":existing.is_some(),"requires_accept":true,
-            "candidates":candidates,"ambiguous_domains":ambiguous,"authority_mapping":candidate,"manifest_toml":toml});
+            "preview":effects,"candidates":candidates,"ambiguous_domains":ambiguous,"authority_mapping":candidate,"manifest_toml":toml});
         if json_output {
             println!("{}", serde_json::to_string_pretty(&preview)?);
         } else {
@@ -119,6 +140,10 @@ pub fn initialize(
         })
     })?;
     manifest.validate()?;
+    if expected_preview.is_some() {
+        let plan = crate::intake_plan::preview(&root, &manifest, &BTreeMap::new(), false)?;
+        crate::intake_plan::check_expected(&plan, expected_preview)?;
+    }
     if existing.is_none() && root.join(".awr/state.db").exists() {
         return Err(Error::SourceConflict("database exists without project.toml; restore its matching manifest before initializing".into()));
     }
@@ -134,15 +159,7 @@ pub fn initialize(
     } else {
         String::new()
     };
-    let needed = [
-        ".awr/state.db",
-        ".awr/state.db-*",
-        ".awr/artifacts/",
-        ".awr/mutations/",
-        ".awr/cache/",
-        ".awr/clients/",
-        ".awr/executions/",
-    ];
+    let needed = crate::intake_plan::IGNORE_ENTRIES;
     let missing: Vec<_> = needed
         .iter()
         .filter(|entry| !previous_ignore.lines().any(|line| line.trim() == **entry))
@@ -211,6 +228,211 @@ pub fn initialize(
             "project initialized with source issues; resolve them and run source reindex".into(),
         ));
     }
+    Ok(())
+}
+
+fn configure(
+    root: &Path,
+    path: &Path,
+    accept: bool,
+    expected: Option<&str>,
+    json_output: bool,
+) -> Result<()> {
+    let root = root.canonicalize()?;
+    let existing = Manifest::load(&root)?;
+    let input = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    };
+    let bytes = awr_source::read_capped(&input, 64 * 1024)?;
+    let candidate = Manifest::parse(
+        std::str::from_utf8(&bytes)
+            .map_err(|_| Error::InvalidInput("manifest must be UTF-8".into()))?,
+    )?;
+    if candidate.project.name != existing.project.name
+        || candidate.project.external_key != existing.project.external_key
+        || candidate.project.authority_mode != existing.project.authority_mode
+    {
+        return Err(Error::SourceConflict(
+            "source configure preserves project name, external_key and authority mode".into(),
+        ));
+    }
+    let plan = crate::intake_plan::preview(&root, &candidate, &BTreeMap::new(), true)?;
+    if !accept {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"status":"preview", "preview":plan, "requires_accept":true})
+            )?
+        );
+        return Ok(());
+    }
+    if expected.is_none() {
+        return Err(Error::InvalidInput(
+            "source configure --accept requires --expected-preview from the reviewed preview"
+                .into(),
+        ));
+    }
+    crate::intake_plan::check_expected(&plan, expected)?;
+    if root.metadata()?.permissions().readonly() {
+        return Err(Error::RuleViolation(
+            "project directory is read-only".into(),
+        ));
+    }
+    let runtime = runtime_dir(&root, false)?;
+    // Do not modify a configuration for a foreign, future or damaged runtime.
+    let store = Store::open_readonly(&runtime.join("state.db"))?;
+    let project = store.project_by_root(&root)?;
+    drop(store);
+    let after = plan["writes"][0]["after_text"]
+        .as_str()
+        .ok_or_else(|| Error::InvalidInput("configuration preview lacks its target text".into()))?
+        .to_owned();
+    let effect = crate::intake_plan::effect(&root, ".awr/project.toml", after)?;
+    if effect.action == "no_change" {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"ok":true,"write_outcome":"no_change","configuration_write_performed":false,"runtime_write_performed":false,"project_id":project.id,"project_revision":project.project_revision})
+            )?
+        );
+        return Ok(());
+    }
+    let _lock = crate::client::lock(&root, "mutations", "source-configuration")?;
+    let current = crate::intake_plan::preview(&root, &candidate, &BTreeMap::new(), true)?;
+    crate::intake_plan::check_expected(&current, expected)?;
+    let permissions = awr_source::open_file_exact(&root.join(".awr/project.toml"))?
+        .metadata()?
+        .permissions();
+    if permissions.readonly() {
+        return Err(Error::RuleViolation(
+            "source configuration is read-only".into(),
+        ));
+    }
+    let id = awr_core::Id::new();
+    let key = plan["fingerprint"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap();
+    let recovery = runtime
+        .join("mutations")
+        .join(format!("source-config-{key}"));
+    fs::create_dir(&recovery)?;
+    let before = crate::intake_plan::current(&root, ".awr/project.toml", 64 * 1024)?
+        .ok_or_else(|| Error::SourceConflict("source manifest disappeared".into()))?;
+    for (name, content) in [
+        ("before.toml", before.as_slice()),
+        ("after.toml", effect.after_text.as_bytes()),
+    ] {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(recovery.join(name))?;
+        file.write_all(content)?;
+        file.sync_all()?;
+    }
+    let receipt_path = recovery.join("receipt.json");
+    let mut receipt = serde_json::json!({"id":id,"operation":"source.configure","project_id":project.id,"preview":plan,"write_outcome":"pending","before_fingerprint":effect.before_fingerprint,"after_fingerprint":effect.after_fingerprint});
+    save_configuration_receipt(&recovery, &receipt)?;
+    // Use a held runtime directory for the final rename; do not follow replacement links.
+    let directory = awr_source::open_dir_exact(&runtime)?;
+    let stage = format!("config-{id}.tmp");
+    let mut options = cap_std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    let mut staged = directory.open_with(&stage, &options)?.into_std();
+    staged.write_all(effect.after_text.as_bytes())?;
+    staged.set_permissions(permissions)?;
+    staged.sync_all()?;
+    crate::intake_plan::verify_file(&root, &effect)?;
+    directory.rename(&stage, &directory, "project.toml")?;
+    receipt["write_outcome"] = serde_json::json!("applied");
+    receipt["configuration_write_performed"] = serde_json::json!(true);
+    let indexed = (|| -> Result<awr_source::IndexReport> {
+        let mut store = Store::open(&runtime.join("state.db"))?;
+        index_project(&mut store, &root, &candidate, false)
+    })();
+    let failure = match indexed {
+        Ok(report) => {
+            let failed = !report.ok;
+            receipt["project_revision"] = serde_json::json!(report.project_revision);
+            receipt["index"] = serde_json::to_value(report)?;
+            failed.then(|| Error::SourceStale("configuration applied with source issues; inspect the result and reindex after fixing affected sources".into()))
+        }
+        Err(error) => {
+            receipt["index_error"] = serde_json::to_value(error.report())?;
+            Some(error)
+        }
+    };
+    receipt["ok"] = serde_json::json!(failure.is_none());
+    receipt["recovery_directory"] = serde_json::json!(recovery.strip_prefix(&root).unwrap());
+    save_configuration_receipt(&recovery, &receipt)?;
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&receipt)?);
+    } else {
+        println!(
+            "Source configuration applied; receipt {}",
+            receipt_path.display()
+        );
+    }
+    if let Some(error) = failure {
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn save_configuration_receipt(directory: &Path, receipt: &Value) -> Result<()> {
+    let dir = awr_source::open_dir_exact(directory)?;
+    let stage = format!("receipt-{}.tmp", awr_core::Id::new());
+    let mut options = cap_std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    let mut file = dir.open_with(&stage, &options)?;
+    file.write_all(&serde_json::to_vec_pretty(receipt)?)?;
+    file.sync_all()?;
+    drop(file);
+    dir.rename(&stage, &dir, "receipt.json")?;
+    Ok(())
+}
+
+fn configure_status(root: &Path, fingerprint: &str) -> Result<()> {
+    let key = fingerprint.strip_prefix("sha256:").unwrap_or(fingerprint);
+    if key.len() != 64 || !key.bytes().all(|c| c.is_ascii_hexdigit()) {
+        return Err(Error::InvalidInput(
+            "configuration receipt requires a SHA256 preview fingerprint".into(),
+        ));
+    }
+    let root = root.canonicalize()?;
+    let recovery = format!(
+        ".awr/mutations/source-config-{}/receipt.json",
+        key.to_ascii_lowercase()
+    );
+    let bytes = crate::intake_plan::current(&root, &recovery, awr_source::YAML_READ_CAP)?
+        .ok_or_else(|| Error::NotFound("configuration receipt".into()))?;
+    let receipt: Value = serde_json::from_slice(&bytes)?;
+    if receipt["preview"]["fingerprint"].as_str()
+        != Some(&format!("sha256:{}", key.to_ascii_lowercase()))
+        || receipt["preview"]["project_root"] != serde_json::to_value(&root)?
+    {
+        return Err(Error::SourceConflict(
+            "configuration receipt belongs to another preview or project".into(),
+        ));
+    }
+    let observed = crate::intake_plan::current(&root, ".awr/project.toml", 64 * 1024)?
+        .map(|b| awr_source::fingerprint(&b));
+    let matches = match observed.as_deref() {
+        Some(hash) if Some(hash) == receipt["after_fingerprint"].as_str() => "after",
+        Some(hash) if Some(hash) == receipt["before_fingerprint"].as_str() => "before",
+        _ => "conflict_or_missing",
+    };
+    println!(
+        "{}",
+        serde_json::to_string_pretty(
+            &json!({"ok":true,"read_only":true,"source_write_performed":false,"runtime_write_performed":false,
+        "receipt":receipt,"observed_configuration":matches,"current_fingerprint":observed,
+        "interpretation":"stored write outcome and current bytes are separate observations; pending/conflicting results require inspection, never automatic replay"})
+        )?
+    );
     Ok(())
 }
 
@@ -298,6 +520,24 @@ pub(crate) fn discover(root: &Path) -> Result<(Option<Manifest>, Vec<Value>, Vec
 
 pub fn run(root: &Path, command: &SourceCommand, json_output: bool) -> Result<()> {
     match command {
+        SourceCommand::ConfigureStatus {
+            preview_fingerprint,
+        } => {
+            return configure_status(root, preview_fingerprint);
+        }
+        SourceCommand::Configure {
+            manifest,
+            accept,
+            expected_preview,
+        } => {
+            return configure(
+                root,
+                manifest,
+                *accept,
+                expected_preview.as_deref(),
+                json_output,
+            );
+        }
         SourceCommand::Show(request) => {
             return crate::drill::source_show(root, request, json_output);
         }
@@ -310,7 +550,10 @@ pub fn run(root: &Path, command: &SourceCommand, json_output: bool) -> Result<()
     let manifest = Manifest::load(&root)?;
     let runtime = runtime_dir(&root, false)?;
     match command {
-        SourceCommand::Show(_) | SourceCommand::History { .. } => unreachable!(),
+        SourceCommand::Configure { .. }
+        | SourceCommand::ConfigureStatus { .. }
+        | SourceCommand::Show(_)
+        | SourceCommand::History { .. } => unreachable!(),
         SourceCommand::List => {
             let store = Store::open_readonly(&runtime.join("state.db"))?;
             let project = store.project_by_root(&root)?;

--- a/crates/awr-cli/tests/host_capabilities.rs
+++ b/crates/awr-cli/tests/host_capabilities.rs
@@ -136,7 +136,6 @@ fn source_read_support_does_not_advertise_lossless_or_markdown_writes() {
         "mutation.multi_file",
         "completion.user_confirmation",
         "project.catalog",
-        "intake.exact_preview",
     ] {
         let capability = result["capabilities"]
             .as_array()

--- a/crates/awr-cli/tests/host_intake.rs
+++ b/crates/awr-cli/tests/host_intake.rs
@@ -1,0 +1,405 @@
+use awr_core::Id;
+use serde_json::Value;
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+};
+
+struct Project(PathBuf);
+impl Project {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!("awr 精确接入 {}", Id::new()));
+        fs::create_dir(&path).unwrap();
+        let p = Self(path);
+        p.write("work-ledger.yaml", "goals:\n- id: G\n  title: Publish a guide\n  status: active\nwork_items:\n- id: W\n  title: Draft a guide\n  goal: G\n  status: ready\n  acceptance: [A useful guide]\n  next_action: Write the first draft\n");
+        p.write("mapping.toml", "[project]\nname='Guide'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work-ledger.yaml'\nadapter='yaml-ledger-v1'\n");
+        p.write(".gitignore", "# User entries\n*.tmp");
+        p
+    }
+    fn write(&self, path: &str, body: &str) {
+        let file = self.0.join(path);
+        fs::create_dir_all(file.parent().unwrap()).unwrap();
+        fs::write(file, body).unwrap();
+    }
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_awr"))
+            .args(["--project", self.0.to_str().unwrap(), "--json"])
+            .args(args)
+            .stdin(Stdio::null())
+            .output()
+            .unwrap()
+    }
+    fn ok(&self, args: &[&str]) -> Value {
+        let r = self.run(args);
+        assert!(
+            r.status.success(),
+            "{}\n{}",
+            String::from_utf8_lossy(&r.stdout),
+            String::from_utf8_lossy(&r.stderr)
+        );
+        serde_json::from_slice(&r.stdout).unwrap()
+    }
+    fn error(&self, args: &[&str], code: &str) {
+        let r = self.run(args);
+        assert!(!r.status.success());
+        assert_eq!(
+            serde_json::from_slice::<Value>(&r.stderr).unwrap()["code"],
+            code
+        );
+    }
+    fn init(&self) -> Value {
+        let preview = self.ok(&["init", "--manifest", "mapping.toml"]);
+        self.ok(&[
+            "init",
+            "--manifest",
+            "mapping.toml",
+            "--accept",
+            "--expected-preview",
+            preview["preview"]["fingerprint"].as_str().unwrap(),
+        ])
+    }
+}
+impl Drop for Project {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn preview_lists_exact_configuration_and_ignore_bytes_without_initializing() {
+    let p = Project::new();
+    let source = fs::read(p.0.join("work-ledger.yaml")).unwrap();
+    let preview = p.ok(&["init", "--manifest", "mapping.toml"]);
+    assert!(!p.0.join(".awr").exists());
+    assert_eq!(
+        fs::read_to_string(p.0.join(".gitignore")).unwrap(),
+        "# User entries\n*.tmp"
+    );
+    let plan = &preview["preview"];
+    assert_eq!(plan["source_write_performed"], false);
+    assert_eq!(plan["source_snapshots"].as_array().unwrap().len(), 1);
+    p.ok(&[
+        "init",
+        "--manifest",
+        "mapping.toml",
+        "--accept",
+        "--expected-preview",
+        plan["fingerprint"].as_str().unwrap(),
+    ]);
+    for effect in plan["writes"].as_array().unwrap() {
+        assert_eq!(
+            fs::read_to_string(p.0.join(effect["path"].as_str().unwrap())).unwrap(),
+            effect["after_text"].as_str().unwrap()
+        );
+    }
+    assert_eq!(fs::read(p.0.join("work-ledger.yaml")).unwrap(), source);
+}
+
+#[test]
+fn source_ignore_and_mapping_changes_invalidate_previews_before_any_runtime_write() {
+    for changed in ["work-ledger.yaml", ".gitignore", "mapping.toml"] {
+        let p = Project::new();
+        let preview = p.ok(&["init", "--manifest", "mapping.toml"]);
+        let old = fs::read_to_string(p.0.join(changed)).unwrap();
+        // Mapping semantics must change; TOML comments are not an authorization change.
+        let new = if changed == "mapping.toml" {
+            old.replace("name='Guide'", "name='Changed Guide'")
+        } else {
+            format!("{old}\n# External edit\n")
+        };
+        p.write(changed, &new);
+        p.error(
+            &[
+                "init",
+                "--manifest",
+                "mapping.toml",
+                "--accept",
+                "--expected-preview",
+                preview["preview"]["fingerprint"].as_str().unwrap(),
+            ],
+            "SourceConflict",
+        );
+        assert!(!p.0.join(".awr").exists());
+        assert_eq!(fs::read_to_string(p.0.join(changed)).unwrap(), new);
+    }
+}
+
+#[test]
+fn inferred_intake_covers_generated_files_and_reviewed_draft_acceptance() {
+    let p = Project::new();
+    fs::remove_file(p.0.join("work-ledger.yaml")).unwrap();
+    let draft_path = std::env::temp_dir().join(format!("host-intake-{}.json", Id::new()));
+    let preview = p.ok(&[
+        "init",
+        "--goal",
+        "Publish a useful guide",
+        "--write-draft",
+        draft_path.to_str().unwrap(),
+    ]);
+    let plan = &preview["preview"];
+    assert!(
+        plan["writes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e["path"] == ".awr/intake/inventory.json")
+    );
+    p.ok(&[
+        "init",
+        "--from-draft",
+        draft_path.to_str().unwrap(),
+        "--accept",
+        "--expected-preview",
+        plan["fingerprint"].as_str().unwrap(),
+    ]);
+    for effect in plan["writes"].as_array().unwrap() {
+        assert_eq!(
+            fs::read_to_string(p.0.join(effect["path"].as_str().unwrap())).unwrap(),
+            effect["after_text"].as_str().unwrap()
+        );
+    }
+    fs::remove_file(draft_path).unwrap();
+}
+
+#[test]
+fn repeated_intake_retains_project_work_and_session_identity() {
+    let p = Project::new();
+    p.init();
+    let before = p.ok(&["work", "show", "W"]);
+    let session = p.ok(&[
+        "session",
+        "start",
+        "--work",
+        "W",
+        "--agent",
+        "host-fixture",
+        "--provider",
+        "local",
+        "--model",
+        "none",
+        "--claim",
+        "--expected-revision",
+        &before["project_revision"].to_string(),
+    ]);
+    let id = session["session"]["id"].as_str().unwrap();
+    let context = p.ok(&[
+        "context",
+        "compile",
+        "--work",
+        "W",
+        "--session",
+        id,
+        "--goal",
+        "G",
+    ]);
+    let checkpoint = p.ok(&[
+        "session",
+        "checkpoint",
+        "--session",
+        id,
+        "--context-hash",
+        context["work_context"]["context_hash"].as_str().unwrap(),
+        "--digest",
+        "Started guide outline",
+        "--next-action",
+        "Write introduction",
+        "--expected-revision",
+        &context["project_revision"].to_string(),
+    ]);
+    let preview = p.ok(&["init"]);
+    p.ok(&[
+        "init",
+        "--accept",
+        "--expected-preview",
+        preview["preview"]["fingerprint"].as_str().unwrap(),
+    ]);
+    let after = p.ok(&["work", "show", "W"]);
+    assert_eq!(before["work"]["id"], after["work"]["id"]);
+    let saved = p.ok(&["session", "show", id]);
+    assert!(saved.to_string().contains(id));
+    assert_eq!(
+        saved["session"]["last_checkpoint_id"],
+        checkpoint["checkpoint"]["id"]
+    );
+    assert_eq!(after["work"]["active_claims"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn explicit_configuration_change_preserves_runtime_and_rejects_stale_or_identity_changes() {
+    let p = Project::new();
+    p.init();
+    let original =
+        fs::read_to_string(p.0.join(".awr/project.toml")).unwrap() + "\n# Preserve this comment\n";
+    p.write(".awr/project.toml", &original);
+    let unchanged = p.ok(&["source", "configure", "--manifest", "mapping.toml"]);
+    assert_eq!(
+        p.ok(&[
+            "source",
+            "configure",
+            "--manifest",
+            "mapping.toml",
+            "--accept",
+            "--expected-preview",
+            unchanged["preview"]["fingerprint"].as_str().unwrap()
+        ])["write_outcome"],
+        "no_change"
+    );
+    assert_eq!(
+        fs::read_to_string(p.0.join(".awr/project.toml")).unwrap(),
+        original
+    );
+    let before = p.ok(&["work", "show", "W"]);
+    p.write(
+        "decisions/choice.md",
+        "# Use a short guide\n\nKeep the first edition concise.\n",
+    );
+    let mapping = fs::read_to_string(p.0.join("mapping.toml")).unwrap();
+    p.write("replacement.toml", &format!("{mapping}\n[[sources]]\ndomain='decisions'\nrole='supporting'\npath='decisions'\nadapter='markdown-directory-v1'\n"));
+    p.error(
+        &[
+            "source",
+            "configure",
+            "--manifest",
+            "replacement.toml",
+            "--accept",
+        ],
+        "InvalidInput",
+    );
+    let preview = p.ok(&["source", "configure", "--manifest", "replacement.toml"]);
+    p.write(
+        "decisions/choice.md",
+        "# Changed choice\n\nUse a detailed guide.\n",
+    );
+    p.error(
+        &[
+            "source",
+            "configure",
+            "--manifest",
+            "replacement.toml",
+            "--accept",
+            "--expected-preview",
+            preview["preview"]["fingerprint"].as_str().unwrap(),
+        ],
+        "SourceConflict",
+    );
+    let preview = p.ok(&["source", "configure", "--manifest", "replacement.toml"]);
+    let result = p.ok(&[
+        "source",
+        "configure",
+        "--manifest",
+        "replacement.toml",
+        "--accept",
+        "--expected-preview",
+        preview["preview"]["fingerprint"].as_str().unwrap(),
+    ]);
+    assert_eq!(result["configuration_write_performed"], true);
+    assert_eq!(result["write_outcome"], "applied");
+    let status = p.ok(&[
+        "source",
+        "configure-status",
+        preview["preview"]["fingerprint"].as_str().unwrap(),
+    ]);
+    assert_eq!(status["observed_configuration"], "after");
+    assert_eq!(status["receipt"]["id"], result["id"]);
+    assert_eq!(status["runtime_write_performed"], false);
+    assert_eq!(
+        p.ok(&["work", "show", "W"])["work"]["id"],
+        before["work"]["id"]
+    );
+    let receipt =
+        p.0.join(result["recovery_directory"].as_str().unwrap())
+            .join("receipt.json");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&fs::read(receipt).unwrap()).unwrap()["write_outcome"],
+        "applied"
+    );
+    let preview = p.ok(&["source", "configure", "--manifest", "replacement.toml"]);
+    assert_eq!(
+        p.ok(&[
+            "source",
+            "configure",
+            "--manifest",
+            "replacement.toml",
+            "--accept",
+            "--expected-preview",
+            preview["preview"]["fingerprint"].as_str().unwrap()
+        ])["write_outcome"],
+        "no_change"
+    );
+    p.write(
+        "replacement.toml",
+        &mapping.replace("name='Guide'", "name='Another project'"),
+    );
+    p.error(
+        &["source", "configure", "--manifest", "replacement.toml"],
+        "SourceConflict",
+    );
+}
+
+#[test]
+fn partial_source_failure_retains_partial_results_and_nonzero_exit() {
+    let p = Project::new();
+    p.write("missing.toml", &(fs::read_to_string(p.0.join("mapping.toml")).unwrap() + "\n[[sources]]\ndomain='plan'\nrole='supporting'\npath='not-present.md'\nadapter='markdown-heading-v1'\n"));
+    let preview = p.ok(&["init", "--manifest", "missing.toml"]);
+    assert_eq!(
+        preview["preview"]["source_issues"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    let result = p.run(&[
+        "init",
+        "--manifest",
+        "missing.toml",
+        "--accept",
+        "--expected-preview",
+        preview["preview"]["fingerprint"].as_str().unwrap(),
+    ]);
+    assert!(!result.status.success());
+    assert_eq!(
+        serde_json::from_slice::<Value>(&result.stderr).unwrap()["code"],
+        "SourceStale"
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(&result.stdout).unwrap()["index"]["indexed"],
+        1
+    );
+    assert_eq!(
+        p.ok(&["object", "show", "work", "W", "--cached"])["ok"],
+        true
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_linked_ignore_target_is_rejected_and_readonly_preview_does_not_initialize() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    let p = Project::new();
+    fs::remove_file(p.0.join(".gitignore")).unwrap();
+    p.write("ignore-target", "keep me\n");
+    symlink(p.0.join("ignore-target"), p.0.join(".gitignore")).unwrap();
+    assert!(
+        !p.run(&["init", "--manifest", "mapping.toml"])
+            .status
+            .success()
+    );
+    assert_eq!(
+        fs::read_to_string(p.0.join("ignore-target")).unwrap(),
+        "keep me\n"
+    );
+    fs::remove_file(p.0.join(".gitignore")).unwrap();
+    p.write(".gitignore", "# Read only\n");
+    fs::set_permissions(&p.0, fs::Permissions::from_mode(0o555)).unwrap();
+    let preview = p.run(&["init", "--manifest", "mapping.toml"]);
+    let accept = p.run(&["init", "--manifest", "mapping.toml", "--accept"]);
+    fs::set_permissions(&p.0, fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(
+        preview.status.success(),
+        "{}",
+        String::from_utf8_lossy(&preview.stderr)
+    );
+    assert!(!p.0.join(".awr").exists());
+    assert!(!accept.status.success());
+}

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -55,6 +55,49 @@ before retrying. Do not synthesize `source_write_performed: false` from a transp
 failure. Input paths and maximum sizes remain command-specific (`--input`, reviewed
 drafts, or documented lifecycle JSON on stdin); there is no universal JSON RPC wrapper.
 
+## Bind intake to the reviewed effects
+
+`init --json` (including `--manifest` or a reviewed `--from-draft`) returns
+`preview.fingerprint`, the source/configuration mapping, bounded source snapshots,
+source issues, and a `writes` inventory with before/after fingerprints and exact
+text for the manifest, `.gitignore` and generated intake files. Runtime database,
+WAL and temporary staging effects are listed separately. This preview performs no
+project writes; an explicitly requested `--write-draft` still writes its output file.
+
+Pass that fingerprint as `init --accept --expected-preview <fingerprint>` with the
+same input/mapping arguments. Changed sources, mapping semantics, existing manifest
+bytes or ignore contents reject the old preview. Existing clients may omit the new
+flag and retain the legacy behavior. A draft file's original inventory fingerprint
+is still checked; editing a draft requires previewing that edited draft before
+acceptance. Multiple source candidates remain an explicit ambiguity.
+
+Repeated initialization keeps the existing manifest, project/work identities,
+events, sessions and checkpoints. Non-Git projects are supported. Preview can read
+a read-only project, but initialization requiring runtime writes is rejected there.
+Source failures remain in the result: acceptance can create a partial index with a
+nonzero `SourceStale` result, preserving usable source records. It must not be shown
+as a fully successful import. Initializing multiple files is not a cross-file atomic
+transaction; interrupted staging may require inspection before retry.
+
+To change an initialized project's source mapping, provide a candidate manifest:
+
+```text
+awr source configure --manifest candidate.toml --json
+awr source configure --manifest candidate.toml --accept --expected-preview <fingerprint> --json
+awr source configure-status <fingerprint> --json
+```
+
+Configuration changes preserve project name, external key and authority mode.
+They require a reviewed fingerprint, leave business source bytes untouched and
+reindex the same project. Before/after manifests and a durable receipt are kept in
+the ignored mutation directory; the preview fingerprint locates the receipt even
+if the return pipe was lost. `configure-status` reads the recorded outcome and
+compares current configuration fingerprints without applying or reindexing anything.
+Pending, externally changed or partially indexed results are distinct from success.
+A failed projection does not mean the configuration was unwritten; inspect the
+receipt and current configuration before acting. Identical configuration returns
+`no_change`. Configuration setup is separate from task/document source editing.
+
 ## Current read/write limits
 
 `source.read` and `object.read` operate on registered references with bounded body


### PR DESCRIPTION
Hosts can now bind project intake to the exact source, manifest and ignore-file effects they previewed with `init --expected-preview`. A new `source configure` path updates an initialized project's mapping while preserving its identity and runtime history; configuration receipts remain inspectable by preview fingerprint after a lost response. Original business sources remain unchanged.

Validation: 26 targeted tests passed, including exact preview contents, stale sources/configuration/ignore files, repeated intake retaining a checkpoint and claim, partial source failures, read-only directories, configuration receipts and existing CLI/intake compatibility. Formatting and public-tree checks passed. Configuration changes are individually committed files with explicit partial-index outcomes, not cross-file atomic transactions.
