### PR TITLE
Expose complete revision-bound project catalogs

### DIFF
--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -76,7 +76,16 @@ fn catalog() -> Vec<Capability> {
             &["object show", "decision show"],
             &["explicit_object_reference", "bounded_body_reads"],
         ),
-        ("project.catalog", false, &[], &["not_implemented"]),
+        (
+            "project.catalog",
+            true,
+            &["object list"],
+            &[
+                "revision_bound_pages",
+                "retired_is_not_archived",
+                "summaries_only_bodies_are_opt_in",
+            ],
+        ),
         (
             "history.cursor",
             true,

--- a/crates/awr-cli/src/catalog.rs
+++ b/crates/awr-cli/src/catalog.rs
@@ -1,0 +1,139 @@
+use awr_core::*;
+use awr_store::{CatalogCursor, CatalogKind, CatalogScope};
+use clap::Args;
+use serde_json::{Value, json};
+use std::path::Path;
+
+#[derive(Debug, Args)]
+pub struct ListArgs {
+    #[arg(value_parser=["goal","plan","rule","work","decision","source","relation","artifact","evidence"])]
+    kind: String,
+    #[arg(long, default_value="active", value_parser=["active","retired","all"])]
+    scope: String,
+    /// JSON next_cursor from the preceding page. Changes require a fresh traversal.
+    #[arg(long)]
+    cursor: Option<String>,
+    #[arg(long, default_value_t = 20)]
+    limit: usize,
+}
+
+pub fn list(root: &Path, args: &ListArgs, json_output: bool) -> Result<()> {
+    let kind: CatalogKind = serde_json::from_value(json!(args.kind))?;
+    let scope: CatalogScope = serde_json::from_value(json!(args.scope))?;
+    let cursor: Option<CatalogCursor> = args
+        .cursor
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .map_err(|_| Error::InvalidInput("invalid catalog cursor JSON".into()))?;
+    if !(1..=200).contains(&args.limit) {
+        return Err(Error::InvalidInput("catalog limit must be 1..200".into()));
+    }
+    let query = crate::query::QueryProject::open(root)?;
+    let page = query.store.catalog_page(
+        query.project.id,
+        query.project.project_revision,
+        kind,
+        scope,
+        cursor.as_ref(),
+        args.limit,
+    )?;
+    let mut value = query.metadata();
+    let items = page
+        .items
+        .iter()
+        .map(|row| {
+            let mut item = serde_json::Map::new();
+            for field in [
+                "id",
+                "external_key",
+                "title",
+                "revision",
+                "source_ref",
+                "status",
+                "raw_status",
+                "owner",
+                "priority",
+                "milestone",
+                "kind",
+                "severity",
+                "unresolved",
+                "domain",
+                "role",
+                "locator",
+                "format",
+                "adapter",
+                "fingerprint",
+                "freshness",
+                "from_kind",
+                "from_key",
+                "relation",
+                "to_kind",
+                "to_key",
+                "required",
+                "artifact_type",
+                "sha256",
+                "size",
+                "mime",
+                "source_event_id",
+                "evidence_type",
+                "level",
+                "source_sha",
+                "work_item_id",
+                "branch_id",
+                "verified_at",
+            ] {
+                if let Some(v) = row.item.get(field) {
+                    item.insert(field.into(), v.clone());
+                }
+            }
+            for field in [
+                "summary",
+                "text",
+                "decision",
+                "rationale",
+                "next_action",
+                "blocker",
+            ] {
+                if let Some(v) = row.item.get(field).and_then(Value::as_str) {
+                    item.insert(field.into(), json!(crate::query::short(v)));
+                }
+            }
+            item.insert("active".into(), json!(row.active));
+            item.insert("source".into(), json!(row.source));
+            item.insert("project_revision".into(), json!(page.project_revision));
+            item.insert("content_included".into(), json!(false));
+            if let Some(source) = &row.source {
+                item.insert("source_revision".into(), json!(source.revision));
+                item.insert("freshness".into(), json!(source.freshness));
+            }
+            Value::Object(item)
+        })
+        .collect::<Vec<_>>();
+    value["project_id"] = json!(page.project_id);
+    value["kind"] = json!(page.kind);
+    value["scope"] = json!(page.scope);
+    value["total"] = json!(page.total);
+    value["active_total"] = json!(page.active_total);
+    value["retired_total"] = json!(page.retired_total);
+    value["total_basis"] = json!("retained_indexed_objects");
+    value["total_is_current"] = json!(query.refresh.ok);
+    value["items"] = json!(items);
+    value["has_more"] = json!(page.has_more);
+    value["next_cursor"] = json!(page.next_cursor);
+    value["content_included"] = json!(false);
+    query.check_revision()?;
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        println!(
+            "{} {} objects ({} returned); current={}\n{}",
+            args.scope,
+            args.kind,
+            items.len(),
+            query.refresh.ok,
+            serde_json::to_string_pretty(&value)?
+        );
+    }
+    query.finish()
+}

