### PR TITLE
Preserve unrelated YAML bytes during field updates

### DIFF
--- a/adapters/yaml-ledger/README.md
+++ b/adapters/yaml-ledger/README.md
@@ -46,7 +46,24 @@ Use `awr proposal create`, `submit`, `approve`, then `apply` as described in the
 | Work | `title`, `kind`, `priority`, `required` / `required_for_v1`, `summary`, `next_action`, `score`, `tags`, `paths` / `deliverables`, `acceptance`, `milestone`, `depends_on` / `dependencies`, `goal` / `goals` |
 | Structured source evidence | `summary` only; evidence identity, provenance and verification level are preserved |
 
-The writer supports ordinary list and keyed-map records, including flow mappings, Unicode and CRLF files. It serializes the selected mapping as JSON flow syntax, which is valid YAML. Whitespace, comments and scalar formatting inside that record can change; bytes outside the record remain unchanged. Standalone trailing comments remain outside the replacement. The complete resulting document must have exactly the proposed semantic changes and must reparse through the same projection adapter before any write is attempted.
+The writer supports ordinary list and keyed-map records, including flow mappings,
+Unicode and CRLF files. It locates the changed fields using parser events and changes
+only their value spans; new fields are appended without reordering existing keys.
+Unchanged fields, inline/standalone comments, and surrounding bytes retain their exact
+representation. Plain, single-quoted, double-quoted, literal and folded scalars are
+supported. Quotes and block style remain when representable; plain strings that would
+become another YAML type are quoted, and block chomping follows the new trailing breaks.
+Existing indentation and LF/CRLF are retained. Collection replacement is one field edit;
+comment-bearing collections are conservatively rejected instead of losing comments.
+Multiline plain target scalars, unusual single-quoted whitespace/line breaks and block
+headers separated from their key by a comment require explicit manual editing.
+Unrelated multiline plain scalars retain their original bytes.
+
+Anchors, aliases, tags, merge/duplicate/complex keys and multiple documents are rejected
+for automatic field writes. These forms may remain readable. The complete resulting
+document must have exactly the proposed semantic changes and reparse through the same
+projection adapter before any write is attempted. There is no whole-record serialization
+fallback when field-level preservation cannot be proved.
 
 Git sources, scalar evidence, aliased targets, anchored/tagged target nodes, complex mapping keys and unsupported fields return `proposal_required`. Generic work field updates cannot change status, owner, blocker, verification or evidence lists. Validated `work progress/block/unblock/cancel/reopen` proposals can change their exact authorized status/blocker/next-action fields (and progress summary); the immutable transition and current runtime/domain conditions are checked before writing. `work complete` additionally binds every acceptance criterion to current registered evidence and checks the actual version 1 report files. It preserves existing evidence references and arbitrary verification metadata, appends selected report locators, and sets `verification.evidence_level` to the minimum supported level across selected records. If a top-level `evidence_level` already exists, both aliases are updated consistently. A manually constructed completion patch must match these preserving changes exactly; source-reference namespace collisions fail before writing. The completed projection is verified before recording `work.completed` and releasing the creating session's claim. See the [completion input and report contract](../../README.md) for report fields and limits. Invalid values and no-op patches fail explicitly. Project runtime files under `.awr` cannot be mutation targets. Source and recovery snapshots are capped at 16 MiB.
 

--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -179,16 +179,20 @@ fn catalog() -> Vec<Capability> {
             &["proposal create", "proposal apply"],
             &[
                 "supported_fields_only",
-                "target_record_reserialized",
+                "field_spans_preserve_unrelated_bytes",
                 "state_requires_domain_action",
                 "single_file",
             ],
         ),
         (
             "mutation.yaml.lossless_fields",
-            false,
-            &[],
-            &["not_implemented"],
+            true,
+            &["proposal apply"],
+            &[
+                "supported_yaml_shapes_only",
+                "scalar_style_when_representable",
+                "domain_actions_still_required",
+            ],
         ),
         ("mutation.work.create", false, &[], &["not_implemented"]),
         ("mutation.markdown", false, &[], &["not_implemented"]),
@@ -270,8 +274,8 @@ pub fn run(args: &CapabilitiesArgs, json_output: bool) -> Result<()> {
             "schema_validation_required": true},
         "source_adapters": awr_source::SOURCE_ADAPTERS.iter().map(|id| json!({
             "id": id, "read": true,
-            "write_mode": if *id == "yaml-ledger-v1" { "supported_record_reserialization" } else { "read_only" },
-            "lossless_field_write": false
+            "write_mode": if *id == "yaml-ledger-v1" { "lossless_supported_fields" } else { "read_only" },
+            "lossless_field_write": *id == "yaml-ledger-v1"
         })).collect::<Vec<_>>(),
         "capabilities": capabilities,
         "source_write_performed": false,

--- a/crates/awr-cli/tests/host_capabilities.rs
+++ b/crates/awr-cli/tests/host_capabilities.rs
@@ -69,7 +69,7 @@ fn callers_can_distinguish_unknown_from_known_unavailable_without_parsing_messag
         "capabilities",
         "--json",
         "--require",
-        "mutation.yaml.lossless_fields",
+        "mutation.multi_file",
         "--require",
         "fictional.capability",
         "--require",
