### PR TITLE
Expose source change windows with retained failure semantics

### DIFF
--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -39,6 +39,16 @@ fn catalog() -> Vec<Capability> {
             &["may_write_runtime", "partial_failure_requires_retry"],
         ),
         (
+            "source.changes",
+            true,
+            &["source changes"],
+            &[
+                "read_only_event_window",
+                "consumer_owns_success_cursor",
+                "current_failures_are_not_retirements",
+            ],
+        ),
+        (
             "intake.reviewed_draft",
             true,
             &["init", "intake inspect"],

--- a/crates/awr-cli/src/drill.rs
+++ b/crates/awr-cli/src/drill.rs
@@ -412,7 +412,13 @@ pub fn source_show(root: &Path, request: &SourceRead, json_output: bool) -> Resu
             for locator in
                 awr_source::source_adapter(&spec.adapter)?.discover(root, &manifest, spec)?
             {
-                if locator.identity()? == source.locator {
+                let identity = if spec.adapter == "markdown-directory-v1" {
+                    awr_source::MarkdownDirectoryAdapter
+                        .source_identity(root, &manifest, spec, &locator)?
+                } else {
+                    locator.identity()?
+                };
+                if identity == source.locator {
                     authorized = Some(locator);
                     break;
                 }

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -20,6 +20,7 @@ mod resume;
 mod search;
 mod session;
 mod source;
+mod source_changes;
 mod work_action;
 
 #[derive(Debug, Parser)]

--- a/crates/awr-cli/src/source.rs
+++ b/crates/awr-cli/src/source.rs
@@ -12,6 +12,8 @@ use std::{
 
 #[derive(Debug, Subcommand)]
 pub enum SourceCommand {
+    /// Read source lifecycle/change receipts in an immutable event window without refreshing files.
+    Changes(crate::source_changes::ChangesArgs),
     /// Preview or apply an exact replacement source mapping while preserving project identity.
     Configure {
         #[arg(long)]
@@ -520,6 +522,7 @@ pub(crate) fn discover(root: &Path) -> Result<(Option<Manifest>, Vec<Value>, Vec
 
 pub fn run(root: &Path, command: &SourceCommand, json_output: bool) -> Result<()> {
     match command {
+        SourceCommand::Changes(args) => return crate::source_changes::run(root, args, json_output),
         SourceCommand::ConfigureStatus {
             preview_fingerprint,
         } => {
@@ -551,6 +554,7 @@ pub fn run(root: &Path, command: &SourceCommand, json_output: bool) -> Result<()
     let runtime = runtime_dir(&root, false)?;
     match command {
         SourceCommand::Configure { .. }
+        | SourceCommand::Changes(_)
         | SourceCommand::ConfigureStatus { .. }
         | SourceCommand::Show(_)
         | SourceCommand::History { .. } => unreachable!(),

--- a/crates/awr-cli/src/source_changes.rs
+++ b/crates/awr-cli/src/source_changes.rs
@@ -1,0 +1,81 @@
+use awr_core::*;
+use awr_store::{EventCursor, EventQuery};
+use clap::Args;
+use serde_json::json;
+use std::path::Path;
+
+#[derive(Debug, Args)]
+pub struct ChangesArgs {
+    #[arg(long, default_value_t = 0, conflicts_with = "cursor")]
+    after_revision: Revision,
+    #[arg(long)]
+    through_revision: Option<Revision>,
+    /// Existing event next_cursor JSON; repeat the returned through_revision.
+    #[arg(long, requires = "through_revision")]
+    cursor: Option<String>,
+    #[arg(long, default_value_t = 20)]
+    limit: usize,
+}
+
+pub fn run(root: &Path, args: &ChangesArgs, _json_output: bool) -> Result<()> {
+    if !(1..=100).contains(&args.limit) {
+        return Err(Error::InvalidInput(
+            "source change limit must be 1..100".into(),
+        ));
+    }
+    let cursor: Option<EventCursor> = args
+        .cursor
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .map_err(|_| Error::InvalidInput("invalid source event cursor JSON".into()))?;
+    let (store, project) = crate::execution::read_state(root)?;
+    let through = args.through_revision.unwrap_or(project.project_revision);
+    let page = store.query_source_events(
+        project.id,
+        &EventQuery {
+            after_revision: args.after_revision,
+            through_revision: Some(through),
+            cursor,
+            limit: args.limit,
+            ..Default::default()
+        },
+    )?;
+    let mut unsupported = 0;
+    let changes=page.events.iter().map(|event| {
+        let supported=event.payload["change_schema"]==1 && event.payload["changes"].is_array() && event.payload["after"].is_object();
+        if !supported {unsupported+=1;}
+        let before=&event.payload["before"];let after=&event.payload["after"];
+        let count=event.payload["changes"].as_array().map(Vec::len);
+        let content_changed=supported && before["fingerprint"]!=after["fingerprint"] && after["fingerprint"].as_str().is_some_and(|s|!s.is_empty());
+        let membership_changed=matches!(event.event_type.as_str(),"source.registered"|"source.retired");
+        let configuration_changed=event.event_type=="source.configured";
+        let freshness_changed=before["freshness"]!=after["freshness"];
+        json!({"event_id":event.id,"event_type":event.event_type,"project_revision":event.project_revision,"created_at":event.created_at,"source_id":event.payload["source_id"],"change_schema":event.payload["change_schema"],"change_details_available":supported,
+            "before":before,"after":after,"content_changed":if supported {Some(content_changed)}else{None},"membership_changed":membership_changed,"configuration_changed":configuration_changed,"freshness_changed":freshness_changed,
+            "projection_change_count":count,"observation_only":supported && !content_changed && !membership_changed && !configuration_changed && count==Some(0),
+            "changes_included":false,"detail_command":["event","show",&event.id.to_string(),"--full","--max-bytes","16777216"]})
+    }).collect::<Vec<_>>();
+    let pending = store
+        .sources(project.id)?
+        .into_iter()
+        .filter(|s| s.freshness != Freshness::Fresh)
+        .collect::<Vec<_>>();
+    let final_revision = store.project(project.id)?.project_revision;
+    if final_revision != project.project_revision {
+        return Err(Error::RevisionConflict {
+            expected: project.project_revision,
+            actual: final_revision,
+        });
+    }
+    let complete = pending.is_empty() && unsupported == 0;
+    let can_finish = complete && page.next_cursor.is_none();
+    let value = json!({"ok":complete,"project_id":project.id,"project_revision":project.project_revision,"after_revision":args.after_revision,"through_revision":through,"changes":changes,"has_more":page.next_cursor.is_some(),"next_cursor":page.next_cursor,
+        "pending_source_total":pending.len(),"pending_sources":pending.iter().take(50).map(|s|json!({"id":s.id,"domain":s.domain,"locator":s.locator,"revision":s.revision,"freshness":s.freshness})).collect::<Vec<_>>(),"pending_sources_omitted":pending.len().saturating_sub(50),"pending_basis":"current_retained_source_state",
+        "unsupported_event_count":unsupported,"next_after_revision_when_processed":if can_finish {Some(through)} else {None},"consumer_checkpoint_updated":false,"read_only":true,"source_refresh_performed":false,"side_effects_performed":false});
+    println!("{}", serde_json::to_string_pretty(&value)?);
+    if !complete {
+        return Err(Error::SourceStale("source changes include unindexed/unavailable sources or unsupported historical receipts; process the full window and resolve source issues before acknowledging it".into()));
+    }
+    Ok(())
+}

--- a/crates/awr-cli/tests/host_catalog.rs
+++ b/crates/awr-cli/tests/host_catalog.rs
@@ -361,3 +361,46 @@ fn runtime_artifacts_and_source_or_runtime_evidence_share_bounded_reference_cata
     assert!(first["items"][0]["source"].is_null() != second["items"][0]["source"].is_null());
     assert_eq!(p.ok(&["work", "show", "W000"])["work"]["status"], "ready");
 }
+
+#[test]
+fn git_directory_reads_match_registered_ref_identity_and_verify_current_snapshot() {
+    let p = Project::new(1);
+    let git = |args: &[&str]| {
+        let r = Command::new("git")
+            .current_dir(&p.0)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(r.status.success(), "{}", String::from_utf8_lossy(&r.stderr));
+    };
+    git(&["init", "--initial-branch=main"]);
+    git(&["config", "user.name", "AWR Fixture"]);
+    git(&["config", "user.email", "fixture@example.invalid"]);
+    git(&["config", "commit.gpgsign", "false"]);
+    fs::create_dir(p.0.join("decisions")).unwrap();
+    let body = "# D: Keep registered Git sources\n\nStatus: accepted\n\n## Decision\n\nRead the selected revision.\n";
+    p.write("decisions/D.md", body);
+    git(&["add", "decisions/D.md"]);
+    git(&["commit", "-m", "Add fixture decision"]);
+    let manifest = fs::read_to_string(p.0.join(".awr/project.toml")).unwrap();
+    p.write(".awr/project.toml",&format!("{manifest}\n[[sources]]\ndomain='decisions'\nrole='supporting'\nlocator='git://HEAD:decisions'\nadapter='markdown-directory-v1'\n"));
+    let source = p.ok(&["object", "list", "source"])["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["domain"] == "decisions")
+        .unwrap()
+        .clone();
+    assert_eq!(source["locator"], "git://HEAD:decisions/D.md");
+    let id = source["id"].as_str().unwrap();
+    assert_eq!(p.ok(&["source", "show", id, "--content"])["content"], body);
+    let revised = body.replace("selected revision", "revised selection");
+    p.write("decisions/D.md", &revised);
+    git(&["add", "decisions/D.md"]);
+    git(&["commit", "-m", "Revise fixture decision"]);
+    p.error(&["source", "show", id, "--content"], "SourceConflict");
+    p.ok(&["source", "reindex"]);
+    let current = p.ok(&["source", "show", id, "--content"]);
+    assert_eq!(current["content"], revised);
+    assert_eq!(current["source"]["id"], id);
+}

--- a/crates/awr-cli/tests/host_changes.rs
+++ b/crates/awr-cli/tests/host_changes.rs
@@ -1,0 +1,310 @@
+use awr_core::Id;
+use serde_json::Value;
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::PathBuf,
+    process::{Command, Output},
+};
+struct Project(PathBuf);
+impl Project {
+    fn new() -> Self {
+        let p = Self(std::env::temp_dir().join(format!("awr 增量消费 {}", Id::new())));
+        fs::create_dir_all(p.0.join("decisions")).unwrap();
+        p.write("work.yaml","goals:\n- id: G\n  title: Keep a useful guide\n  status: active\n  success_criteria: [A useful guide]\nwork_items:\n- id: W\n  title: Draft guide\n  status: ready\n  goal: G\n  acceptance: [A useful guide]\n  next_action: Write the outline\n");
+        for key in ["D1", "D2"] {
+            p.decision(key, "Keep the original format.");
+        }
+        p.write("mapping.toml","[project]\nname='Changes'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n[[sources]]\ndomain='decisions'\nrole='supporting'\npath='decisions'\nadapter='markdown-directory-v1'\n");
+        p.ok(&["init", "--manifest", "mapping.toml", "--accept"]);
+        p
+    }
+    fn write(&self, path: &str, body: &str) {
+        fs::write(self.0.join(path), body).unwrap();
+    }
+    fn decision(&self, key: &str, body: &str) {
+        self.write(
+            &format!("decisions/{key}.md"),
+            &format!(
+                "# {key}: Guide format\n\nID: {key}\nStatus: accepted\n\n## Decision\n\n{body}\n"
+            ),
+        );
+    }
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_awr"))
+            .args(["--project", self.0.to_str().unwrap(), "--json"])
+            .args(args)
+            .output()
+            .unwrap()
+    }
+    fn ok(&self, args: &[&str]) -> Value {
+        let r = self.run(args);
+        assert!(
+            r.status.success(),
+            "{args:?}\n{}\n{}",
+            String::from_utf8_lossy(&r.stdout),
+            String::from_utf8_lossy(&r.stderr)
+        );
+        serde_json::from_slice(&r.stdout).unwrap()
+    }
+    fn failed(&self, args: &[&str]) -> Value {
+        let r = self.run(args);
+        assert!(!r.status.success(), "{args:?}");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&r.stderr).unwrap()["code"],
+            "SourceStale"
+        );
+        serde_json::from_slice(&r.stdout).unwrap()
+    }
+    fn revision(&self) -> String {
+        self.ok(&["source", "list"])["project_revision"].to_string()
+    }
+    fn events(&self, after: &str, through: &str) -> Vec<Value> {
+        let mut page = self.ok(&[
+            "source",
+            "changes",
+            "--after-revision",
+            after,
+            "--through-revision",
+            through,
+            "--limit",
+            "1",
+        ]);
+        let mut events = vec![];
+        let mut ids = BTreeSet::new();
+        loop {
+            for event in page["changes"].as_array().unwrap() {
+                assert!(ids.insert(event["event_id"].to_string()));
+                events.push(event.clone());
+            }
+            assert_eq!(page["read_only"], true);
+            assert_eq!(page["consumer_checkpoint_updated"], false);
+            if !page["has_more"].as_bool().unwrap() {
+                assert_eq!(
+                    page["next_after_revision_when_processed"].to_string(),
+                    through
+                );
+                break;
+            }
+            assert!(page["next_after_revision_when_processed"].is_null());
+            page = self.ok(&[
+                "source",
+                "changes",
+                "--cursor",
+                &page["next_cursor"].to_string(),
+                "--through-revision",
+                through,
+                "--limit",
+                "1",
+            ]);
+        }
+        events
+    }
+}
+impl Drop for Project {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn no_change_refreshes_have_empty_event_windows_and_one_document_reports_only_its_facts() {
+    let p = Project::new();
+    let baseline = p.revision();
+    for command in ["scan", "reindex", "reindex"] {
+        let result = p.ok(&["source", command]);
+        assert_eq!(result["project_revision"].to_string(), baseline);
+        assert_eq!(
+            result["change_window"]["after_revision"],
+            result["change_window"]["through_revision"]
+        );
+        assert_eq!(result["projection_complete"], true);
+    }
+    assert!(p.events(&baseline, &baseline).is_empty());
+    let before = p.ok(&["decision", "show", "D1", "--full"]);
+    p.decision("D1", "Use revised examples in the same guide.");
+    let changed = p.ok(&["source", "reindex"]);
+    assert_eq!(changed["indexed"], 1);
+    assert_eq!(changed["retired"], 0);
+    let through = changed["change_window"]["through_revision"].to_string();
+    // A later runtime event must not leak into the immutable source window or force a new page.
+    p.ok(&[
+        "event",
+        "append",
+        "--type",
+        "host.note",
+        "--summary",
+        "Host observed the index operation",
+        "--expected-revision",
+        &through,
+    ]);
+    let after = p.revision();
+    let events = p.events(&baseline, &through);
+    assert_eq!(p.revision(), after);
+    assert!(!events.is_empty());
+    assert!(
+        events
+            .iter()
+            .all(|e| e["source_id"] == before["source_ref"]["source_id"])
+    );
+    let projected = events
+        .iter()
+        .find(|e| e["event_type"] == "source.projected")
+        .unwrap();
+    assert_eq!(projected["content_changed"], true);
+    assert_eq!(projected["projection_change_count"], 1);
+    assert_eq!(projected["changes_included"], false);
+    let full = p.ok(&[
+        "event",
+        "show",
+        projected["event_id"].as_str().unwrap(),
+        "--full",
+    ]);
+    assert_eq!(full["event"]["payload"]["changes"][0]["action"], "updated");
+    assert_eq!(
+        full["event"]["payload"]["changes"][0]["id"],
+        before["decision"]["id"]
+    );
+    let latest = p.ok(&["decision", "show", "D1", "--full"]);
+    assert_eq!(latest["decision"]["id"], before["decision"]["id"]);
+    assert!(p.events(&through, &after).is_empty());
+}
+
+#[test]
+fn failed_refresh_retains_pending_sources_and_restarting_from_old_success_does_not_skip_changes() {
+    let p = Project::new();
+    let baseline = p.revision();
+    p.decision("D1", "Updated valid decision.");
+    p.write(
+        "decisions/D2.md",
+        "---\nstatus: [broken\n---\n# Broken metadata\n",
+    );
+    let result = p.failed(&["source", "reindex"]);
+    assert_eq!(result["indexed"], 1);
+    assert_eq!(result["retired"], 0);
+    assert_eq!(result["projection_complete"], false);
+    assert!(!result["issues"].as_array().unwrap().is_empty());
+    let feed = p.failed(&["source", "changes", "--after-revision", &baseline]);
+    assert_eq!(feed["pending_source_total"], 1);
+    assert!(feed["next_after_revision_when_processed"].is_null());
+    assert!(
+        feed["changes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e["content_changed"] == true)
+    );
+    let before_retry = p.revision();
+    p.failed(&["source", "reindex"]);
+    assert_eq!(p.revision(), before_retry);
+    let retry = p.failed(&["source", "changes", "--after-revision", &baseline]);
+    assert_eq!(retry["changes"], feed["changes"]);
+    p.decision("D2", "Fixed metadata and changed the decision.");
+    p.ok(&["source", "reindex"]);
+    let through = p.revision();
+    let events = p.events(&baseline, &through);
+    let changed = events
+        .iter()
+        .filter(|e| e["event_type"] == "source.projected" && e["content_changed"] == true)
+        .map(|e| e["source_id"].to_string())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(changed.len(), 2);
+    let cursor = p.ok(&[
+        "source",
+        "changes",
+        "--after-revision",
+        &baseline,
+        "--limit",
+        "1",
+    ])["next_cursor"]
+        .to_string();
+    let other = Project::new();
+    let r = other.run(&[
+        "source",
+        "changes",
+        "--cursor",
+        &cursor,
+        "--through-revision",
+        &other.revision(),
+    ]);
+    assert!(!r.status.success());
+}
+
+#[test]
+fn deleted_children_retire_but_unavailable_directories_do_not_and_history_survives() {
+    let p = Project::new();
+    let baseline = p.revision();
+    let original = p.ok(&["decision", "show", "D1", "--full"]);
+    let source = original["source_ref"]["source_id"].as_str().unwrap();
+    fs::rename(p.0.join("decisions"), p.0.join("temporarily-offline")).unwrap();
+    let unavailable = p.failed(&["source", "reindex"]);
+    assert_eq!(unavailable["retired"], 0);
+    let failed = p.failed(&["source", "changes", "--after-revision", &baseline]);
+    assert_eq!(failed["pending_source_total"], 2);
+    assert!(
+        failed["changes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|e| e["event_type"] != "source.retired")
+    );
+    fs::rename(p.0.join("temporarily-offline"), p.0.join("decisions")).unwrap();
+    p.ok(&["source", "reindex"]);
+    assert_eq!(
+        p.ok(&["decision", "show", "D1", "--full"])["decision"]["id"],
+        original["decision"]["id"]
+    );
+    let before_delete = p.revision();
+    fs::remove_file(p.0.join("decisions/D1.md")).unwrap();
+    let removed = p.ok(&["source", "reindex"]);
+    assert_eq!(removed["retired"], 1);
+    let events = p.events(&before_delete, &p.revision());
+    let retired = events
+        .iter()
+        .find(|e| e["event_type"] == "source.retired")
+        .unwrap();
+    assert_eq!(retired["source_id"], source);
+    assert_eq!(retired["after"]["active"], false);
+    assert_eq!(p.ok(&["source", "show", source])["active"], false);
+    assert!(
+        !p.ok(&["source", "history", source])["events"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    p.decision("D1", "Keep the original format.");
+    p.ok(&["source", "reindex"]);
+    assert_eq!(
+        p.ok(&["decision", "show", "D1", "--full"])["decision"]["id"],
+        original["decision"]["id"]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn unreadable_file_is_a_failure_not_a_retirement() {
+    use std::os::unix::fs::PermissionsExt;
+    let p = Project::new();
+    let path = p.0.join("decisions/D1.md");
+    let permissions = fs::metadata(&path).unwrap().permissions();
+    let baseline = p.revision();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0)).unwrap();
+    // Privileged runners can still read chmod(0); only assert actual access denial where enforced.
+    if fs::read(&path).is_ok() {
+        fs::set_permissions(&path, permissions).unwrap();
+        return;
+    }
+    let result = p.failed(&["source", "reindex"]);
+    fs::set_permissions(&path, permissions).unwrap();
+    assert_eq!(result["retired"], 0);
+    let feed = p.failed(&["source", "changes", "--after-revision", &baseline]);
+    assert_eq!(feed["pending_source_total"], 1);
+    assert!(
+        feed["changes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|e| e["event_type"] != "source.retired")
+    );
+    p.ok(&["source", "reindex"]);
+}

--- a/crates/awr-source/src/indexer.rs
+++ b/crates/awr-source/src/indexer.rs
@@ -32,12 +32,20 @@ pub struct IndexReport {
     pub ok: bool,
     pub project_id: Id,
     pub project_revision: Revision,
+    /// Exact event interval observed by this operation; consumers acknowledge only after processing.
+    pub change_window: SourceChangeWindow,
+    pub projection_complete: bool,
     pub indexed: usize,
     pub unchanged: usize,
     pub retired: usize,
     pub pending: usize,
     pub sources: Vec<IndexedSource>,
     pub issues: Vec<IndexIssue>,
+}
+#[derive(Debug, Clone, Serialize)]
+pub struct SourceChangeWindow {
+    pub after_revision: Revision,
+    pub through_revision: Revision,
 }
 impl IndexReport {
     fn issue(&mut self, mapping: &str, locator: Option<&str>, error: &Error) {
@@ -131,6 +139,11 @@ fn process_project(
         ok: true,
         project_id: project.id,
         project_revision: project.project_revision,
+        change_window: SourceChangeWindow {
+            after_revision: project.project_revision,
+            through_revision: project.project_revision,
+        },
+        projection_complete: false,
         indexed: 0,
         unchanged: 0,
         retired: 0,
@@ -266,6 +279,8 @@ fn process_project(
         }
     }
     report.project_revision = store.project(project.id)?.project_revision;
+    report.change_window.through_revision = report.project_revision;
+    report.projection_complete = report.ok && report.pending == 0;
     Ok(report)
 }
 

--- a/crates/awr-store/src/events.rs
+++ b/crates/awr-store/src/events.rs
@@ -194,6 +194,18 @@ impl Store {
         self.conn.query_row("SELECT id,project_id,work_item_id,session_id,branch_id,event_type,importance,summary,payload_json,project_revision,created_at FROM events WHERE project_id=?1 AND id=?2",params![project.to_string(),id.to_string()],event_row).optional().map_err(db_error)?.ok_or_else(||Error::NotFound(format!("event {id}")))
     }
     pub fn query_events(&self, project: Id, query: &EventQuery) -> Result<EventPage> {
+        self.query_events_filtered(project, query, false)
+    }
+    /// Reuse event ordering, cursor validation and immutable upper bounds for source consumers.
+    pub fn query_source_events(&self, project: Id, query: &EventQuery) -> Result<EventPage> {
+        self.query_events_filtered(project, query, true)
+    }
+    fn query_events_filtered(
+        &self,
+        project: Id,
+        query: &EventQuery,
+        sources_only: bool,
+    ) -> Result<EventPage> {
         if query.limit == 0 || query.limit > 1000 {
             return Err(Error::InvalidInput("event limit must be 1..1000".into()));
         }
@@ -273,8 +285,9 @@ impl Store {
               AND project_revision>?8 AND (?9 IS NULL OR (project_revision,created_at,id)>(?9,?10,?11))
               AND (?13 IS NULL OR (event_type LIKE 'source.%' AND json_extract(payload_json,'$.source_id')=?13))
               AND (?14 IS NULL OR project_revision<=?14)
+              AND (NOT ?15 OR event_type LIKE 'source.%')
             ORDER BY project_revision,created_at,id LIMIT ?12").map_err(db_error)?
-            .query_map(params![project.to_string(),query.work_item_id.map(|id|id.to_string()),query.session_id.map(|id|id.to_string()),all_branches,branch.map(|id|id.to_string()),query.event_type,query.importance,sqlite_revision(query.after_revision)?,query.cursor.as_ref().map(|c|sqlite_revision(c.project_revision)).transpose()?,query.cursor.as_ref().map(|c|c.created_at),query.cursor.as_ref().map(|c|c.event_id.to_string()),(query.limit+1) as i64,query.source_id.map(|id|id.to_string()),query.through_revision.map(sqlite_revision).transpose()?],event_row).map_err(db_error)?.collect::<rusqlite::Result<Vec<_>>>().map_err(db_error)?;
+            .query_map(params![project.to_string(),query.work_item_id.map(|id|id.to_string()),query.session_id.map(|id|id.to_string()),all_branches,branch.map(|id|id.to_string()),query.event_type,query.importance,sqlite_revision(query.after_revision)?,query.cursor.as_ref().map(|c|sqlite_revision(c.project_revision)).transpose()?,query.cursor.as_ref().map(|c|c.created_at),query.cursor.as_ref().map(|c|c.event_id.to_string()),(query.limit+1) as i64,query.source_id.map(|id|id.to_string()),query.through_revision.map(sqlite_revision).transpose()?,sources_only],event_row).map_err(db_error)?.collect::<rusqlite::Result<Vec<_>>>().map_err(db_error)?;
         let more = events.len() > query.limit;
         events.truncate(query.limit);
         let next_cursor = if more {

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -171,6 +171,59 @@ without installing hooks; caller-provided summaries remain caller assertions. An
 artifact import copies content, while references in evidence/events keep their own
 documented read and verification rules.
 
+## Consume changes without losing failures
+
+`source scan` observes current registrations and availability; it does not parse
+pending content. `source reindex` refreshes projections. Both return a `change_window`
+with `after_revision` and `through_revision`, plus `projection_complete` (false for
+pending or failed sources). A fully unchanged refresh creates no new source event or
+work identity. Keep stdout, stderr and exit code for partial failures.
+
+Read immutable source receipts, including changes missed before a host restart:
+
+```text
+awr source changes --after-revision <last-successfully-processed-revision> --json
+awr source changes --cursor '<next_cursor JSON>' --through-revision <returned-bound> --json
+```
+
+This command is read-only and reuses the existing event cursor/order. Pages contain
+at most 100 source events (default 20); runtime events do not consume that limit.
+Hold `through_revision` fixed while paging. Each receipt exposes the source's before
+and after versions/freshness, content/configuration/membership changes and an exact
+projection change count. `observation_only` is true when the event changes neither
+content, configuration, membership nor objects; a freshness observation may still
+mean the source needs reindexing. Scanning is not a knowledge-processing result.
+
+Object change details stay in their original `source.projected`/retirement event.
+Use the returned `detail_command` to read its bounded payload, including stable IDs,
+added/updated/removed actions and before/after object revisions. A summary never
+stands in for omitted details. Unknown historical change schemas return an explicit
+partial result requiring a full refresh/rebaseline; they are not guessed compatible.
+
+`pending_source_total` and bounded `pending_sources` describe the **current retained
+index state**, independently of the historical event window. A nonzero `SourceStale`
+result retains useful stdout and withholds `next_after_revision_when_processed`.
+An unreadable or malformed source stays stale/unavailable; repeated failure can have
+no new event while the pending source remains visible. Retry the failed refresh and
+resume from the last successfully processed window. `source list` exposes all retained
+active source metadata if more than 50 pending summaries were omitted. Reads alone do
+not check whether previously fresh files changed since the last scan/index.
+
+Successful directory discovery can prove a child is no longer selected, and removing
+a manifest mapping explicitly retires its source. Failure to read a file/directory,
+parse it or access an authorized root does not prove retirement. The `issues` from
+scan/reindex preserve typed failures and affected mappings. `retired` means no longer
+selected as current authority; it is not a claim that a physical file was deleted.
+Events, evidence and completed checkpoints remain in runtime history. Reappearance
+under the same source identity/explicit object key keeps its retained IDs. File moves
+or changed source identities do not authorize guessing a rename or rewriting history.
+
+When all pages, object changes and pending sources have been handled successfully,
+the host may persist `next_after_revision_when_processed` as its own success cursor.
+`consumer_checkpoint_updated` is always false: AWR never acknowledges knowledge
+weaving or application processing on the host's behalf. A returned revision or an
+empty change page alone is not proof that downstream work finished.
+
 ## External clients, checkpoints and continuation
 
 One work may have several AWR sessions and several native client conversations.


### PR DESCRIPTION
Hosts can now consume source changes through bounded, read-only event windows. Scan/reindex return the matching revision interval and projection completeness; the change feed distinguishes content and object changes from observations, retains failed sources as pending, and leaves downstream success-cursor acknowledgement to the consumer. Registered Git-directory content reads now compare the configured ref identity before checking the pinned snapshot.

Validation: 28 targeted CLI/source checks passed, covering unchanged refreshes, complete pagination, partial parse failures, unavailable files/directories, retirement/reappearance, history retention and Git-ref reads. Public-tree and formatting checks passed.