--- a/crates/awr-cli/src/drill.rs
+++ b/crates/awr-cli/src/drill.rs
@@ -4,7 +4,7 @@ use crate::{
     session::{RuntimeProject, event_brief},
 };
 use awr_core::*;
-use awr_source::{Locator, Manifest, SourceSpec};
+use awr_source::Manifest;
 use awr_store::{BranchFilter, EventCursor, EventQuery, Store};
 use clap::{Args, Subcommand, ValueEnum};
 use serde_json::{Value, json};
@@ -22,6 +22,8 @@ pub enum ObjectKind {
 
 #[derive(Debug, Subcommand)]
 pub enum ObjectCommand {
+    /// Traverse all indexed objects with bounded pages and revision-bound cursors.
+    List(crate::catalog::ListArgs),
     /// Read one projected object by external key/ID, or an immutable checkpoint by ID.
     Show {
         #[arg(value_enum)]
@@ -128,6 +130,9 @@ fn resolve_source(store: &Store, project: Id, reference: &str) -> Result<(Source
 }
 
 pub fn object(root: &Path, command: &ObjectCommand, json_output: bool) -> Result<()> {
+    if let ObjectCommand::List(args) = command {
+        return crate::catalog::list(root, args, json_output);
+    }
     let ObjectCommand::Show {
         kind,
         reference,
@@ -135,7 +140,10 @@ pub fn object(root: &Path, command: &ObjectCommand, json_output: bool) -> Result
         cached,
         entity_revision,
         max_bytes,
-    } = command;
+    } = command
+    else {
+        unreachable!()
+    };
     let db = RuntimeProject::open(root, !cached && *kind != ObjectKind::Checkpoint)?;
     let mut checkpoint_save = Value::Null;
     let mut session_delta = Value::Null;
@@ -389,19 +397,37 @@ pub fn source_show(root: &Path, request: &SourceRead, json_output: bool) -> Resu
     value["freshness_basis"] = json!("last_recorded_source_state");
     if request.content {
         check_limit(0, request.max_bytes)?;
+        if !active {
+            return Err(Error::SourceUnavailable("retired source retains metadata and history; content requires a current source registration".into()));
+        }
         let manifest = Manifest::load(root)?;
-        let spec = SourceSpec {
-            domain: source.domain.clone(),
-            role: source.role.clone(),
-            path: None,
-            locator: Some(source.locator.clone()),
-            adapter: source.adapter.clone(),
-            options: Default::default(),
-        };
+        // A retained DB locator is not permission to reopen a removed source.
+        // Only rediscover the matching registered domain/adapter, never the project tree.
+        let mut authorized = None;
+        for spec in manifest
+            .sources
+            .iter()
+            .filter(|spec| spec.domain == source.domain && spec.adapter == source.adapter)
+        {
+            for locator in
+                awr_source::source_adapter(&spec.adapter)?.discover(root, &manifest, spec)?
+            {
+                if locator.identity()? == source.locator {
+                    authorized = Some(locator);
+                    break;
+                }
+            }
+            if authorized.is_some() {
+                break;
+            }
+        }
+        let locator = authorized.ok_or_else(|| {
+            Error::SourceUnavailable("source is no longer registered for content reads".into())
+        })?;
         let cap = request
             .max_bytes
-            .min(awr_source::source_read_cap(&spec.adapter)?);
-        let snapshot = Locator::from_spec(root, &manifest, &spec)?.read(root, cap)?;
+            .min(awr_source::source_read_cap(&source.adapter)?);
+        let snapshot = locator.read(root, cap)?;
         if snapshot.fingerprint != source.fingerprint {
             return Err(Error::SourceConflict(
                 "source bytes changed since indexing; reindex and obtain a new reference".into(),

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -3,6 +3,7 @@ use clap::{CommandFactory, Parser, Subcommand};
 use std::path::PathBuf;
 mod branch;
 mod capabilities;
+mod catalog;
 mod client;
 mod context;
 mod doctor;

--- a/crates/awr-cli/tests/host_capabilities.rs
+++ b/crates/awr-cli/tests/host_capabilities.rs
@@ -135,7 +135,6 @@ fn source_read_support_does_not_advertise_lossless_or_markdown_writes() {
         "mutation.human_save",
         "mutation.multi_file",
         "completion.user_confirmation",
-        "project.catalog",
     ] {
         let capability = result["capabilities"]
             .as_array()

--- a/crates/awr-cli/tests/host_catalog.rs
+++ b/crates/awr-cli/tests/host_catalog.rs
@@ -1,0 +1,363 @@
+use awr_core::Id;
+use serde_json::{Value, json};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+};
+
+struct Project(PathBuf);
+impl Project {
+    fn new(count: usize) -> Self {
+        let p = Self(std::env::temp_dir().join(format!("awr 完整目录 {}", Id::new())));
+        fs::create_dir(&p.0).unwrap();
+        p.write("mapping.toml","[project]\nname='Catalog'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n[sources.options.status_map]\n'待处理'='planned'\n'`ready`'='ready'\n");
+        p.write_ledger(count);
+        p.ok(&["init", "--manifest", "mapping.toml", "--accept"]);
+        p
+    }
+    fn write(&self, path: &str, text: &str) {
+        fs::write(self.0.join(path), text).unwrap();
+    }
+    fn write_ledger(&self, count: usize) {
+        let mut text = String::from(
+            "goals:\n- id: G\n  title: Same title\n  status: active\n  success_criteria: [A useful document]\nmilestones:\n- id: M\n  title: First phase\n  status: active\n  summary: Draft and review\nwork_items:\n",
+        );
+        for n in 0..count {
+            let status = ["ready", "待处理", "`ready`", "unclear", "completed"][n % 5];
+            text.push_str(&format!("- id: W{n:03}\n  title: Same title\n  owner: '资料编辑 张老师'\n  status: '{status}'\n  goal: G\n  milestone: M\n  depends_on: []\n  acceptance: [A useful document]\n  summary: '{}'\n", "original body ".repeat(40)));
+        }
+        self.write("work.yaml", &text);
+    }
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_awr"))
+            .args(["--project", self.0.to_str().unwrap(), "--json"])
+            .args(args)
+            .stdin(Stdio::null())
+            .output()
+            .unwrap()
+    }
+    fn ok(&self, args: &[&str]) -> Value {
+        let r = self.run(args);
+        assert!(
+            r.status.success(),
+            "{:?}\n{}\n{}",
+            args,
+            String::from_utf8_lossy(&r.stdout),
+            String::from_utf8_lossy(&r.stderr)
+        );
+        serde_json::from_slice(&r.stdout).unwrap()
+    }
+    fn error(&self, args: &[&str], code: &str) -> Output {
+        let r = self.run(args);
+        assert!(!r.status.success(), "{:?}", args);
+        assert_eq!(
+            serde_json::from_slice::<Value>(&r.stderr).unwrap()["code"],
+            code
+        );
+        r
+    }
+}
+impl Drop for Project {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn every_kind_can_be_browsed_and_work_pages_preserve_raw_values_and_sources() {
+    let p = Project::new(53);
+    p.write(
+        "rules.md",
+        "# Traceable facts {#R severity=hard scope=project value=*}\n\nKeep facts traceable.\n",
+    );
+    fs::create_dir(p.0.join("decisions")).unwrap();
+    p.write(
+        "decisions/D.md",
+        "# D: Publish a guide\n\nStatus: accepted\n\n## Decision\n\nUse Markdown.\n",
+    );
+    let manifest = fs::read_to_string(p.0.join(".awr/project.toml")).unwrap();
+    p.write(".awr/project.toml", &format!("{manifest}\n[[sources]]\ndomain='rules'\nrole='primary'\npath='rules.md'\nadapter='markdown-rules-v1'\n[[sources]]\ndomain='decisions'\nrole='supporting'\npath='decisions'\nadapter='markdown-directory-v1'\n"));
+    let mut page = p.ok(&["object", "list", "work"]);
+    let revision = page["project_revision"].clone();
+    let mut seen = BTreeMap::new();
+    loop {
+        assert_eq!(page["total"], 53);
+        assert_eq!(page["active_total"], 53);
+        assert_eq!(page["retired_total"], 0);
+        assert_eq!(page["project_revision"], revision);
+        assert_eq!(page["total_is_current"], true);
+        assert_eq!(page["content_included"], false);
+        for item in page["items"].as_array().unwrap() {
+            let key = item["external_key"].as_str().unwrap();
+            assert!(seen.insert(key.to_owned(), item["id"].clone()).is_none());
+            assert_eq!(item["title"], "Same title");
+            assert_eq!(item["owner"], "资料编辑 张老师");
+            assert!(
+                item["source_ref"]["pointer"]
+                    .as_str()
+                    .unwrap()
+                    .starts_with("/work_items/")
+            );
+            assert!(
+                item["source"]["locator"]
+                    .as_str()
+                    .unwrap()
+                    .ends_with("/work.yaml")
+            );
+            assert_eq!(
+                item["source_revision"],
+                item["source_ref"]["source_revision"]
+            );
+            let n = key[1..].parse::<usize>().unwrap();
+            assert_eq!(
+                item["raw_status"],
+                ["ready", "待处理", "`ready`", "unclear", "completed"][n % 5]
+            );
+            assert_eq!(
+                item["status"],
+                ["ready", "planned", "ready", "unknown", "completed"][n % 5]
+            );
+            assert!(item["summary"].as_str().unwrap().len() < "original body ".repeat(40).len());
+        }
+        if !page["has_more"].as_bool().unwrap() {
+            assert!(page["next_cursor"].is_null());
+            break;
+        }
+        page = p.ok(&[
+            "object",
+            "list",
+            "work",
+            "--cursor",
+            &page["next_cursor"].to_string(),
+        ]);
+    }
+    assert_eq!(seen.len(), 53);
+    for kind in [
+        "goal", "plan", "rule", "decision", "source", "relation", "artifact", "evidence",
+    ] {
+        let v = p.ok(&["object", "list", kind, "--limit", "200"]);
+        assert_eq!(
+            v["items"].as_array().unwrap().len() as u64,
+            v["total"].as_u64().unwrap()
+        );
+        assert_eq!(v["has_more"], false);
+        if ["goal", "plan", "rule", "decision", "source"].contains(&kind) {
+            assert_eq!(v["total"], if kind == "source" { 3 } else { 1 }, "{kind}");
+        }
+    }
+    let before = seen["W000"].clone();
+    let text = fs::read_to_string(p.0.join("work.yaml")).unwrap().replacen(
+        "  title: Same title\n  owner:",
+        "  title: Revised title\n  owner:",
+        1,
+    );
+    p.write("work.yaml", &text);
+    let after = p.ok(&["object", "show", "work", "W000", "--full"]);
+    assert_eq!(after["object"]["id"], before);
+    assert_eq!(after["object"]["title"], "Revised title");
+    assert_eq!(after["object"]["summary"], "original body ".repeat(40));
+    p.ok(&["source", "reindex"]);
+    assert_eq!(
+        p.ok(&["object", "show", "work", "W000"])["object"]["id"],
+        before
+    );
+}
+
+#[test]
+fn cursors_reject_scope_project_and_source_revision_changes() {
+    let p = Project::new(23);
+    let first = p.ok(&["object", "list", "work"]);
+    let cursor = first["next_cursor"].to_string();
+    p.error(
+        &["object", "list", "goal", "--cursor", &cursor],
+        "InvalidInput",
+    );
+    p.error(
+        &[
+            "object", "list", "work", "--scope", "all", "--cursor", &cursor,
+        ],
+        "InvalidInput",
+    );
+    let other = Project::new(23);
+    other.error(
+        &["object", "list", "work", "--cursor", &cursor],
+        "InvalidInput",
+    );
+    p.write_ledger(24);
+    p.error(
+        &["object", "list", "work", "--cursor", &cursor],
+        "RevisionConflict",
+    );
+    assert_eq!(p.ok(&["object", "list", "work"])["total"], 24);
+    p.error(
+        &["object", "list", "work", "--limit", "201"],
+        "InvalidInput",
+    );
+    p.error(
+        &["object", "list", "work", "--cursor", "{}"],
+        "InvalidInput",
+    );
+}
+
+#[test]
+fn removal_and_failed_refresh_have_distinct_totals_and_freshness() {
+    let p = Project::new(23);
+    p.write_ledger(22);
+    assert_eq!(p.ok(&["object", "list", "work"])["total"], 22);
+    let retired = p.ok(&["object", "list", "work", "--scope", "retired"]);
+    assert_eq!(retired["total"], 1);
+    assert_eq!(retired["items"][0]["external_key"], "W022");
+    assert_eq!(retired["items"][0]["active"], false);
+    assert_eq!(
+        p.ok(&["object", "list", "work", "--scope", "all"])["total"],
+        23
+    );
+    p.write("work.yaml", "work_items: [broken\n");
+    let failed = p.error(&["object", "list", "work"], "SourceStale");
+    let v: Value = serde_json::from_slice(&failed.stdout).unwrap();
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["total"], 22);
+    assert_eq!(v["total_is_current"], false);
+    assert!(!v["source_issues"].as_array().unwrap().is_empty());
+    assert!(
+        v["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|i| i["freshness"] != "fresh")
+    );
+}
+
+#[test]
+fn full_source_reads_are_explicit_versioned_and_bounded() {
+    let p = Project::new(1);
+    let source = p.ok(&["object", "list", "source"])["items"][0].clone();
+    let id = source["id"].as_str().unwrap();
+    let meta = p.ok(&["source", "show", id]);
+    assert!(meta.get("content").is_none());
+    let full = p.ok(&[
+        "source",
+        "show",
+        id,
+        "--content",
+        "--fingerprint",
+        source["fingerprint"].as_str().unwrap(),
+    ]);
+    assert_eq!(
+        full["content"],
+        fs::read_to_string(p.0.join("work.yaml")).unwrap()
+    );
+    p.error(
+        &["source", "show", id, "--content", "--max-bytes", "10"],
+        "InvalidInput",
+    );
+    p.error(
+        &[
+            "object",
+            "show",
+            "work",
+            "W000",
+            "--full",
+            "--max-bytes",
+            "10",
+        ],
+        "InvalidInput",
+    );
+    p.write_ledger(2);
+    p.error(&["source", "show", id, "--content"], "SourceConflict");
+}
+
+#[test]
+fn removed_registration_retains_metadata_but_cannot_reopen_content() {
+    let p = Project::new(1);
+    let source = p.ok(&["object", "list", "source"])["items"][0].clone();
+    let id = source["id"].as_str().unwrap();
+    p.write("goal.md", "# Keep a guide\n\nA useful document.\n");
+    p.write(".awr/project.toml", "[project]\nname='Catalog'\ncontext_profile='minimal'\n[[sources]]\ndomain='goal'\nrole='primary'\npath='goal.md'\nadapter='markdown-heading-v1'\n");
+    // Revocation applies immediately, even before the next projection refresh.
+    p.ok(&["source", "show", id]);
+    p.error(&["source", "show", id, "--content"], "SourceUnavailable");
+    let retired = p.ok(&["object", "list", "source", "--scope", "retired"]);
+    assert_eq!(retired["total"], 1);
+    assert_eq!(retired["items"][0]["id"], id);
+    p.error(&["source", "show", id, "--content"], "SourceUnavailable");
+    assert!(p.0.join("work.yaml").is_file());
+}
+
+#[test]
+fn runtime_artifacts_and_source_or_runtime_evidence_share_bounded_reference_catalogs() {
+    let p = Project::new(1);
+    let ledger = fs::read_to_string(p.0.join("work.yaml")).unwrap();
+    p.write(
+        "work.yaml",
+        &ledger.replace("  acceptance:", "  evidence: [guide.txt]\n  acceptance:"),
+    );
+    p.write("guide.txt", "An actual fixture guide.\n");
+    let rev = p.ok(&["work", "show", "W000"])["project_revision"].to_string();
+    let started = p.ok(&[
+        "session",
+        "start",
+        "--work",
+        "W000",
+        "--agent",
+        "fixture-writer",
+        "--provider",
+        "fixture",
+        "--model",
+        "none",
+        "--expected-revision",
+        &rev,
+    ]);
+    let imported = p.ok(&[
+        "artifact",
+        "add",
+        "guide.txt",
+        "--type",
+        "guide",
+        "--mime",
+        "text/plain",
+        "--source-event",
+        started["event"]["id"].as_str().unwrap(),
+        "--expected-revision",
+        &started["project_revision"].to_string(),
+    ]);
+    let artifacts = p.ok(&["object", "list", "artifact"]);
+    assert_eq!(artifacts["total"], 1);
+    assert_eq!(artifacts["items"][0]["id"], imported["artifact"]["id"]);
+    assert_eq!(
+        artifacts["items"][0]["source_event_id"],
+        started["event"]["id"]
+    );
+    assert_eq!(artifacts["items"][0]["content_included"], false);
+    assert_eq!(
+        p.ok(&["object", "list", "artifact", "--scope", "retired"])["total"],
+        0
+    );
+    p.write("evidence.json",&json!({"external_key":"GUIDE-REVIEW","work_item_key":"W000","evidence_type":"review","level":"designed","summary":"A caller supplied reference","locator":imported["artifact"]["locator"],"sha256":imported["artifact"]["sha256"],"scope":["W000"]}).to_string());
+    p.ok(&[
+        "evidence",
+        "add",
+        "--input",
+        "evidence.json",
+        "--expected-revision",
+        &artifacts["project_revision"].to_string(),
+    ]);
+    let first = p.ok(&["object", "list", "evidence", "--limit", "1"]);
+    assert_eq!(first["total"], 2);
+    assert_eq!(first["has_more"], true);
+    let second = p.ok(&[
+        "object",
+        "list",
+        "evidence",
+        "--limit",
+        "1",
+        "--cursor",
+        &first["next_cursor"].to_string(),
+    ]);
+    assert_eq!(second["has_more"], false);
+    assert_ne!(first["items"][0]["id"], second["items"][0]["id"]);
+    assert!(first["items"][0]["source"].is_null() != second["items"][0]["source"].is_null());
+    assert_eq!(p.ok(&["work", "show", "W000"])["work"]["status"], "ready");
+}

--- a/crates/awr-store/src/lib.rs
+++ b/crates/awr-store/src/lib.rs
@@ -12,6 +12,7 @@ mod execution;
 mod handoff;
 mod mutation;
 mod mutation_apply;
+mod object_catalog;
 mod projection;
 mod query;
 mod reconcile;
@@ -32,6 +33,7 @@ pub use delta::{
     DeltaEvents, EntityDelta, EventReference, HistoryCount, ImportantEvent, SourceDelta,
 };
 pub use events::{BranchFilter, EventCursor, EventPage, EventQuery};
+pub use object_catalog::{CatalogCursor, CatalogKind, CatalogPage, CatalogRow, CatalogScope};
 pub use reconcile::{ReconcileAction, ReconcileReceipt, RuntimeFinding, RuntimeInspection};
 use rusqlite::{Connection, OpenFlags, TransactionBehavior};
 pub use search::{SearchHit, SearchQuery, SearchReport};

--- a/crates/awr-store/src/object_catalog.rs
+++ b/crates/awr-store/src/object_catalog.rs
@@ -1,0 +1,234 @@
+//! Bounded, revision-bound traversal of the retained project catalog.
+use crate::{
+    Store,
+    catalog::{SOURCE_COLUMNS, revision_at, source_row},
+    db_error,
+};
+use awr_core::{Error, Id, Result, Revision, Source};
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogKind {
+    Goal,
+    Plan,
+    Rule,
+    Work,
+    Decision,
+    Source,
+    Relation,
+    Artifact,
+    Evidence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogScope {
+    Active,
+    Retired,
+    All,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CatalogCursor {
+    pub version: u32,
+    pub project_id: Id,
+    pub project_revision: Revision,
+    pub kind: CatalogKind,
+    pub scope: CatalogScope,
+    pub after_id: Id,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CatalogRow {
+    pub item: Value,
+    pub source: Option<Source>,
+    pub active: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CatalogPage {
+    pub project_id: Id,
+    pub project_revision: Revision,
+    pub kind: CatalogKind,
+    pub scope: CatalogScope,
+    pub total: u64,
+    pub active_total: u64,
+    pub retired_total: u64,
+    pub items: Vec<CatalogRow>,
+    pub has_more: bool,
+    pub next_cursor: Option<CatalogCursor>,
+}
+
+impl Store {
+    /// The caller refreshes sources first. Any intervening runtime/source revision
+    /// invalidates the cursor; this API never labels mixed pages as one snapshot.
+    pub fn catalog_page(
+        &self,
+        project: Id,
+        revision: Revision,
+        kind: CatalogKind,
+        scope: CatalogScope,
+        cursor: Option<&CatalogCursor>,
+        limit: usize,
+    ) -> Result<CatalogPage> {
+        if !(1..=200).contains(&limit) {
+            return Err(Error::InvalidInput("catalog limit must be 1..200".into()));
+        }
+        let check = || -> Result<()> {
+            let actual = self.project(project)?.project_revision;
+            if actual != revision {
+                return Err(Error::RevisionConflict {
+                    expected: revision,
+                    actual,
+                });
+            }
+            Ok(())
+        };
+        check()?;
+        if let Some(c) = cursor {
+            if c.version != 1 || c.project_id != project || c.kind != kind || c.scope != scope {
+                return Err(Error::InvalidInput(
+                    "catalog cursor belongs to another version, project, kind or scope".into(),
+                ));
+            }
+            if c.project_revision != revision {
+                return Err(Error::RevisionConflict {
+                    expected: c.project_revision,
+                    actual: revision,
+                });
+            }
+        }
+        let table = match kind {
+            CatalogKind::Goal => "goals",
+            CatalogKind::Plan => "plans",
+            CatalogKind::Rule => "rules",
+            CatalogKind::Work => "work_items",
+            CatalogKind::Decision => "decisions",
+            CatalogKind::Source => "sources",
+            CatalogKind::Relation => "edges",
+            CatalogKind::Artifact => "artifacts",
+            CatalogKind::Evidence => "evidence",
+        };
+        let has_source = !matches!(kind, CatalogKind::Source | CatalogKind::Artifact);
+        let from = if has_source {
+            format!(
+                "{table} e LEFT JOIN sources s ON s.id=e.source_id AND s.project_id=e.project_id"
+            )
+        } else {
+            format!("{table} e")
+        };
+        let active = match kind {
+            CatalogKind::Source => "e.active=1",
+            CatalogKind::Artifact => "1",
+            CatalogKind::Evidence => "e.active=1 AND (e.source_id IS NULL OR s.active=1)",
+            _ => "e.active=1 AND s.active=1",
+        };
+        let filter = match scope {
+            CatalogScope::Active => format!("({active})"),
+            CatalogScope::Retired => format!("NOT ({active})"),
+            CatalogScope::All => "1".into(),
+        };
+        let (active_total, retired_total): (u64, u64) = self.conn.query_row(
+            &format!("SELECT coalesce(sum(CASE WHEN {active} THEN 1 ELSE 0 END),0), coalesce(sum(CASE WHEN {active} THEN 0 ELSE 1 END),0) FROM {from} WHERE e.project_id=?1"),
+            [project.to_string()], |r| Ok((revision_at(r,0)?, revision_at(r,1)?))).map_err(db_error)?;
+        let payload = match kind {
+            CatalogKind::Source => {
+                "json_object('id',e.id,'domain',e.domain,'role',e.role,'locator',e.locator,'format',e.format,'adapter',e.adapter,'revision',e.revision,'fingerprint',e.fingerprint,'freshness',e.freshness)"
+            }
+            CatalogKind::Relation => {
+                "json_object('id',e.id,'from_kind',e.from_kind,'from_key',e.from_key,'relation',e.relation,'to_kind',e.to_kind,'to_key',e.to_key,'required',json(CASE WHEN e.required THEN 'true' ELSE 'false' END),'revision',e.revision,'source_ref',json(e.source_ref_json))"
+            }
+            CatalogKind::Artifact => {
+                "json_object('id',e.id,'project_id',e.project_id,'artifact_type',e.artifact_type,'locator',e.locator,'sha256',e.sha256,'size',e.size,'mime',e.mime,'source_event_id',e.source_event_id,'revision',e.revision)"
+            }
+            _ => "e.payload_json",
+        };
+        let source_columns = if has_source {
+            SOURCE_COLUMNS
+                .split(',')
+                .map(|c| format!("s.{c}"))
+                .collect::<Vec<_>>()
+                .join(",")
+        } else {
+            std::iter::repeat_n("NULL", 11)
+                .collect::<Vec<_>>()
+                .join(",")
+        };
+        let sql = format!(
+            "SELECT {source_columns},{payload},({active}) FROM {from} WHERE e.project_id=?1 AND {filter} AND (?2 IS NULL OR e.id>?2) ORDER BY e.id LIMIT ?3"
+        );
+        let mut rows = self
+            .conn
+            .prepare(&sql)
+            .map_err(db_error)?
+            .query_map(
+                params![
+                    project.to_string(),
+                    cursor.map(|c| c.after_id.to_string()),
+                    limit as i64 + 1
+                ],
+                |r| {
+                    let item = serde_json::from_str(&r.get::<_, String>(11)?).map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            11,
+                            rusqlite::types::Type::Text,
+                            Box::new(e),
+                        )
+                    })?;
+                    Ok(CatalogRow {
+                        item,
+                        source: if r.get::<_, Option<String>>(0)?.is_some() {
+                            Some(source_row(r)?)
+                        } else {
+                            None
+                        },
+                        active: r.get(12)?,
+                    })
+                },
+            )
+            .map_err(db_error)?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(db_error)?;
+        let has_more = rows.len() > limit;
+        rows.truncate(limit);
+        let next_cursor = if has_more {
+            let after_id = rows
+                .last()
+                .and_then(|r| r.item["id"].as_str())
+                .ok_or_else(|| Error::Storage("catalog row has no identity".into()))?
+                .parse()
+                .map_err(|e| Error::Storage(format!("catalog identity: {e}")))?;
+            Some(CatalogCursor {
+                version: 1,
+                project_id: project,
+                project_revision: revision,
+                kind,
+                scope,
+                after_id,
+            })
+        } else {
+            None
+        };
+        check()?;
+        Ok(CatalogPage {
+            project_id: project,
+            project_revision: revision,
+            kind,
+            scope,
+            total: match scope {
+                CatalogScope::Active => active_total,
+                CatalogScope::Retired => retired_total,
+                CatalogScope::All => active_total + retired_total,
+            },
+            active_total,
+            retired_total,
+            items: rows,
+            has_more,
+            next_cursor,
+        })
+    }
+}

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -98,6 +98,50 @@ A failed projection does not mean the configuration was unwritten; inspect the
 receipt and current configuration before acting. Identical configuration returns
 `no_change`. Configuration setup is separate from task/document source editing.
 
+## Traverse the complete catalog
+
+```text
+awr object list work --limit 20 --json
+awr object list work --cursor '<next_cursor JSON>' --json
+awr object list source --scope all --json
+```
+
+Use `object list` for `goal`, `plan`, `rule`, `work`, `decision`, `source`,
+`relation`, `artifact` and `evidence`. Each page contains at most 200 objects
+(default 20), an exact `total` for the selected scope, `has_more`, and a nullable
+`next_cursor`. Repeat the same kind and scope. The cursor binds the project identity,
+project revision and last stable object ID. Any intervening source or runtime revision
+requires a new traversal (`RevisionConflict`); do not append pages from different
+versions. A changed title retains identity when the source's explicit key is stable.
+Title-derived keys can change identity; AWR does not guess a rename from similarity.
+
+Scope defaults to `active`. `retired` includes projections removed from a source or
+whose source was unregistered; `all` combines both. These scopes describe retained
+index membership, not completion, archive status or a reporting period. `active_total`
+and `retired_total` remain separate. Select the desired milestone/relations for period
+reporting; never infer engineering verification from `status: completed`.
+
+Lists preserve source references, object/source/project revisions, raw status and
+owner values alongside normalized status. Owner strings are source data, not runnable
+Agent identities or runtime claims. Use `work show`/`ready` for readiness diagnostics
+and current claims, and `object list relation` for dependencies and groupings. Unknown
+states remain unknown; custom language or code-wrapped spellings use the project's
+explicit `status_map`. Original bytes remain available through the source reader.
+
+Long text is summarized and `content_included` is false. Drill down with
+`object show <kind> <id> --full`, `decision show --full`, `source show --content`,
+`artifact show`/`cat`, or `evidence show --content`, using their byte/version guards.
+Source content reads require a current registration and the indexed fingerprint;
+retired/revoked sources retain metadata and history without granting new file reads.
+Explicit cached object reads expose historical projections, not fresh file content.
+
+A failed source refresh can still return a useful page on stdout with a nonzero
+`SourceStale` result. Its `total_basis` is `retained_indexed_objects` and
+`total_is_current` is false; inspect `source_issues` and each source's freshness.
+The retained count is not the authoritative total of an unreadable source. An empty
+partial index must not be displayed as a confirmed empty project. Process stdout,
+stderr and exit code together. Existing status/ready summary limits are unchanged.
+
 ## Current read/write limits
 
 `source.read` and `object.read` operate on registered references with bounded body


### PR DESCRIPTION
Hosts can now traverse the full indexed project catalog with bounded pages, exact indexed counts and revision-bound cursors. Lists retain identities, raw statuses, owners and source references, distinguish active and retired entries, and report partial source refreshes without presenting stale counts as current. Full source reads also require a current registration, so removing a source revokes new file reads while preserving historical metadata.

Validation: 22 targeted CLI tests passed, covering complete traversal, cursor conflicts, renamed objects, retained failures, reference catalogs and bounded/full reads. Public-tree and formatting checks passed.