@@ -87,7 +87,7 @@ fn callers_can_distinguish_unknown_from_known_unavailable_without_parsing_messag
     );
     assert_eq!(
         error["details"]["unsupported"],
-        serde_json::json!(["mutation.yaml.lossless_fields"])
+        serde_json::json!(["mutation.multi_file"])
     );
     assert_eq!(error["details"]["runtime_write_performed"], false);
     assert_eq!(fs::read_dir(&host.0).unwrap().count(), 0);
@@ -118,15 +118,18 @@ fn unsupported_protocol_and_invalid_usage_keep_distinct_error_codes() {
 }
 
 #[test]
-fn source_read_support_does_not_advertise_lossless_or_markdown_writes() {
+fn yaml_lossless_support_does_not_imply_markdown_or_human_writes() {
     let host = Host::new();
     let result = host.ok(&["--json", "capabilities"]);
     let adapters = result["source_adapters"].as_array().unwrap();
     for adapter in adapters {
         assert_eq!(adapter["read"], true);
-        assert_eq!(adapter["lossless_field_write"], false);
+        assert_eq!(
+            adapter["lossless_field_write"],
+            adapter["id"] == "yaml-ledger-v1"
+        );
         if adapter["id"] == "yaml-ledger-v1" {
-            assert_eq!(adapter["write_mode"], "supported_record_reserialization");
+            assert_eq!(adapter["write_mode"], "lossless_supported_fields");
         } else {
             assert_eq!(adapter["write_mode"], "read_only");
         }

--- a/crates/awr-source/src/lib.rs
+++ b/crates/awr-source/src/lib.rs
@@ -10,6 +10,7 @@ mod manifest;
 mod markdown;
 mod markdown_ledger;
 mod mutation;
+mod yaml_edit;
 mod yaml_ledger;
 mod yaml_mutation;
 

--- a/crates/awr-source/src/yaml_edit.rs
+++ b/crates/awr-source/src/yaml_edit.rs
@@ -1,0 +1,530 @@
+//! Field-level YAML edits. Parser events locate structure; original bytes remain authoritative.
+use awr_core::{Error, Result};
+use serde_json::{Map, Value};
+use std::{collections::BTreeSet, ops::Range};
+use yaml_rust2::{
+    parser::{Event, Parser},
+    scanner::TScalarStyle,
+};
+
+fn unsupported(message: &str) -> Error {
+    Error::MutationUnsupported(message.into())
+}
+
+struct Node {
+    range: Range<usize>,
+    kind: Kind,
+}
+enum Kind {
+    Scalar(TScalarStyle, String),
+    Mapping(Vec<(String, Node)>, bool, usize), // fields, flow, field indentation
+    Sequence(Vec<Node>),
+}
+struct Reader<'a> {
+    text: &'a str,
+    parser: Parser<std::str::Chars<'a>>,
+    offsets: Vec<usize>,
+}
+impl<'a> Reader<'a> {
+    fn token(&mut self) -> Result<(Event, usize)> {
+        let (event, marker) = self
+            .parser
+            .next_token()
+            .map_err(|e| Error::InvalidInput(format!("YAML mutation syntax: {e}")))?;
+        let byte = *self
+            .offsets
+            .get(marker.index())
+            .ok_or_else(|| unsupported("YAML marker outside source"))?;
+        Ok((event, byte))
+    }
+
+    fn node(
+        &mut self,
+        first: (Event, usize),
+        parent_indent: usize,
+        depth: usize,
+        in_flow: bool,
+    ) -> Result<Node> {
+        if depth > 128 {
+            return Err(unsupported("YAML mutation nesting exceeds 128 levels"));
+        }
+        let (event, mut start) = first;
+        let (end, kind) = match event {
+            Event::MappingStart(anchor, tag) => {
+                reject_properties(anchor, tag.is_some())?;
+                let flow = self.text[start..].starts_with('{');
+                let mut fields = Vec::new();
+                let mut keys = BTreeSet::new();
+                let mut indent = parent_indent;
+                let marker_end = loop {
+                    let (key, key_start) = self.token()?;
+                    if key == Event::MappingEnd {
+                        break key_start;
+                    }
+                    let Event::Scalar(key, style, anchor, tag) = key else {
+                        return Err(unsupported("complex mapping keys require manual editing"));
+                    };
+                    reject_properties(anchor, tag.is_some())?;
+                    if key == "<<" || !keys.insert(key.clone()) {
+                        return Err(unsupported(
+                            "merge or duplicate mapping keys require manual editing",
+                        ));
+                    }
+                    if fields.is_empty() {
+                        indent = column(self.text, key_start);
+                        if !flow {
+                            start = key_start;
+                        }
+                    }
+                    let mut value = self.token()?;
+                    let key_end = scalar_end(self.text, key_start, style, true, flow, indent)?;
+                    let colon = self.text[key_end..]
+                        .find(':')
+                        .map(|n| key_end + n)
+                        .ok_or_else(|| unsupported("missing YAML mapping colon"))?;
+                    if matches!(
+                        value.0,
+                        Event::Scalar(_, TScalarStyle::Literal | TScalarStyle::Folded, _, _)
+                    ) {
+                        // yaml-rust2 locates nonempty block scalars at their first content
+                        // character. Recover the header from this field's lexical colon.
+                        let header = colon + 1 + self.text[colon + 1..].len()
+                            - self.text[colon + 1..].trim_start().len();
+                        if !self.text[header..].starts_with(['|', '>']) {
+                            return Err(unsupported(
+                                "block scalar header separated by a comment requires manual editing",
+                            ));
+                        }
+                        value.1 = header;
+                    }
+                    // An implicit null has no token bytes. Its parser marker can belong to the
+                    // next key, so recover the insertion point from this key's colon instead.
+                    let mut child = if matches!(&value.0, Event::Scalar(s, TScalarStyle::Plain, 0, None) if s.is_empty())
+                    {
+                        Node {
+                            range: colon + 1..colon + 1,
+                            kind: Kind::Scalar(TScalarStyle::Plain, String::new()),
+                        }
+                    } else {
+                        self.node(value, column(self.text, key_start), depth + 1, flow)?
+                    };
+                    if matches!(&child.kind, Kind::Mapping(_, false, _) | Kind::Sequence(_))
+                        && !self.text[child.range.start..].starts_with(['[', '{'])
+                    {
+                        child.range.start = colon + 1;
+                    }
+                    fields.push((key, child));
+                };
+                let end = if flow {
+                    close(self.text, marker_end, '}')?
+                } else {
+                    fields.last().map_or(start, |(_, n)| n.range.end)
+                };
+                (end, Kind::Mapping(fields, flow, indent))
+            }
+            Event::SequenceStart(anchor, tag) => {
+                reject_properties(anchor, tag.is_some())?;
+                let flow = self.text[start..].starts_with('[');
+                let mut children = Vec::new();
+                let marker_end = loop {
+                    let child = self.token()?;
+                    if child.0 == Event::SequenceEnd {
+                        break child.1;
+                    }
+                    children.push(self.node(child, parent_indent, depth + 1, flow)?);
+                };
+                let end = if flow {
+                    close(self.text, marker_end, ']')?
+                } else {
+                    children.last().map_or(start, |n| n.range.end)
+                };
+                (end, Kind::Sequence(children))
+            }
+            Event::Scalar(value, style, anchor, tag) => {
+                reject_properties(anchor, tag.is_some())?;
+                let end = scalar_end(self.text, start, style, false, in_flow, parent_indent)?;
+                (end, Kind::Scalar(style, value))
+            }
+            Event::Alias(_) => return Err(unsupported("YAML aliases require manual editing")),
+            _ => return Err(unsupported("unexpected YAML node boundary")),
+        };
+        Ok(Node {
+            range: start..end,
+            kind,
+        })
+    }
+}
+fn reject_properties(anchor: usize, tagged: bool) -> Result<()> {
+    if anchor != 0 || tagged {
+        Err(unsupported(
+            "anchored or tagged YAML requires manual editing",
+        ))
+    } else {
+        Ok(())
+    }
+}
+fn close(text: &str, end: usize, expected: char) -> Result<usize> {
+    if text[end..].starts_with(expected) {
+        Ok(end + 1)
+    } else {
+        Err(unsupported("could not bound a YAML flow collection"))
+    }
+}
+fn column(text: &str, start: usize) -> usize {
+    let line = text[..start].rfind('\n').map_or(0, |n| n + 1);
+    text[line..start].chars().count()
+}
+fn line_end(text: &str, start: usize) -> usize {
+    text[start..]
+        .find('\n')
+        .map_or(text.len(), |n| start + n + 1)
+}
+fn scalar_end(
+    text: &str,
+    start: usize,
+    style: TScalarStyle,
+    key: bool,
+    flow: bool,
+    indent: usize,
+) -> Result<usize> {
+    let bytes = text.as_bytes();
+    match style {
+        TScalarStyle::SingleQuoted | TScalarStyle::DoubleQuoted => {
+            let quote = if style == TScalarStyle::SingleQuoted {
+                b'\''
+            } else {
+                b'"'
+            };
+            if bytes.get(start) != Some(&quote) {
+                return Err(unsupported("quoted scalar marker mismatch"));
+            }
+            let mut pos = start + 1;
+            while pos < bytes.len() {
+                if quote == b'"' && bytes[pos] == b'\\' {
+                    pos += 2;
+                    continue;
+                }
+                if bytes[pos] == quote {
+                    if quote == b'\'' && bytes.get(pos + 1) == Some(&quote) {
+                        pos += 2;
+                        continue;
+                    }
+                    return Ok(pos + 1);
+                }
+                pos += 1;
+            }
+            Err(unsupported("unclosed quoted scalar"))
+        }
+        TScalarStyle::Literal | TScalarStyle::Folded => {
+            let mut end = line_end(text, start);
+            while end < text.len() {
+                let next = line_end(text, end);
+                let line = &text[end..next];
+                let spaces = line.bytes().take_while(|b| *b == b' ').count();
+                if !line.trim().is_empty() && spaces <= indent {
+                    break;
+                }
+                end = next;
+            }
+            Ok(end)
+        }
+        TScalarStyle::Plain => {
+            let mut end = start;
+            while end < bytes.len() {
+                let b = bytes[end];
+                if b == b'\n'
+                    || b == b'\r'
+                    || (b == b'#' && (end == start || bytes[end - 1].is_ascii_whitespace()))
+                    || (b == b':'
+                        && (key
+                            || bytes
+                                .get(end + 1)
+                                .is_none_or(|b| b.is_ascii_whitespace() || b",]}".contains(b))))
+                    || (flow && b",]}".contains(&b))
+                {
+                    break;
+                }
+                end += 1;
+            }
+            end = start + text[start..end].trim_end().len();
+            if !key && !flow {
+                let mut line = line_end(text, end);
+                while line < text.len() {
+                    let next = line_end(text, line);
+                    let content = &text[line..next];
+                    if !content.trim().is_empty() && !content.trim_start().starts_with('#') {
+                        let spaces = content.bytes().take_while(|b| *b == b' ').count();
+                        if spaces <= indent {
+                            break;
+                        }
+                        end = line + content.trim_end().len();
+                    }
+                    line = next;
+                }
+            }
+            Ok(end)
+        }
+    }
+}
+fn json(value: &Value) -> Result<String> {
+    Ok(serde_json::to_string(value)?
+        .replace('\u{85}', "\\u0085")
+        .replace('\u{2028}', "\\u2028")
+        .replace('\u{2029}', "\\u2029"))
+}
+
+fn render(text: &str, node: &Node, value: &Value, newline: &str) -> Result<String> {
+    let original = &text[node.range.clone()];
+    let Kind::Scalar(style, old_value) = &node.kind else {
+        // Collection values are one edited field. Do not silently discard its comments.
+        // A conservative '#' rejection also catches quoted hashes; callers can edit children.
+        if text[node.range.start..line_end(text, node.range.end)].contains('#') {
+            return Err(unsupported(
+                "collection replacement would lose comments; edit individual fields",
+            ));
+        }
+        let prefix = if original.starts_with(char::is_whitespace) {
+            " "
+        } else {
+            ""
+        };
+        return Ok(format!("{prefix}{}", json(value)?));
+    };
+    if *style == TScalarStyle::Plain && !node.range.is_empty() && original.trim() != old_value {
+        return Err(unsupported(
+            "multiline plain scalars require an explicit block or quoted style before editing",
+        ));
+    }
+    let Some(string) = value.as_str() else {
+        return json(value);
+    };
+    match *style {
+        TScalarStyle::SingleQuoted
+            if !string.contains(['\n', '\r', '\u{85}', '\u{2028}', '\u{2029}']) =>
+        {
+            Ok(format!("'{}'", string.replace('\'', "''")))
+        }
+        TScalarStyle::SingleQuoted => {
+            if string.contains(['\r', '\u{85}', '\u{2028}', '\u{2029}'])
+                || string.lines().any(|l| l.trim() != l)
+            {
+                return Err(unsupported(
+                    "single-quoted multiline replacement cannot preserve edge whitespace or special line breaks",
+                ));
+            }
+            let indent = " ".repeat(column(text, node.range.start) + 2);
+            let mut body = String::new();
+            let mut chars = string.chars().peekable();
+            while let Some(c) = chars.next() {
+                if c == '\n' {
+                    body.push_str(newline);
+                    body.push_str(newline);
+                    body.push_str(&indent);
+                    while chars.peek() == Some(&'\n') {
+                        chars.next();
+                        body.push_str(newline);
+                        body.push_str(&indent);
+                    }
+                } else {
+                    body.push(c);
+                    if c == '\'' {
+                        body.push(c);
+                    }
+                }
+            }
+            Ok(format!("'{body}'"))
+        }
+        TScalarStyle::DoubleQuoted => json(value),
+        TScalarStyle::Plain => {
+            let safe = !string.is_empty()
+                && !string.contains([
+                    '\n', '\r', ',', '[', ']', '{', '}', '#', '\u{85}', '\u{2028}', '\u{2029}',
+                ])
+                && string.trim() == string
+                && !string.contains(": ")
+                && serde_yaml_ng::from_str::<Value>(string).ok().as_ref() == Some(value);
+            Ok(if safe {
+                string.to_owned()
+            } else {
+                json(value)?
+            })
+        }
+        TScalarStyle::Literal | TScalarStyle::Folded => {
+            if string.contains(['\r', '\u{85}', '\u{2028}', '\u{2029}']) {
+                return Err(unsupported(
+                    "block scalar cannot preserve these line break characters",
+                ));
+            }
+            let header_end = original.find('\n').map_or(original.len(), |n| n + 1);
+            let header = original[..header_end].trim_end_matches(['\r', '\n']);
+            let indicator_end = header
+                .find(|c: char| c.is_whitespace() || c == '#')
+                .unwrap_or(header.len());
+            let indicator = &header[..indicator_end];
+            let width = indicator.chars().find(|c| c.is_ascii_digit());
+            let tail = &header[indicator_end..];
+            let trailing = string.len() - string.trim_end_matches('\n').len();
+            let chomp = if trailing == 0 {
+                "-"
+            } else if trailing == 1 {
+                ""
+            } else {
+                "+"
+            };
+            let content = &original[header_end..];
+            let spaces = content
+                .lines()
+                .find(|l| !l.trim().is_empty())
+                .map(|l| l.bytes().take_while(|b| *b == b' ').count())
+                .unwrap_or_else(|| column(text, node.range.start) + 2);
+            let indent = " ".repeat(spaces);
+            let mut body = string.trim_end_matches('\n').to_owned();
+            if *style == TScalarStyle::Folded {
+                // Folding preserves breaks adjacent to more-indented lines. For ordinary
+                // paragraphs add exactly one blank line per run of logical line breaks.
+                let lines: Vec<_> = body.split('\n').collect();
+                let mut folded = String::new();
+                for (i, line) in lines.iter().enumerate() {
+                    if i > 0 {
+                        folded.push('\n');
+                    }
+                    folded.push_str(line);
+                    if !line.is_empty()
+                        && !line.starts_with([' ', '\t'])
+                        && i + 1 < lines.len()
+                        && lines[i + 1..]
+                            .iter()
+                            .find(|l| !l.is_empty())
+                            .is_some_and(|l| !l.starts_with([' ', '\t']))
+                    {
+                        folded.push('\n');
+                    }
+                }
+                body = folded;
+            }
+            let mut output = format!(
+                "{}{}{chomp}{tail}{newline}",
+                if *style == TScalarStyle::Literal {
+                    '|'
+                } else {
+                    '>'
+                },
+                width.map_or(String::new(), |c| c.to_string())
+            );
+            if !body.is_empty() {
+                for line in body.split('\n') {
+                    output.push_str(&indent);
+                    output.push_str(line);
+                    output.push_str(newline);
+                }
+            }
+            for _ in 1..trailing {
+                output.push_str(newline);
+            }
+            Ok(output)
+        }
+    }
+}
+
+pub(crate) fn edit_fields(
+    text: &str,
+    pointer: &str,
+    changes: &Map<String, Value>,
+) -> Result<String> {
+    let offsets = text
+        .char_indices()
+        .map(|(i, _)| i)
+        .chain(std::iter::once(text.len()))
+        .collect();
+    let mut reader = Reader {
+        text,
+        parser: Parser::new_from_str(text),
+        offsets,
+    };
+    if reader.token()?.0 != Event::StreamStart || reader.token()?.0 != Event::DocumentStart {
+        return Err(unsupported("YAML stream has no document"));
+    }
+    let first = reader.token()?;
+    let root = reader.node(first, 0, 0, false)?;
+    if reader.token()?.0 != Event::DocumentEnd || reader.token()?.0 != Event::StreamEnd {
+        return Err(unsupported(
+            "multiple YAML documents require manual editing",
+        ));
+    }
+    let mut target = &root;
+    for part in pointer
+        .strip_prefix('/')
+        .ok_or_else(|| unsupported("expected JSON pointer"))?
+        .split('/')
+    {
+        let key = part.replace("~1", "/").replace("~0", "~");
+        target = match &target.kind {
+            Kind::Mapping(fields, ..) => fields.iter().find(|(k, _)| k == &key).map(|(_, n)| n),
+            Kind::Sequence(nodes) => key.parse::<usize>().ok().and_then(|i| nodes.get(i)),
+            _ => None,
+        }
+        .ok_or_else(|| Error::SourceConflict("exact YAML record pointer is missing".into()))?;
+    }
+    let Kind::Mapping(fields, flow, indent) = &target.kind else {
+        return Err(unsupported("the exact YAML record must be a mapping"));
+    };
+    let newline = if text.contains("\r\n") { "\r\n" } else { "\n" };
+    let mut edits = Vec::new();
+    let mut added = Vec::new();
+    for (key, value) in changes {
+        if let Some((_, node)) = fields.iter().find(|(k, _)| k == key) {
+            let mut replacement = render(text, node, value, newline)?;
+            if node.range.is_empty() {
+                replacement.insert(0, ' ');
+            }
+            edits.push((node.range.clone(), replacement));
+        } else {
+            added.push(format!(
+                "{}: {}",
+                json(&Value::String(key.clone()))?,
+                json(value)?
+            ));
+        }
+    }
+    if !added.is_empty() {
+        if *flow {
+            let at = target.range.end - 1;
+            edits.push((
+                at..at,
+                format!(
+                    "{}{}",
+                    if fields.is_empty() { "" } else { ", " },
+                    added.join(", ")
+                ),
+            ));
+        } else {
+            let end = target.range.end;
+            let at = if text[..end].ends_with('\n') {
+                end
+            } else {
+                line_end(text, end)
+            };
+            let prefix = if at > 0 && !text[..at].ends_with('\n') {
+                newline
+            } else {
+                ""
+            };
+            let mut addition = prefix.to_owned();
+            for value in added {
+                addition += &format!("{}{value}{newline}", " ".repeat(*indent));
+            }
+            edits.push((at..at, addition));
+        }
+    }
+    edits.sort_by_key(|(r, _)| std::cmp::Reverse(r.start));
+    let mut output = text.to_owned();
+    let mut boundary = text.len();
+    for (range, replacement) in edits {
+        if range.end > boundary {
+            return Err(unsupported("overlapping YAML field edits"));
+        }
+        boundary = range.start;
+        output.replace_range(range, &replacement);
+    }
+    Ok(output)
+}

--- a/crates/awr-source/src/yaml_mutation.rs
+++ b/crates/awr-source/src/yaml_mutation.rs
@@ -6,10 +6,8 @@ use awr_core::*;
 use serde_json::Value;
 use std::{
     collections::BTreeMap,
-    ops::Range,
     path::{Path, PathBuf},
 };
-use yaml_rust2::parser::{Event, Parser};
 
 pub struct PreparedYamlMutation {
     pub path: PathBuf,
@@ -20,181 +18,6 @@ pub struct PreparedYamlMutation {
 
 fn unsupported(message: &str) -> Error {
     Error::MutationUnsupported(message.into())
-}
-fn bytes_at(text: &str, index: usize) -> Result<usize> {
-    text.char_indices()
-        .nth(index)
-        .map(|(byte, _)| byte)
-        .or_else(|| (text.chars().count() == index).then_some(text.len()))
-        .ok_or_else(|| Error::InvalidInput("YAML marker is outside its source".into()))
-}
-fn token(parser: &mut Parser<std::str::Chars<'_>>) -> Result<(Event, usize)> {
-    parser
-        .next_token()
-        .map(|(event, mark)| (event, mark.index()))
-        .map_err(|e| Error::InvalidInput(format!("YAML mutation syntax: {e}")))
-}
-fn node(
-    parser: &mut Parser<std::str::Chars<'_>>,
-    first: (Event, usize),
-    path: &mut Vec<String>,
-    target: &[String],
-    text: &str,
-    found: &mut Option<Range<usize>>,
-    depth: usize,
-    in_target: bool,
-) -> Result<()> {
-    if depth > 128 {
-        return Err(unsupported("YAML mutation nesting exceeds 128 levels"));
-    }
-    let here = path == target;
-    let in_target = in_target || here;
-    match first.0 {
-        Event::MappingStart(anchor, tag) => {
-            if in_target && (anchor != 0 || tag.is_some()) {
-                return Err(unsupported(
-                    "anchored or tagged target mappings require manual mutation",
-                ));
-            }
-            let flow = here && text[bytes_at(text, first.1)?..].starts_with('{');
-            let mut mapping_start = first.1;
-            let mut first_key = true;
-            let end = loop {
-                let key = token(parser)?;
-                if key.0 == Event::MappingEnd {
-                    break key.1;
-                }
-                if first_key && !flow {
-                    mapping_start = key.1;
-                }
-                first_key = false;
-                let Event::Scalar(key, _, anchor, tag) = key.0 else {
-                    return Err(unsupported(
-                        "complex YAML mapping keys require manual mutation",
-                    ));
-                };
-                if anchor != 0 || tag.is_some() {
-                    return Err(unsupported(
-                        "tagged or anchored YAML keys require manual mutation",
-                    ));
-                }
-                path.push(key);
-                let value = token(parser)?;
-                node(
-                    parser,
-                    value,
-                    path,
-                    target,
-                    text,
-                    found,
-                    depth + 1,
-                    in_target,
-                )?;
-                path.pop();
-            };
-            if here {
-                if found.is_some() {
-                    return Err(Error::SourceConflict(
-                        "YAML pointer resolved more than once".into(),
-                    ));
-                }
-                let start = bytes_at(text, mapping_start)?;
-                let mut end = bytes_at(text, end)?;
-                if text[start..].starts_with('{') {
-                    if !text[end..].starts_with('}') {
-                        return Err(unsupported("could not bound the flow mapping exactly"));
-                    }
-                    end += 1;
-                } else {
-                    // Leave separators, indentation and standalone trailing comments outside
-                    // the replacement. Comments within the selected record may be normalized.
-                    end = start + text[start..end].trim_end().len();
-                    loop {
-                        let line = text[..end]
-                            .rfind('\n')
-                            .map_or(start, |n| (n + 1).max(start));
-                        if line <= start || !text[line..end].trim_start().starts_with('#') {
-                            break;
-                        }
-                        end = start + text[start..line].trim_end().len();
-                    }
-                }
-                *found = Some(start..end);
-            }
-        }
-        Event::SequenceStart(anchor, tag) => {
-            if in_target && (anchor != 0 || tag.is_some()) {
-                return Err(unsupported(
-                    "anchored or tagged target values require manual mutation",
-                ));
-            }
-            if here {
-                return Err(unsupported("a mutation target must be a YAML mapping"));
-            }
-            let mut index = 0;
-            loop {
-                let child = token(parser)?;
-                if child.0 == Event::SequenceEnd {
-                    break;
-                }
-                path.push(index.to_string());
-                node(
-                    parser,
-                    child,
-                    path,
-                    target,
-                    text,
-                    found,
-                    depth + 1,
-                    in_target,
-                )?;
-                path.pop();
-                index += 1;
-            }
-        }
-        Event::Scalar(_, _, anchor, tag) => {
-            if here || (in_target && (anchor != 0 || tag.is_some())) {
-                return Err(unsupported(
-                    "scalar, anchored or tagged targets require manual mutation",
-                ));
-            }
-        }
-        Event::Alias(_) if !here => (),
-        Event::Alias(_) => return Err(unsupported("an aliased target requires manual mutation")),
-        _ => return Err(unsupported("unexpected YAML node boundary")),
-    }
-    Ok(())
-}
-fn target_range(text: &str, pointer: &str) -> Result<Range<usize>> {
-    let parts = pointer
-        .strip_prefix('/')
-        .ok_or_else(|| unsupported("YAML target requires a JSON pointer"))?
-        .split('/')
-        .map(|s| s.replace("~1", "/").replace("~0", "~"))
-        .collect::<Vec<_>>();
-    let mut parser = Parser::new_from_str(text);
-    if token(&mut parser)?.0 != Event::StreamStart || token(&mut parser)?.0 != Event::DocumentStart
-    {
-        return Err(unsupported("YAML stream has no document"));
-    }
-    let first = token(&mut parser)?;
-    let mut found = None;
-    node(
-        &mut parser,
-        first,
-        &mut Vec::new(),
-        &parts,
-        text,
-        &mut found,
-        0,
-        false,
-    )?;
-    if token(&mut parser)?.0 != Event::DocumentEnd || token(&mut parser)?.0 != Event::StreamEnd {
-        return Err(unsupported(
-            "multiple YAML documents require manual mutation",
-        ));
-    }
-    found.ok_or_else(|| Error::SourceConflict("YAML mutation target pointer is missing".into()))
 }
 fn document(snapshot: &SourceSnapshot) -> Result<Value> {
     crate::limits::check_source_size(&snapshot.bytes, crate::YAML_READ_CAP)?;
@@ -375,13 +198,16 @@ pub fn prepare_yaml_mutation(
             "proposal would not change its source record".into(),
         ));
     }
-    let replacement = serde_json::to_string(&expected.pointer(pointer).unwrap())?
-        .replace('\u{85}', "\\u0085")
-        .replace('\u{2028}', "\\u2028")
-        .replace('\u{2029}', "\\u2029");
-    let range = target_range(before.text()?, pointer)?;
-    let mut output = before.text()?.to_string();
-    output.replace_range(range, &replacement);
+    let changed_fields = expected
+        .pointer(pointer)
+        .unwrap()
+        .as_object()
+        .unwrap()
+        .iter()
+        .filter(|(key, value)| original.pointer(pointer).unwrap().get(*key) != Some(*value))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+    let output = crate::yaml_edit::edit_fields(before.text()?, pointer, &changed_fields)?;
     crate::limits::check_source_size(output.as_bytes(), crate::YAML_READ_CAP)?;
     let after = SourceSnapshot {
         locator: before.locator.clone(),
@@ -390,7 +216,7 @@ pub fn prepare_yaml_mutation(
     };
     if document(&after)? != expected {
         return Err(unsupported(
-            "exact target replacement cannot preserve the document's other facts",
+            "exact field replacement cannot preserve the document's other facts",
         ));
     }
     let (_, target_after_hash) =

--- a/crates/awr-source/tests/yaml_mutation.rs
+++ b/crates/awr-source/tests/yaml_mutation.rs
@@ -92,6 +92,10 @@ fn mapped_yaml_writer_retains_original_keys_and_other_records() {
         .plan(EntityKind::WorkItem, "W", json!({"next_action":"After"}))
         .unwrap();
     let after = parsed(plan.after.text().unwrap());
+    assert_eq!(
+        plan.after.text().unwrap(),
+        text.replace("next: Before", "next: After")
+    );
     assert_eq!(after["work_items"][0]["next"], "After");
     assert!(after["work_items"][0].get("next_action").is_none());
     assert_eq!(after["work_items"][0]["phase"], "Pending");
@@ -104,6 +108,164 @@ fn mapped_yaml_writer_retains_original_keys_and_other_records() {
         f.plan(EntityKind::WorkItem, "W", json!({"status":"completed"})),
         Err(Error::MutationUnsupported(_))
     ));
+}
+
+#[test]
+fn one_field_keeps_all_other_bytes_comments_key_order_quotes_and_line_endings() {
+    for newline in ["\n", "\r\n"] {
+        let text = [
+            "# 项目",
+            "work_items:",
+            "- id: W  # stable",
+            "  title: 'Keep my title'",
+            "  status: ready",
+            "  next_action: \"Before\" # keep inline",
+            "  summary: >-",
+            "    Preserve this folded",
+            "    description exactly.",
+            "  tags: [first, 'second']",
+            "# trailing comment",
+            "- id: OTHER",
+            "  title: Do not touch",
+            "",
+        ]
+        .join(newline);
+        let f = Fixture::new(&text);
+        let plan = f
+            .plan(
+                EntityKind::WorkItem,
+                "W",
+                json!({"next_action":"新的动作 🐾"}),
+            )
+            .unwrap();
+        assert_eq!(
+            plan.after.text().unwrap(),
+            text.replace("\"Before\"", "\"新的动作 🐾\"")
+        );
+        assert_eq!(
+            fs::read(f.root.join("ledger.yaml")).unwrap(),
+            text.as_bytes()
+        );
+    }
+}
+
+#[test]
+fn quoted_fields_keep_quote_style_and_escape_new_content_without_touching_neighbors() {
+    for (old, new, encoded) in [
+        ("'Before'", "Don't normalize", "'Don''t normalize'"),
+        ("\"Before\"", "Quoted \"value\"", "\"Quoted \\\"value\\\"\""),
+        ("Before", "false", "\"false\""),
+    ] {
+        let text = format!(
+            "work_items: [{{id: W, status: ready, next_action: {old}, title: 'Keep'}}] # comment\n"
+        );
+        let f = Fixture::new(&text);
+        let plan = f
+            .plan(EntityKind::WorkItem, "W", json!({"next_action":new}))
+            .unwrap();
+        assert_eq!(plan.after.text().unwrap(), text.replace(old, encoded));
+    }
+}
+
+#[test]
+fn new_field_and_empty_scalar_preserve_existing_inline_and_trailing_comments() {
+    for text in [
+        "work_items:\n- id: W\n  status: ready # state note\n# outside\n- id: OTHER\n  status: ready\n",
+        "work_items: [{id: W, status: ready}, {id: OTHER, status: ready}] # outside\n",
+        "work_items:\n  W:\n    status: ready # state note",
+        "work_items:\n- id: W\n  status: ready\n  summary: # keep empty comment\n  next_action: Before\n",
+    ] {
+        let f = Fixture::new(text);
+        let plan = f
+            .plan(EntityKind::WorkItem, "W", json!({"summary":"New summary"}))
+            .unwrap();
+        let output = plan.after.text().unwrap();
+        assert!(output.contains("status: ready"));
+        for comment in ["# state note", "# outside", "# keep empty comment"] {
+            if text.contains(comment) {
+                assert!(output.contains(comment));
+            }
+        }
+        let mut expected = parsed(text);
+        if expected["work_items"].is_array() {
+            expected["work_items"][0]["summary"] = json!("New summary");
+        } else {
+            expected["work_items"]["W"]["summary"] = json!("New summary");
+        }
+        assert_eq!(parsed(output), expected);
+    }
+}
+
+#[test]
+fn block_field_edits_keep_literal_or_folded_style_header_comment_and_neighbor_bytes() {
+    for newline in ["\n", "\r\n"] {
+        for style in ["|-", ">-", "|2-", ">2-"] {
+            let prefix = format!(
+                "work_items:{newline}- id: W{newline}  status: ready{newline}  next_action: "
+            );
+            let suffix = format!("  title: 'Untouched'{newline}# outside{newline}");
+            let text =
+                format!("{prefix}{style} # keep header{newline}    Old line{newline}{suffix}");
+            let f = Fixture::new(&text);
+            for value in [
+                "First line\nsecond line",
+                "Paragraph one\n\nparagraph two\n",
+                "Keep a final blank\n\n",
+            ] {
+                let plan = f
+                    .plan(EntityKind::WorkItem, "W", json!({"next_action":value}))
+                    .unwrap();
+                let out = plan.after.text().unwrap();
+                assert!(out.starts_with(&format!("{prefix}{}", &style[..1])));
+                assert!(out.contains("# keep header"));
+                assert!(out.ends_with(&suffix));
+                assert_eq!(parsed(out)["work_items"][0]["next_action"], value);
+                if newline == "\r\n" {
+                    assert!(!out.replace("\r\n", "").contains('\n'));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn unrelated_multiline_plain_fields_are_preserved_and_ambiguous_target_edits_are_rejected() {
+    let text = "work_items:\n- id: W\n  status: ready\n  title: A plain title continued\n    on another line\n  next_action: Before\n";
+    let f = Fixture::new(text);
+    assert_eq!(
+        f.plan(EntityKind::WorkItem, "W", json!({"next_action":"After"}))
+            .unwrap()
+            .after
+            .text()
+            .unwrap(),
+        text.replace("Before", "After")
+    );
+    assert!(matches!(
+        f.plan(EntityKind::WorkItem, "W", json!({"title":"Changed"})),
+        Err(Error::MutationUnsupported(_))
+    ));
+    assert_eq!(
+        fs::read_to_string(f.root.join("ledger.yaml")).unwrap(),
+        text
+    );
+}
+
+#[test]
+fn comment_bearing_collection_and_anchor_edits_fail_before_writing() {
+    for text in [
+        "work_items:\n- id: W\n  status: ready\n  tags:\n  - old # a tag comment\n  next_action: Before\n",
+        "work_items:\n- id: W\n  status: ready\n  tags: &tags [old]\nextra: *tags\n",
+    ] {
+        let f = Fixture::new(text);
+        assert!(matches!(
+            f.plan(EntityKind::WorkItem, "W", json!({"tags":["new"]})),
+            Err(Error::MutationUnsupported(_))
+        ));
+        assert_eq!(
+            fs::read_to_string(f.root.join("ledger.yaml")).unwrap(),
+            text
+        );
+    }
 }
 
 #[test]

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -155,14 +155,20 @@ reads. Status, ready and summaries do not provide a complete project catalog. Co
 projections can write the runtime database; `read_only` and freshness fields are part
 of the result, not an inference from the command's name.
 
-`mutation.yaml.record` supports selected YAML fields through source-bound proposals;
-it reserializes the selected record. It preserves neither every comment nor its
-original quoting/formatting. Require `mutation.yaml.lossless_fields` if the host
-promises field-level preservation. Markdown adapters currently read sources; they do
-not authorize Markdown body or ledger writes. Unsupported capabilities are explicitly
-listed as unavailable, including human-save shortcuts, new tasks, multi-file writes
-and user-confirmed completion. Never route an unsupported operation through a generic
-status patch or a second writer.
+`mutation.yaml.record` and `mutation.yaml.lossless_fields` support selected YAML
+fields through source-bound proposals. Field spans preserve unrelated bytes, comments,
+key order and line endings. Existing scalar styles are retained when the new value can
+be represented in that style; a plain string that would become a boolean is quoted.
+Block style is retained with chomping adjusted to the new value. Unsupported anchors,
+aliases, tags, duplicate/complex keys, comment-bearing collection replacement and
+ambiguous scalar forms fail before writing. The entire result must have precisely the
+expected semantics and reparse through the source adapter. See the
+[YAML writer](../../adapters/yaml-ledger/README.md) for supported shapes.
+
+Markdown adapters currently read sources; they do not authorize Markdown body or ledger
+writes. Unsupported capabilities include human-save shortcuts, new tasks, multi-file
+writes and user-confirmed completion. Never route an unsupported operation through a
+generic status patch or a second writer.
 
 `work complete` retains the engineering contract: a real session/claim and evidence
 covering the source's acceptance criteria at the supplied source SHA. A source's raw


### PR DESCRIPTION
Updating one YAML task field previously reserialized its entire record, changing unrelated comments and formatting. Replace record serialization with parser-located field edits that preserve surrounding bytes, key order, mapped names, quotes and LF/CRLF. The complete result must still match the intended semantics and reparse through the existing adapter before application.

Advertise supported lossless field writes in capability discovery and document explicit unsupported shapes. Existing source fingerprint checks, proposal journals, domain transitions and completion evidence gates remain in effect.

Validation: 11 source tests and 41 CLI proposal/domain/completion/capability tests pass. Formatting, diff and public-tree checks pass. Optional strict Clippy remains blocked by pre-existing warnings in unchanged source/core files; no suppressions were added.
