### PR TITLE
Retain idempotent external execution reports and host continuity

### DIFF
--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -135,6 +135,20 @@ fn catalog() -> Vec<Capability> {
             &["local_supervisor", "project_scoped_operation_key"],
         ),
         (
+            "execution.external.report",
+            true,
+            &[
+                "execution report",
+                "execution report-status",
+                "execution inspect",
+            ],
+            &[
+                "host_supplied_provenance",
+                "never_promotes_managed_or_verified",
+                "request_key_idempotent",
+            ],
+        ),
+        (
             "artifact.managed",
             true,
             &["artifact add", "artifact show", "artifact cat"],

--- a/crates/awr-cli/src/execution.rs
+++ b/crates/awr-cli/src/execution.rs
@@ -7,7 +7,7 @@ use std::{
     fs,
     io::{Read, Write},
     net::TcpListener,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
     time::Duration,
 };
@@ -35,6 +35,18 @@ pub enum ExecutionCommand {
         purpose: String,
         #[arg(long)]
         reference: String,
+    },
+    /// Record a bounded ExternalExecutionReport JSON file; never changes supervisor facts.
+    Report {
+        #[arg(long)]
+        input: PathBuf,
+        #[arg(long)]
+        expected_revision: Revision,
+    },
+    /// Look up the immutable report receipt before retrying after a lost response.
+    ReportStatus {
+        #[arg(long)]
+        key: String,
     },
     List {
         #[arg(long)]
@@ -118,6 +130,27 @@ fn protect_runtime(root: &Path) -> Result<()> {
 pub fn run(root: &Path, command: &ExecutionCommand, _json_output: bool) -> Result<()> {
     let root = root.canonicalize()?;
     let result = match command {
+        ExecutionCommand::Report {
+            input,
+            expected_revision,
+        } => {
+            let bytes = awr_source::read_capped(&root.join(input), 1024 * 1024)?;
+            let report: ExternalExecutionReport = serde_json::from_slice(&bytes).map_err(|_| {
+                Error::InvalidInput("invalid external execution report JSON".into())
+            })?;
+            // External observations must remain recordable when source parsing fails.
+            // This opens existing runtime state without refreshing or mutating source files.
+            let mut db = RuntimeProject::open(&root, false)?;
+            let (event, created) =
+                db.store
+                    .report_external_execution(db.project.id, *expected_revision, report)?;
+            json!({"ok":true,"project_revision":db.store.project(db.project.id)?.project_revision,"event":event,"created":created,"receipt_recorded":true,"validation_basis":"host_supplied_report","outcome_verified":false,"source_write_performed":false,"source_refresh_performed":false})
+        }
+        ExecutionCommand::ReportStatus { key } => {
+            let (store, project) = read_state(&root)?;
+            let event = store.external_report_by_key(project.id, key)?;
+            json!({"ok":true,"project_revision":project.project_revision,"found":event.is_some(),"event":event,"validation_basis":"host_supplied_report","outcome_verified":false,"side_effects_performed":false})
+        }
         ExecutionCommand::Run {
             session,
             key,
@@ -195,11 +228,11 @@ pub fn run(root: &Path, command: &ExecutionCommand, _json_output: bool) -> Resul
         ExecutionCommand::Inspect { id } => {
             let (store, project) = read_state(&root)?;
             let e = store.execution(project.id, *id)?;
-            json!({"observation":awr_runtime::inspect_execution(&root,&e)?,"side_effects_performed":false})
+            json!({"observation":awr_runtime::inspect_execution(&root,&e)?,"external_report":store.latest_external_report(project.id,*id)?,"side_effects_performed":false})
         }
         ExecutionCommand::Show { id } => {
             let db = RuntimeProject::open(&root, false)?;
-            json!({"execution":db.store.execution(db.project.id,*id)?,"live_verification_performed":false})
+            json!({"execution":db.store.execution(db.project.id,*id)?,"external_report":db.store.latest_external_report(db.project.id,*id)?,"live_verification_performed":false})
         }
         ExecutionCommand::Worker { id } => return supervise(&root, *id),
     };

--- a/crates/awr-cli/src/recovery.rs
+++ b/crates/awr-cli/src/recovery.rs
@@ -21,7 +21,22 @@ pub fn run(root: &Path, command: &RecoveryCommand, json_output: bool) -> Result<
     let checkpoint = store.recovery_checkpoint(project.id, session.id)?;
     let executions =
         awr_runtime::inspect_work_executions(&store, root, project.id, work, session.branch_id)?;
-    let result = json!({"session":session,"checkpoint":checkpoint,"executions":executions,"all_execution_states_verified":executions.iter().all(|e|e.verified),"observed_at":now_millis()?,"source_refresh_performed":false,"side_effects_performed":false,"next_step":"Use session resume to refresh project sources and compile the successor context. Unknown executions require explicit investigation before a retry."});
+    let reports = executions
+        .iter()
+        .map(|e| store.latest_external_report(project.id, e.execution_id))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let findings = store.inspect_runtime(project.id, now_millis()?)?.findings;
+    let actual = store.project(project.id)?.project_revision;
+    if actual != project.project_revision {
+        return Err(Error::RevisionConflict {
+            expected: project.project_revision,
+            actual,
+        });
+    }
+    let result = json!({"session":session,"checkpoint":checkpoint,"executions":executions,"external_reports":reports,"runtime_findings":findings,"project_revision":project.project_revision,"all_execution_states_verified":executions.iter().all(|e|e.verified),"observed_at":now_millis()?,"source_refresh_performed":false,"side_effects_performed":false,"next_step":"Use doctor for read-only current-source and artifact diagnostics, then session resume to refresh sources and compile the successor context. Unknown executions and incomplete writes require explicit investigation before any retry."});
     if json_output {
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {

--- a/crates/awr-cli/tests/host_continuity.rs
+++ b/crates/awr-cli/tests/host_continuity.rs
@@ -1,0 +1,437 @@
+//! Synthetic host contract checks; these do not launch Kimi/Grok or claim native acceptance.
+use awr_core::*;
+use awr_store::Store;
+use serde_json::{Value, json};
+use std::{
+    fs,
+    io::Write,
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+    sync::Arc,
+};
+
+struct Host(PathBuf);
+impl Host {
+    fn new() -> Self {
+        let h = Self(std::env::temp_dir().join(format!("awr 宿主续接 {}", Id::new())));
+        fs::create_dir(&h.0).unwrap();
+        h.write("work.yaml","goals:\n- id: G\n  title: Publish a guide\n  status: active\n  success_criteria: [A useful guide]\nwork_items:\n- id: W\n  title: Draft the guide\n  status: ready\n  goal: G\n  acceptance: [A useful guide]\n  next_action: Write the outline\n");
+        h.write("mapping.toml","[project]\nname='Continuity'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n");
+        h.ok(&["init", "--manifest", "mapping.toml", "--accept"]);
+        h
+    }
+    fn write(&self, path: &str, body: &str) {
+        fs::write(self.0.join(path), body).unwrap();
+    }
+    fn run(&self, args: &[&str], input: Option<Value>) -> Output {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_awr"))
+            .args(["--project", self.0.to_str().unwrap(), "--json"])
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        if let Some(input) = input {
+            child
+                .stdin
+                .take()
+                .unwrap()
+                .write_all(&serde_json::to_vec(&input).unwrap())
+                .unwrap();
+        } else {
+            drop(child.stdin.take());
+        }
+        child.wait_with_output().unwrap()
+    }
+    fn ok(&self, args: &[&str]) -> Value {
+        decode(self.run(args, None))
+    }
+    fn error(&self, args: &[&str], code: &str) {
+        let r = self.run(args, None);
+        assert!(!r.status.success(), "{args:?}");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&r.stderr).unwrap()["code"],
+            code
+        );
+    }
+    fn revision(&self) -> String {
+        self.ok(&["session", "list"])["project_revision"].to_string()
+    }
+    fn bind(&self, external: &str) -> Value {
+        self.ok(&[
+            "client",
+            "bind",
+            "--client",
+            "generic",
+            "--external-session",
+            external,
+            "--work",
+            "W",
+            "--model",
+            "fixture-model",
+        ])
+    }
+    fn hook(&self, external: &str, event: &str, turn: &str) -> Value {
+        decode(self.run(
+            &["client", "hook", "--client", "generic", "--work", "W"],
+            Some(
+                json!({"session_id":external,"hook_event_name":event,"turn_id":turn,"cwd":self.0}),
+            ),
+        ))
+    }
+    fn register(&self, session: &str, key: &str) -> Value {
+        self.ok(&[
+            "execution",
+            "register",
+            "--session",
+            session,
+            "--key",
+            key,
+            "--purpose",
+            "Draft the guide",
+            "--reference",
+            "host://fixture/execution/guide",
+        ])
+    }
+    fn report(&self, execution: &Value, key: &str, phase: &str) -> Value {
+        json!({"version":1,"request_key":key,"execution_id":execution["execution"]["id"],"host_id":"fixture-host","host_work_key":"workspace/guide","native_session":"fixture-provider/first-conversation","agent_id":"fixture-author","origin":"host_observed","phase":phase,"observed_at":now_millis().unwrap(),"summary":"Host observed a guide drafting stage","detail_references":["host://fixture/logs/guide","host://fixture/artifacts/guide"]})
+    }
+    fn submit(&self, report: &Value, rev: &str) -> Value {
+        self.write("report.json", &report.to_string());
+        self.ok(&[
+            "execution",
+            "report",
+            "--input",
+            "report.json",
+            "--expected-revision",
+            rev,
+        ])
+    }
+}
+impl Drop for Host {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+fn decode(r: Output) -> Value {
+    assert!(
+        r.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&r.stdout),
+        String::from_utf8_lossy(&r.stderr)
+    );
+    serde_json::from_slice(&r.stdout).unwrap()
+}
+
+#[test]
+fn external_reports_are_idempotent_queryable_and_never_promote_execution_success() {
+    let h = Host::new();
+    let b = h.bind("fixture-provider/first-conversation");
+    let s = b["binding"]["session_id"].as_str().unwrap();
+    let registered = h.register(s, "guide-execution");
+    let id = registered["execution"]["id"].as_str().unwrap();
+    assert_eq!(registered["outcome_verified"], false);
+    let rev = h.revision();
+    let report = h.report(&registered, "stage-1", "succeeded");
+    let saved = h.submit(&report, &rev);
+    assert_eq!(saved["created"], true);
+    assert_eq!(saved["outcome_verified"], false);
+    assert_eq!(saved["event"]["session_id"], s);
+    assert_eq!(
+        saved["event"]["work_item_id"],
+        registered["execution"]["work_item_id"]
+    );
+    let replay = h.submit(&report, &rev);
+    assert_eq!(replay["created"], false);
+    assert_eq!(replay["event"], saved["event"]);
+    assert_eq!(replay["project_revision"], saved["project_revision"]);
+    let status = h.ok(&["execution", "report-status", "--key", "stage-1"]);
+    assert_eq!(status["event"], saved["event"]);
+    assert_eq!(status["side_effects_performed"], false);
+    assert_eq!(
+        h.ok(&["execution", "report-status", "--key", "not-recorded"])["found"],
+        false
+    );
+    let inspected = h.ok(&["execution", "inspect", id]);
+    assert_eq!(inspected["observation"]["state"], "unknown");
+    assert_eq!(inspected["observation"]["verified"], false);
+    assert_eq!(inspected["external_report"]["id"], saved["event"]["id"]);
+    let shown = h.ok(&["execution", "show", id]);
+    assert_eq!(shown["execution"], registered["execution"]);
+    assert_eq!(shown["external_report"]["payload"]["report"], report);
+    let mut changed = report.clone();
+    changed["phase"] = json!("failed");
+    h.write("report.json", &changed.to_string());
+    h.error(
+        &[
+            "execution",
+            "report",
+            "--input",
+            "report.json",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "SourceConflict",
+    );
+    h.error(
+        &[
+            "execution",
+            "run",
+            "--session",
+            s,
+            "--key",
+            "guide-execution",
+            "--purpose",
+            "Draft the guide",
+            "--",
+            "forbidden-replay",
+        ],
+        "SourceConflict",
+    );
+    assert!(h.ok(&["execution", "show", id])["execution"]["worker"].is_null());
+    assert_eq!(h.ok(&["work", "show", "W"])["work"]["status"], "ready");
+    assert!(!h.0.join(".awr/executions").join(id).exists());
+    h.ok(&[
+        "session",
+        "end",
+        "--session",
+        s,
+        "--outcome",
+        "ended",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    let ended = h.report(&registered, "stage-late", "interrupted");
+    h.submit(&ended, &h.revision());
+    assert_eq!(h.ok(&["session", "show", s])["session"]["status"], "ended");
+}
+
+#[test]
+fn duplicate_concurrent_report_delivery_creates_one_receipt() {
+    let h = Arc::new(Host::new());
+    let b = h.bind("parallel-host");
+    let r = h.register(
+        b["binding"]["session_id"].as_str().unwrap(),
+        "parallel-exec",
+    );
+    h.write(
+        "report.json",
+        &h.report(&r, "one-report", "progress").to_string(),
+    );
+    let revision = h.revision();
+    let jobs = (0..4)
+        .map(|_| {
+            let h = h.clone();
+            let revision = revision.clone();
+            std::thread::spawn(move || {
+                h.ok(&[
+                    "execution",
+                    "report",
+                    "--input",
+                    "report.json",
+                    "--expected-revision",
+                    &revision,
+                ])
+            })
+        })
+        .collect::<Vec<_>>();
+    let values = jobs
+        .into_iter()
+        .map(|j| j.join().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(values.iter().filter(|v| v["created"] == true).count(), 1);
+    assert!(
+        values
+            .iter()
+            .all(|v| v["event"]["id"] == values[0]["event"]["id"])
+    );
+}
+
+#[test]
+fn generic_host_handoff_uses_fresh_context_and_keeps_external_outcomes_unknown() {
+    let h = Host::new();
+    let bound = h.bind("provider-a/native-one");
+    let sid = bound["binding"]["session_id"].as_str().unwrap();
+    let registered = h.register(sid, "first-exec");
+    h.ok(&[
+        "client",
+        "progress",
+        "--client",
+        "generic",
+        "--external-session",
+        "provider-a/native-one",
+        "--digest",
+        "Drafted the guide outline",
+        "--next-action",
+        "Review the guide examples",
+        "--open-loop",
+        "Check the external tool result before retrying",
+    ]);
+    let cp = h.hook("provider-a/native-one", "Stop", "stage-one");
+    let duplicate = h.hook("provider-a/native-one", "Stop", "stage-one");
+    assert_eq!(cp["awr"]["checkpoint_saved"], true);
+    assert_eq!(duplicate["awr"]["duplicate"], true);
+    assert_eq!(
+        cp["awr"]["binding"]["checkpoint_id"],
+        duplicate["awr"]["binding"]["checkpoint_id"]
+    );
+    let checkpoint = cp["awr"]["binding"]["checkpoint_id"].as_str().unwrap();
+    let read = h.ok(&["object", "show", "checkpoint", checkpoint, "--full"]);
+    assert!(read.to_string().contains("Review the guide examples"));
+    let original = fs::read_to_string(h.0.join("work.yaml")).unwrap();
+    h.write(
+        "work.yaml",
+        &original.replace("Write the outline", "Include revised examples"),
+    );
+    let revision = h.revision();
+    let sessions = h.ok(&["session", "list"]);
+    let inspect = h.ok(&["recovery", "inspect", "--session", sid]);
+    assert_eq!(inspect["side_effects_performed"], false);
+    assert_eq!(inspect["source_refresh_performed"], false);
+    assert_eq!(inspect["checkpoint"]["id"], checkpoint);
+    assert_eq!(inspect["executions"][0]["state"], "unknown");
+    let diagnosis = h.run(&["doctor"], None);
+    assert!(!diagnosis.status.success());
+    let doctor: Value = serde_json::from_slice(&diagnosis.stdout).unwrap();
+    assert_eq!(doctor["read_only"], true);
+    assert!(
+        doctor["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|f| f["code"] == "source_fingerprint_changed")
+    );
+    assert_eq!(h.revision(), revision);
+    assert_eq!(h.ok(&["session", "list"]), sessions);
+    let successor = h.ok(&[
+        "client",
+        "bind",
+        "--client",
+        "generic",
+        "--external-session",
+        "provider-b/native-two",
+        "--work",
+        "W",
+        "--from-session",
+        sid,
+        "--model",
+        "fixture-successor",
+    ]);
+    assert_ne!(successor["binding"]["session_id"], sid);
+    assert_eq!(
+        successor["binding"]["next_action"],
+        "Review the guide examples"
+    );
+    assert!(
+        successor["context"]
+            .to_string()
+            .contains("Include revised examples")
+    );
+    let executions = h.ok(&["execution", "list", "--work", "W"]);
+    assert_eq!(executions["executions"].as_array().unwrap().len(), 1);
+    assert_eq!(executions["executions"][0], registered["execution"]);
+    assert!(!h.0.join(".codex").exists());
+    assert!(!h.0.join(".kimi").exists());
+}
+
+#[test]
+fn source_failure_does_not_lose_reports_and_reports_cannot_adopt_foreign_or_managed_work() {
+    let h = Host::new();
+    let bound = h.bind("host-source-failure");
+    let sid = bound["binding"]["session_id"].as_str().unwrap();
+    let r = h.register(sid, "external-source-failure");
+    let proposal = h.ok(&[
+        "proposal",
+        "create",
+        "--kind",
+        "work",
+        "--target",
+        "W",
+        "--intent",
+        "Revise next action",
+        "--patch",
+        r#"{"next_action":"Read the report"}"#,
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    let inspected = h.ok(&["recovery", "inspect", "--session", sid]);
+    assert!(
+        inspected["runtime_findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(
+                |f| f["code"] == "pending_mutation" && f["object_id"] == proposal["proposal"]["id"]
+            )
+    );
+    h.write("work.yaml", "work_items: [broken\n");
+    let before = fs::read(h.0.join("work.yaml")).unwrap();
+    h.submit(
+        &h.report(&r, "after-source-failure", "unknown"),
+        &h.revision(),
+    );
+    assert_eq!(fs::read(h.0.join("work.yaml")).unwrap(), before);
+    let other = Host::new();
+    other.write(
+        "report.json",
+        &h.report(&r, "foreign", "progress").to_string(),
+    );
+    other.error(
+        &[
+            "execution",
+            "report",
+            "--input",
+            "report.json",
+            "--expected-revision",
+            &other.revision(),
+        ],
+        "NotFound",
+    );
+    let mut store = Store::open_existing(&h.0.join(".awr/state.db")).unwrap();
+    let project = store.project_by_root(&h.0).unwrap();
+    let managed = store
+        .register_execution(
+            project.id,
+            project.project_revision,
+            sid.parse().unwrap(),
+            ExecutionIntent {
+                operation_key: "managed-intent-only".into(),
+                purpose: "A fixture intent; never dispatched".into(),
+                executor: ExecutorKind::ManagedLocal,
+                command: vec!["not-dispatched".into()],
+                cwd: h.0.to_string_lossy().into(),
+                external_reference: None,
+            },
+        )
+        .unwrap()
+        .0;
+    drop(store);
+    let mut forged = h.report(&r, "managed-report", "succeeded");
+    forged["execution_id"] = json!(managed.id);
+    h.write("report.json", &forged.to_string());
+    h.error(
+        &[
+            "execution",
+            "report",
+            "--input",
+            "report.json",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "InvalidTransition",
+    );
+    forged["worker"] = json!({"pid":123});
+    h.write("report.json", &forged.to_string());
+    h.error(
+        &[
+            "execution",
+            "report",
+            "--input",
+            "report.json",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "InvalidInput",
+    );
+}

--- a/crates/awr-core/src/event_payload.rs
+++ b/crates/awr-core/src/event_payload.rs
@@ -149,6 +149,7 @@ fn domain_fields(kind: &str, payload: &Value) -> Result<()> {
             | "execution.starting"
             | "execution.running"
             | "execution.finished" => "execution",
+            "execution.external_reported" => "execution_id report",
             "session.started" => {
                 "agent_id provider model start_project_revision claim_id expired_claim_ids expires_at"
             }
@@ -209,6 +210,7 @@ fn domain_fields(kind: &str, payload: &Value) -> Result<()> {
         | "execution.starting"
         | "execution.running"
         | "execution.finished" => "execution",
+        "execution.external_reported" => "execution_id report",
         "session.started" => "agent_id provider model start_project_revision",
         "work.claimed" => "claim_id agent_id expired_claim_ids",
         "session.resumed" | "session.resumed_from" | "session.handoff_received" => {
@@ -267,7 +269,7 @@ fn domain_fields(kind: &str, payload: &Value) -> Result<()> {
             | "source_write_performed" => value.is_boolean(),
             "execution" | "binding" | "before" | "after" | "write_plan" | "work_action"
             | "draft" | "session_delta" | "git_binding" | "selection" | "closure" | "original"
-            | "target_work" => value.is_object(),
+            | "target_work" | "report" => value.is_object(),
             "changes" => value
                 .as_array()
                 .is_some_and(|v| v.iter().all(Value::is_object)),

--- a/crates/awr-core/src/execution.rs
+++ b/crates/awr-core/src/execution.rs
@@ -8,6 +8,71 @@ pub enum ExecutorKind {
     External,
 }
 
+/// Claimed provenance of an external report; neither value grants supervisor authority.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalReportOrigin {
+    CallerReported,
+    HostObserved,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalReportPhase {
+    Started,
+    Progress,
+    WaitingUser,
+    Succeeded,
+    Failed,
+    Interrupted,
+    Unknown,
+}
+
+/// Immutable host observation. Reports are separate from AWR's execution state machine.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalExecutionReport {
+    pub version: u32,
+    pub request_key: String,
+    pub execution_id: Id,
+    pub host_id: String,
+    pub host_work_key: String,
+    pub native_session: String,
+    pub agent_id: String,
+    pub origin: ExternalReportOrigin,
+    pub phase: ExternalReportPhase,
+    pub observed_at: i64,
+    pub summary: String,
+    #[serde(default)]
+    pub detail_references: Vec<String>,
+}
+impl ExternalExecutionReport {
+    pub fn validate(&self) -> crate::Result<()> {
+        if self.version != 1
+            || self.observed_at < 0
+            || [
+                &self.request_key,
+                &self.host_id,
+                &self.host_work_key,
+                &self.native_session,
+                &self.agent_id,
+            ]
+            .iter()
+            .any(|s| s.trim().is_empty() || s.len() > 512 || s.contains('\0'))
+            || self.summary.trim().is_empty()
+            || self.summary.len() > 8192
+            || self.detail_references.len() > 32
+            || self
+                .detail_references
+                .iter()
+                .any(|s| s.trim().is_empty() || s.len() > 4096 || s.contains('\0'))
+        {
+            return Err(crate::Error::InvalidInput("external report requires version 1, bounded identities, timestamp, summary and references".into()));
+        }
+        crate::ensure_public_data(self)
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecutionState {

--- a/crates/awr-store/src/execution.rs
+++ b/crates/awr-store/src/execution.rs
@@ -20,6 +20,59 @@ fn key_at(conn: &Connection, project: Id, key: &str) -> Result<Option<Execution>
     value.map(decode).transpose()
 }
 impl Store {
+    /// Immutable report lookup also works after its originating work session ends.
+    pub fn external_report_by_key(&self, project: Id, key: &str) -> Result<Option<Event>> {
+        report_at(&self.conn, project, "$.report.request_key", key)
+    }
+    pub fn latest_external_report(&self, project: Id, execution: Id) -> Result<Option<Event>> {
+        self.execution(project, execution)?;
+        report_at(
+            &self.conn,
+            project,
+            "$.execution_id",
+            &execution.to_string(),
+        )
+    }
+    pub fn report_external_execution(
+        &mut self,
+        project: Id,
+        expected: Revision,
+        report: ExternalExecutionReport,
+    ) -> Result<(Event, bool)> {
+        report.validate()?;
+        let same = |event: Event| -> Result<(Event, bool)> {
+            if event.payload["report"] != serde_json::to_value(&report)? {
+                return Err(Error::SourceConflict(
+                    "external report request key was already used for different content".into(),
+                ));
+            }
+            Ok((event, false))
+        };
+        if let Some(event) = self.external_report_by_key(project, &report.request_key)? {
+            return same(event);
+        }
+        let result=self.runtime_transaction_with_event(project,expected,EventDraft::new("execution.external_reported",&report.summary),|tx,_,event| {
+            let execution=at(tx,project,report.execution_id)?;
+            if execution.intent.executor!=ExecutorKind::External {
+                return Err(Error::InvalidTransition("host reports require an external execution; managed supervisors retain exclusive ownership".into()));
+            }
+            event.work_item_id=Some(execution.work_item_id);
+            event.session_id=Some(execution.session_id);
+            event.branch_id=execution.branch_id;
+            event.payload=serde_json::json!({"execution_id":execution.id,"report":report});
+            Ok(())
+        });
+        match result {
+            Ok((_, event)) => Ok((event, true)),
+            Err(error @ Error::RevisionConflict { .. }) => {
+                match self.external_report_by_key(project, &report.request_key)? {
+                    Some(event) => same(event),
+                    None => Err(error),
+                }
+            }
+            Err(error) => Err(error),
+        }
+    }
     pub fn execution(&self, project: Id, id: Id) -> Result<Execution> {
         at(&self.conn, project, id)
     }
@@ -246,4 +299,10 @@ impl Store {
             },
         )
     }
+}
+
+fn report_at(conn: &Connection, project: Id, selector: &str, value: &str) -> Result<Option<Event>> {
+    // selector is supplied only by the two typed readers above and remains a SQL parameter.
+    let id:Option<String>=conn.query_row("SELECT id FROM events WHERE project_id=?1 AND event_type='execution.external_reported' AND json_extract(payload_json,?2)=?3 ORDER BY project_revision DESC LIMIT 1",params![project.to_string(),selector,value],|r|r.get(0)).optional().map_err(db_error)?;
+    id.map(|id|conn.query_row("SELECT id,project_id,work_item_id,session_id,branch_id,event_type,importance,summary,payload_json,project_revision,created_at FROM events WHERE project_id=?1 AND id=?2",params![project.to_string(),id],crate::events::event_row).map_err(db_error)).transpose()
 }

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -171,6 +171,99 @@ without installing hooks; caller-provided summaries remain caller assertions. An
 artifact import copies content, while references in evidence/events keep their own
 documented read and verification rules.
 
+## External clients, checkpoints and continuation
+
+One work may have several AWR sessions and several native client conversations.
+Keep the host's navigation key, the work's AWR ID/key, AWR session ID, native session
+namespace and execution ID separate. Source `owner`, chosen Agent and actual session
+Agent are separate facts. For a client without native hooks, call the generic
+receiver explicitly; no hook installation or client-private history access is needed.
+
+1. Start an AWR session with `session start` and the actual Agent/provider/model,
+   or let `client bind --client generic --external-session <namespaced-native-id>
+   --work <key>` create it. Pass `--session <id>` to bind an already created session.
+   Binding does not claim the work; claim ownership remains an explicit domain action.
+2. `client bind` returns the current context. `context compile --session <id>` can
+   return a separately budgeted context, rendered body, hash and completeness result.
+   Record actual delivery/receipt in the host; a hash alone proves no model received it.
+3. If the host supervises the client, register only an external execution with
+   `execution register --session <id> --key <operation-key> --purpose <purpose>
+   --reference <host-execution-reference>`. AWR never adopts the PID, launches or
+   terminates that client. `execution run` is for commands owned by AWR's supervisor.
+4. Save useful progress with `client progress --client generic --external-session
+   <native-id> --digest <observed-summary> --next-action <next> --open-loop <issue>`.
+   Deliver a lifecycle callback using `client hook --client generic --work <key>`
+   and JSON on stdin: `session_id`, `cwd`, `hook_event_name` and optional `turn_id`.
+   Events are `SessionStart`, `PostCompact`, `PreCompact`, `Stop`, `SessionEnd`,
+   `Interrupt`. Start/PostCompact return context; the others persist a checkpoint.
+   Stable repeated callbacks deduplicate against source state and saved progress.
+   Changed progress/source facts can legitimately produce a new checkpoint even with
+   the same native turn ID. Wait for `awr.checkpoint_saved` before calling a save done.
+5. After reopening the host, use `client show` to recover the binding and
+   `recovery inspect --session <id>` to inspect the last completed checkpoint,
+   pending runtime writes and external/managed execution observations. This does not
+   refresh sources, release claims, create a successor, restart or stop a process.
+   Combine it with `doctor --json` for read-only current-source/artifact diagnostics;
+   preserve nonzero diagnostics. Investigate unfinished writes and unknown effects.
+6. Explicitly continue with `session resume` at the current project revision, or
+   bind a new native conversation with `client bind --from-session <old-id>`.
+   Continuation refreshes sources and compiles new context before work proceeds;
+   stale checkpoints do not authorize replay. Repeating a binding keeps its session.
+   A raw resume that already created a successor must be inspected, not retried as a
+   new continuation. Native resumption remains a separate, client-supported host action.
+
+### Durable external reports
+
+`execution report --input report.json --expected-revision <revision>` records a
+version 1 `ExternalExecutionReport`. For example, a synthetic host might send:
+
+```json
+{
+  "version": 1,
+  "request_key": "guide-execution/stage-2",
+  "execution_id": "<registered AWR execution ULID>",
+  "host_id": "example-host",
+  "host_work_key": "workspace/guide",
+  "native_session": "provider/conversation-id",
+  "agent_id": "guide-author",
+  "origin": "host_observed",
+  "phase": "waiting_user",
+  "observed_at": 1,
+  "summary": "The draft needs the user's choice of examples.",
+  "detail_references": ["host://example/logs/guide"]
+}
+```
+
+Use the actual ULID and observation time (Unix milliseconds). Supported phases are
+`started`, `progress`, `waiting_user`, `succeeded`, `failed`, `interrupted`, `unknown`.
+These are report classifications, not another work/execution state machine. `origin`
+is `caller_reported` or `host_observed`; both are host-supplied provenance assertions.
+Neither is authentication or an AWR-owned observation. Reports reject managed or
+foreign-project executions and cannot overwrite their execution snapshot, create a
+worker, verify business completion or change source work status.
+
+The project-scoped `request_key` is immutable: identical content returns the same
+event (even with the original revision after a lost response); different content
+returns `SourceConflict`. Concurrent identical submissions make one receipt.
+First-time stale revisions still fail. Use `execution report-status --key <key>`
+before retrying a timeout; `found: false` means no retained receipt was found at that
+read, not proof an in-flight writer cannot finish. Report lookup is read-only.
+
+Reports remain recordable after the originating session ends or source parsing fails.
+The file is capped at 1 MiB, identifiers at 512 bytes, summary at 8192 bytes, and
+references at 32 entries of 4096 bytes each. References are retained, never opened,
+copied or authenticated by this operation. Use the host's controlled detail viewer
+for original logs. No token streams, client secrets or fabricated native IDs are needed.
+
+The `execution.external_reported` event binds the work, original session, execution
+and immutable report. Read its history with the existing event cursor and its full
+body with `event show --full`. `execution show`/`inspect` return the latest report
+separately; `recovery inspect` includes latest reports and project runtime findings.
+An external host's reported `succeeded` still leaves AWR's observation `unknown` and
+unverified. Interpret the host report using its actual supporting records before
+retrying or completing work. Generic fixture checks and actual Kimi/Grok receiving
+context are separate acceptance evidence.
+
 ## Compatibility and recovery
 
 The schema declaration describes what this build can open, subject to ownership and


### PR DESCRIPTION
Hosts can now record immutable external execution reports with request-key deduplication and read-only result lookup. Reports bind the originating work/session/execution, native conversation, actual Agent and detail references, while AWR supervisor state and verification remain separate. Recovery inspection exposes the latest external reports and pending runtime findings; the host contract documents generic lifecycle callbacks, current-source diagnostics and explicit continuation.

Validation: 30 targeted CLI checks passed, covering concurrent duplicate delivery, lost-response lookup, generic cross-client handoff, checkpoint deduplication, read-only recovery and managed/external ownership. Three ignored child-process helpers are launched by their owning tests. Public-tree and formatting checks passed. These fixtures do not claim real Kimi/Grok integration.
