### PR TITLE
feat: durable title-only work drafts

### DIFF
--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -194,7 +194,17 @@ fn catalog() -> Vec<Capability> {
                 "domain_actions_still_required",
             ],
         ),
-        ("mutation.work.create", false, &[], &["not_implemented"]),
+        (
+            "mutation.work.create",
+            true,
+            &["work create", "work create-status", "work create-recover"],
+            &[
+                "registered_yaml_ledger_only",
+                "exact_preview_and_revision",
+                "stable_request_key",
+                "draft_state_not_executable",
+            ],
+        ),
         ("mutation.markdown", false, &[], &["not_implemented"]),
         ("mutation.human_save", false, &[], &["not_implemented"]),
         ("mutation.multi_file", false, &[], &["not_implemented"]),
@@ -269,7 +279,7 @@ pub fn run(args: &CapabilitiesArgs, json_output: bool) -> Result<()> {
             "os": std::env::consts::OS, "arch": std::env::consts::ARCH},
         "database": {"schema_version": awr_store::SCHEMA_VERSION,
             "read_only_schema_versions": [awr_store::SCHEMA_VERSION],
-            "migrate_from_schema_versions": [1, 2],
+            "migrate_from_schema_versions": [1, 2, 3],
             "newer_schema_policy": "reject_without_migration",
             "schema_validation_required": true},
         "source_adapters": awr_source::SOURCE_ADAPTERS.iter().map(|id| json!({

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -22,6 +22,7 @@ mod session;
 mod source;
 mod source_changes;
 mod work_action;
+mod work_create;
 
 #[derive(Debug, Parser)]
 #[command(

--- a/crates/awr-cli/src/query.rs
+++ b/crates/awr-cli/src/query.rs
@@ -7,6 +7,12 @@ use std::{collections::BTreeMap, path::Path};
 
 #[derive(Debug, Subcommand)]
 pub enum WorkCommand {
+    /// Preview or accept one new source-backed, non-executable task draft.
+    Create(crate::work_create::CreateArgs),
+    /// Read the durable outcome for a stable creation request without applying it.
+    CreateStatus(crate::work_create::StatusArgs),
+    /// Explicitly recover a pending creation while retaining externally changed bytes.
+    CreateRecover(crate::work_create::RecoverArgs),
     /// Record progress in the source ledger; requires an active owned runtime claim.
     Progress(crate::work_action::ActionArgs),
     /// Mark in-progress source work blocked with a concrete blocker.
@@ -340,6 +346,9 @@ pub fn ready(root: &Path, limit: usize, reference: Option<&str>, json_output: bo
 
 pub fn work(root: &Path, command: &WorkCommand, json_output: bool) -> Result<()> {
     match command {
+        WorkCommand::Create(args) => crate::work_create::create(root, args, json_output),
+        WorkCommand::CreateStatus(args) => crate::work_create::status(root, args, json_output),
+        WorkCommand::CreateRecover(args) => crate::work_create::recover(root, args, json_output),
         WorkCommand::Progress(args) => {
             crate::work_action::run(root, args, WorkAction::Progress, json_output)
         }

--- a/crates/awr-cli/src/session.rs
+++ b/crates/awr-cli/src/session.rs
@@ -592,6 +592,9 @@ pub fn work(root: &Path, command: &WorkCommand, json_output: bool) -> Result<()>
             )
         }
         WorkCommand::Show { .. }
+        | WorkCommand::Create(_)
+        | WorkCommand::CreateStatus(_)
+        | WorkCommand::CreateRecover(_)
         | WorkCommand::Progress(_)
         | WorkCommand::Block(_)
         | WorkCommand::Unblock(_)

--- a/crates/awr-cli/src/work_create.rs
+++ b/crates/awr-cli/src/work_create.rs
@@ -1,0 +1,105 @@
+use awr_core::*;
+use awr_runtime::{CreateWorkInput, CreationReport};
+use awr_store::Store;
+use clap::Args;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Args)]
+pub struct CreateArgs {
+    /// Protected JSON with version, request_key, title and optional source_id.
+    #[arg(long,conflicts_with_all=["title","request_key","source"])]
+    input: Option<PathBuf>,
+    #[arg(long, required_unless_present = "input")]
+    title: Option<String>,
+    /// Stable host request ID, reused only with identical creation content.
+    #[arg(long, required_unless_present = "input")]
+    request_key: Option<String>,
+    #[arg(long)]
+    source: Option<Id>,
+    #[arg(long)]
+    accept: bool,
+    #[arg(long)]
+    expected_preview: Option<String>,
+    #[arg(long)]
+    expected_revision: Option<Revision>,
+}
+#[derive(Debug, Args)]
+pub struct StatusArgs {
+    #[arg(long)]
+    key: String,
+}
+#[derive(Debug, Args)]
+pub struct RecoverArgs {
+    #[arg(long)]
+    key: String,
+    #[arg(long)]
+    expected_revision: Revision,
+}
+fn output(report: CreationReport, json_output: bool) -> Result<()> {
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&report.value)?);
+    } else {
+        println!(
+            "Work creation: {}\nWork key: {}\nReceipt: {}",
+            report.value["status"],
+            report.value["external_key"],
+            report.value["recovery_directory"]
+        );
+    }
+    match report.failure {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+pub fn create(root: &Path, args: &CreateArgs, json_output: bool) -> Result<()> {
+    let root = root.canonicalize()?;
+    let input = if let Some(path) = &args.input {
+        let path = if path.is_absolute() {
+            path.clone()
+        } else {
+            root.join(path)
+        };
+        serde_json::from_slice(&awr_source::read_capped(&path, 64 * 1024)?).map_err(|_| {
+            Error::InvalidInput(
+                "creation JSON requires version, request_key, title and optional source_id".into(),
+            )
+        })?
+    } else {
+        CreateWorkInput {
+            version: 1,
+            request_key: args.request_key.clone().unwrap(),
+            title: args.title.clone().unwrap(),
+            source_id: args.source,
+        }
+    };
+    let mut store =
+        Store::open_existing(&crate::source::runtime_dir(&root, false)?.join("state.db"))?;
+    output(
+        awr_runtime::create_work(
+            &mut store,
+            &root,
+            input,
+            args.accept,
+            args.expected_preview.as_deref(),
+            args.expected_revision,
+        )?,
+        json_output,
+    )
+}
+pub fn status(root: &Path, args: &StatusArgs, json_output: bool) -> Result<()> {
+    let root = root.canonicalize()?;
+    let store = Store::open_readonly(&crate::source::runtime_dir(&root, false)?.join("state.db"))?;
+    output(
+        awr_runtime::creation_status(&store, &root, &args.key)?,
+        json_output,
+    )
+}
+pub fn recover(root: &Path, args: &RecoverArgs, json_output: bool) -> Result<()> {
+    let root = root.canonicalize()?;
+    let mut store =
+        Store::open_existing(&crate::source::runtime_dir(&root, false)?.join("state.db"))?;
+    output(
+        awr_runtime::recover_creation(&mut store, &root, &args.key, args.expected_revision)?,
+        json_output,
+    )
+}

--- a/crates/awr-cli/tests/host_create.rs
+++ b/crates/awr-cli/tests/host_create.rs
@@ -1,0 +1,372 @@
+//! Native CLI creation/retry checks; recovery boundary edits are synthetic fixtures.
+use awr_core::Id;
+use serde_json::{Value, json};
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+    sync::Arc,
+};
+
+struct Host(PathBuf);
+impl Host {
+    fn new(text: &str, options: &str) -> Self {
+        let h = Self(std::env::temp_dir().join(format!("awr 新增 台账 {}", Id::new())));
+        fs::create_dir(&h.0).unwrap();
+        h.write("工作.yaml", text);
+        h.write("mapping.toml",&format!("[project]\nname='Creation'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='工作.yaml'\nadapter='yaml-ledger-v1'\n{options}"));
+        h.ok(&["init", "--manifest", "mapping.toml", "--accept"]);
+        h
+    }
+    fn write(&self, path: &str, text: &str) {
+        fs::write(self.0.join(path), text).unwrap();
+    }
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_awr"))
+            .env_clear()
+            .args(["--project", self.0.to_str().unwrap(), "--json"])
+            .args(args)
+            .stdin(Stdio::null())
+            .output()
+            .unwrap()
+    }
+    fn ok(&self, args: &[&str]) -> Value {
+        let out = self.run(args);
+        assert!(
+            out.status.success(),
+            "{args:?}\n{}\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        serde_json::from_slice(&out.stdout).unwrap()
+    }
+    fn error(&self, args: &[&str], code: &str) {
+        let out = self.run(args);
+        assert!(!out.status.success(), "{args:?}");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&out.stderr).unwrap()["code"],
+            code
+        );
+    }
+    fn preview(&self, key: &str, title: &str) -> Value {
+        self.ok(&["work", "create", "--request-key", key, "--title", title])
+    }
+    fn accept(&self, key: &str, title: &str, preview: &Value) -> Value {
+        self.ok(&[
+            "work",
+            "create",
+            "--request-key",
+            key,
+            "--title",
+            title,
+            "--accept",
+            "--expected-preview",
+            preview["preview"]["fingerprint"].as_str().unwrap(),
+            "--expected-revision",
+            &preview["project_revision"].to_string(),
+        ])
+    }
+    fn revision(&self) -> String {
+        self.ok(&["session", "list"])["project_revision"].to_string()
+    }
+    fn stored(&self, created: &Value) -> (PathBuf, Value) {
+        let p = self
+            .0
+            .join(created["recovery_directory"].as_str().unwrap())
+            .join("receipt.json");
+        let value = serde_json::from_slice(&fs::read(&p).unwrap()).unwrap();
+        (p, value)
+    }
+}
+impl Drop for Host {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn title_only_creates_one_non_executable_draft_and_replays_the_same_identity() {
+    let h = Host::new("work_items: []\n", "");
+    let before = fs::read(h.0.join("工作.yaml")).unwrap();
+    let p = h.preview("one-request", "准备旅行清单");
+    assert_eq!(p["source_write_performed"], false);
+    assert_eq!(fs::read(h.0.join("工作.yaml")).unwrap(), before);
+    let saved = h.accept("one-request", "准备旅行清单", &p);
+    assert_eq!(saved["phase"], "completed");
+    let rev = h.revision();
+    let after = fs::read(h.0.join("工作.yaml")).unwrap();
+    let replay = h.accept("one-request", "准备旅行清单", &p);
+    assert_eq!(saved["work_id"], replay["work_id"]);
+    assert_eq!(replay["already_recorded"], true);
+    assert_eq!(replay["source_write_performed"], false);
+    assert_eq!(h.revision(), rev);
+    assert_eq!(fs::read(h.0.join("工作.yaml")).unwrap(), after);
+    let key = saved["external_key"].as_str().unwrap();
+    let work = h.ok(&["work", "show", key]);
+    assert_eq!(work["work"]["status"], "draft");
+    assert_eq!(work["work"]["ready"], false);
+    h.error(
+        &[
+            "session",
+            "start",
+            "--work",
+            key,
+            "--agent",
+            "fixture",
+            "--provider",
+            "fixture",
+            "--model",
+            "no-model",
+            "--claim",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "DependencyBlocked",
+    );
+    assert_eq!(h.ok(&["object", "list", "work"])["total"], 1);
+    assert_eq!(h.ok(&["session", "list"])["sessions"], json!([]));
+    let status = h.ok(&["work", "create-status", "--key", "one-request"]);
+    assert_eq!(status["work_id"], saved["work_id"]);
+    assert_eq!(status["current_source"], "after");
+    assert_eq!(h.revision(), rev);
+    h.error(
+        &[
+            "work",
+            "create",
+            "--request-key",
+            "one-request",
+            "--title",
+            "Different title",
+            "--accept",
+        ],
+        "SourceConflict",
+    );
+}
+
+#[test]
+fn list_map_flow_mapped_fields_and_crlf_retain_existing_records_and_ids() {
+    for text in [
+        "# header\nwork_items:\n- id: OLD\n  title: 'Original' # keep\n  status: planned\n# footer\n",
+        "work_items: [{id: OLD, title: 'Original', status: planned}] # keep\n",
+        "work_items:\r\n  OLD:\r\n    title: 'Original' # keep\r\n    status: planned\r\n# footer\r\n",
+        "work_items: {OLD: {title: Original, status: planned}} # keep\n",
+    ] {
+        let h = Host::new(text, "");
+        let old = h.ok(&["work", "show", "OLD"])["work"]["id"].clone();
+        let p = h.preview("new-work", "A new work");
+        h.accept("new-work", "A new work", &p);
+        assert_eq!(h.ok(&["work", "show", "OLD"])["work"]["id"], old);
+        let output = fs::read_to_string(h.0.join("工作.yaml")).unwrap();
+        assert!(output.contains("# keep"));
+        if text.contains("\r\n") {
+            assert!(!output.replace("\r\n", "").contains('\n'));
+        }
+        let prior: Value = serde_yaml_ng::from_str(text).unwrap();
+        let after: Value = serde_yaml_ng::from_str(&output).unwrap();
+        if prior["work_items"].is_array() {
+            assert_eq!(prior["work_items"][0], after["work_items"][0]);
+        } else {
+            assert_eq!(prior["work_items"]["OLD"], after["work_items"]["OLD"]);
+        }
+    }
+    let h = Host::new(
+        "work_items: []\n",
+        "[sources.options.field_map]\nid='ticket'\ntitle='name'\nstatus='phase'\n[sources.options.status_map]\nDrafting='draft'\nPending='planned'\n",
+    );
+    let p = h.preview("mapped", "映射字段");
+    let saved = h.accept("mapped", "映射字段", &p);
+    let text = fs::read_to_string(h.0.join("工作.yaml")).unwrap();
+    let value: Value = serde_yaml_ng::from_str(&text).unwrap();
+    assert_eq!(value["work_items"][0]["phase"], "Drafting");
+    assert_eq!(value["work_items"][0]["name"], "映射字段");
+    assert_eq!(value["work_items"][0]["ticket"], saved["external_key"]);
+    assert!(value["work_items"][0].get("id").is_none());
+}
+
+#[test]
+fn changed_source_or_mapping_invalidates_review_and_missing_acceptance_never_writes() {
+    for mapping in [false, true] {
+        let h = Host::new("work_items: []\n", "");
+        let p = h.preview("review", "New task");
+        let path = if mapping {
+            ".awr/project.toml"
+        } else {
+            "工作.yaml"
+        };
+        let old = fs::read_to_string(h.0.join(path)).unwrap();
+        h.write(
+            path,
+            &if mapping {
+                old.replace("role = \"primary\"", "role = \"supporting\"")
+            } else {
+                format!("{old}# external edit\n")
+            },
+        );
+        let before = fs::read(h.0.join("工作.yaml")).unwrap();
+        let out = h.run(&[
+            "work",
+            "create",
+            "--request-key",
+            "review",
+            "--title",
+            "New task",
+            "--accept",
+            "--expected-preview",
+            p["preview"]["fingerprint"].as_str().unwrap(),
+            "--expected-revision",
+            &p["project_revision"].to_string(),
+        ]);
+        assert!(!out.status.success());
+        assert_eq!(fs::read(h.0.join("工作.yaml")).unwrap(), before);
+    }
+    let h = Host::new("work_items: []\n", "");
+    h.error(
+        &[
+            "work",
+            "create",
+            "--request-key",
+            "missing-review",
+            "--title",
+            "New task",
+            "--accept",
+        ],
+        "SourceConflict",
+    );
+    assert_eq!(
+        fs::read_to_string(h.0.join("工作.yaml")).unwrap(),
+        "work_items: []\n"
+    );
+}
+
+#[test]
+fn concurrent_delivery_and_discarded_response_do_not_create_two_work_keys() {
+    let h = Arc::new(Host::new("work_items: []\n", ""));
+    let p = h.preview("parallel", "Parallel task");
+    let jobs = (0..4)
+        .map(|_| {
+            let h = h.clone();
+            let p = p.clone();
+            std::thread::spawn(move || {
+                h.run(&[
+                    "work",
+                    "create",
+                    "--request-key",
+                    "parallel",
+                    "--title",
+                    "Parallel task",
+                    "--accept",
+                    "--expected-preview",
+                    p["preview"]["fingerprint"].as_str().unwrap(),
+                    "--expected-revision",
+                    &p["project_revision"].to_string(),
+                ])
+            })
+        })
+        .collect::<Vec<_>>();
+    let outputs = jobs
+        .into_iter()
+        .map(|j| j.join().unwrap())
+        .collect::<Vec<_>>();
+    assert!(outputs.iter().any(|o| o.status.success()));
+    // The host lost/discarded successful command output. Recover through the request key.
+    let status = h.ok(&["work", "create-status", "--key", "parallel"]);
+    assert_eq!(status["phase"], "completed");
+    let replay = h.accept("parallel", "Parallel task", &p);
+    assert_eq!(replay["work_id"], status["work_id"]);
+    assert_eq!(h.ok(&["object", "list", "work"])["total"], 1);
+}
+
+#[test]
+fn persisted_boundary_recovery_never_overwrites_external_edits_or_allocates_a_second_id() {
+    let h = Host::new("work_items: []\n", "");
+    let p = h.preview("recover", "Recover task");
+    let saved = h.accept("recover", "Recover task", &p);
+    let after = fs::read(h.0.join("工作.yaml")).unwrap();
+    let (path, mut receipt) = h.stored(&saved);
+    // Synthetic boundary fixture: source installed, acknowledgement not persisted.
+    receipt["phase"] = json!("applied");
+    receipt["work_id"] = Value::Null;
+    fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+    let recovered = h.ok(&[
+        "work",
+        "create-recover",
+        "--key",
+        "recover",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    assert_eq!(recovered["work_id"], saved["work_id"]);
+    assert_eq!(recovered["source_write_performed"], false);
+    assert_eq!(fs::read(h.0.join("工作.yaml")).unwrap(), after);
+    fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+    let external = [after, b"# user added new information\n".to_vec()].concat();
+    fs::write(h.0.join("工作.yaml"), &external).unwrap();
+    h.error(
+        &[
+            "work",
+            "create-recover",
+            "--key",
+            "recover",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "SourceConflict",
+    );
+    assert_eq!(fs::read(h.0.join("工作.yaml")).unwrap(), external);
+}
+
+#[test]
+fn unsupported_shapes_and_foreign_receipts_do_not_become_task_writes() {
+    let h = Host::new("work_items: &works []\nextra: *works\n", "");
+    h.error(
+        &[
+            "work",
+            "create",
+            "--request-key",
+            "unsupported",
+            "--title",
+            "New task",
+        ],
+        "MutationUnsupported",
+    );
+    let first = Host::new("work_items: []\n", "");
+    let p = first.preview("same-key", "First project");
+    let saved = first.accept("same-key", "First project", &p);
+    let second = Host::new("work_items: []\n", "");
+    let p = second.preview("same-key", "Second project");
+    let saved2 = second.accept("same-key", "Second project", &p);
+    assert_ne!(saved["external_key"], saved2["external_key"]);
+    assert_ne!(saved["project_id"], saved2["project_id"]);
+    assert_eq!(
+        second.ok(&["work", "create-status", "--key", "same-key"])["work_id"],
+        saved2["work_id"]
+    );
+    let (path2, _) = second.stored(&saved2);
+    let (path1, _) = first.stored(&saved);
+    fs::copy(path1, path2).unwrap();
+    second.error(
+        &["work", "create-status", "--key", "same-key"],
+        "SourceConflict",
+    );
+}
+
+#[test]
+fn old_explicit_draft_spelling_mapping_is_retained_but_cannot_make_new_work_executable() {
+    let h = Host::new(
+        "work_items: [{id: OLD, title: Existing work, status: draft}]\n",
+        "[sources.options.status_map]\ndraft='planned'\n",
+    );
+    assert_eq!(h.ok(&["work", "show", "OLD"])["work"]["status"], "planned");
+    h.error(
+        &[
+            "work",
+            "create",
+            "--request-key",
+            "new",
+            "--title",
+            "New task",
+        ],
+        "MutationUnsupported",
+    );
+    assert_eq!(h.ok(&["object", "list", "work"])["total"], 1);
+}

--- a/crates/awr-cli/tests/work_cli.rs
+++ b/crates/awr-cli/tests/work_cli.rs
@@ -112,7 +112,7 @@ fn search_cli_combines_text_and_structured_filters() {
     let diagnosed = f.run(&["doctor"]);
     assert!(!diagnosed.status.success());
     let diagnosis: Value = serde_json::from_slice(&diagnosed.stdout).unwrap();
-    assert_eq!(diagnosis["schema_version"], 3);
+    assert_eq!(diagnosis["schema_version"], awr_store::SCHEMA_VERSION);
     assert_eq!(diagnosis["database_ok"], true);
     assert!(
         diagnosis["findings"]

--- a/crates/awr-core/src/model.rs
+++ b/crates/awr-core/src/model.rs
@@ -32,6 +32,7 @@ pub enum Freshness {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkStatus {
+    Draft,
     Planned,
     Ready,
     Claimed,
@@ -45,6 +46,7 @@ pub enum WorkStatus {
 impl WorkStatus {
     pub fn normalize(raw: &str) -> Self {
         match raw {
+            "draft" => Self::Draft,
             "planned" => Self::Planned,
             "ready" => Self::Ready,
             "claimed" => Self::Claimed,

--- a/crates/awr-runtime/src/lib.rs
+++ b/crates/awr-runtime/src/lib.rs
@@ -15,6 +15,7 @@ mod organization;
 mod read;
 mod resume;
 mod work_action;
+mod work_create;
 pub use artifact::ArtifactFile;
 use awr_store::Store;
 pub use awr_store::{BranchFilter, EventCursor, EventPage, EventQuery};
@@ -30,6 +31,9 @@ pub use mutation::{
 pub use organization::{OrganizationReport, OrganizationState, inspect_organization};
 pub use resume::{ResumeReport, ResumeRequest, resume_session};
 pub use work_action::{WorkActionRequest, perform_work_action};
+pub use work_create::{
+    CreateWorkInput, CreationReport, create_work, creation_status, recover_creation,
+};
 
 /// Hard ceilings; a caller may select a smaller budget, never raise these limits.
 pub const ARTIFACT_IMPORT_CAP: u64 = 64 * 1024 * 1024;

--- a/crates/awr-runtime/src/mutation_apply.rs
+++ b/crates/awr-runtime/src/mutation_apply.rs
@@ -15,7 +15,7 @@ use std::{
     path::Path,
 };
 
-fn directory(parent: &Dir, name: &str, path: &Path) -> Result<Dir> {
+pub(crate) fn directory(parent: &Dir, name: &str, path: &Path) -> Result<Dir> {
     match parent.create_dir(name) {
         Ok(()) => (),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => (),
@@ -30,7 +30,7 @@ fn directory(parent: &Dir, name: &str, path: &Path) -> Result<Dir> {
     }
     Ok(parent.open_dir_nofollow(name)?)
 }
-fn recovery_root(root: &Path) -> Result<Dir> {
+pub(crate) fn recovery_root(root: &Path) -> Result<Dir> {
     let runtime = root.join(".awr");
     let project = open_dir_exact(root)?;
     let meta = project.symlink_metadata(".awr")?;
@@ -45,7 +45,7 @@ fn recovery_root(root: &Path) -> Result<Dir> {
         .map_err(|e| Error::SourceUnavailable(format!("{}: {e}", runtime.display())))?;
     directory(&runtime_dir, "mutations", &runtime.join("mutations"))
 }
-struct SourceLock(File);
+pub(crate) struct SourceLock(File);
 impl Drop for SourceLock {
     fn drop(&mut self) {
         // Release this writer's reservation explicitly. A concurrent process spawn
@@ -54,9 +54,18 @@ impl Drop for SourceLock {
         let _ = self.0.unlock();
     }
 }
-fn source_lock(root: &Path, source: Id) -> Result<SourceLock> {
+pub(crate) fn source_lock(root: &Path, source: Id) -> Result<SourceLock> {
+    named_lock(root, &format!("{source}.lock"))
+}
+pub(crate) fn named_lock(root: &Path, name: &str) -> Result<SourceLock> {
+    if name.len() > 100
+        || !name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b".-".contains(&b))
+    {
+        return Err(Error::InvalidInput("invalid mutation lock name".into()));
+    }
     let directory = recovery_root(root)?;
-    let name = format!("{source}.lock");
     let path = root.join(".awr/mutations").join(&name);
     if directory
         .symlink_metadata(&name)
@@ -92,7 +101,7 @@ fn source_lock(root: &Path, source: Id) -> Result<SourceLock> {
     })?;
     Ok(SourceLock(file))
 }
-fn new_file(directory: &Dir, name: &OsStr) -> Result<File> {
+pub(crate) fn new_file(directory: &Dir, name: &OsStr) -> Result<File> {
     let mut options = OpenOptions::new();
     options.create_new(true).write(true);
     #[cfg(unix)]
@@ -190,13 +199,13 @@ fn stored_after(root: &Path, plan: &MutationWritePlan) -> Result<Vec<u8>> {
 
 /// Hold one approved source directory for temp creation, replacement and cleanup.
 /// Domain fingerprint/revision checks still run immediately before install.
-struct SourceReplacement {
+pub(crate) struct SourceReplacement {
     directory: Dir,
     name: OsString,
     temp: Option<OsString>,
 }
 impl SourceReplacement {
-    fn prepare(path: &Path, bytes: &[u8], permissions: fs::Permissions) -> Result<Self> {
+    pub(crate) fn prepare(path: &Path, bytes: &[u8], permissions: fs::Permissions) -> Result<Self> {
         let directory = open_dir_exact(
             path.parent()
                 .ok_or_else(|| Error::InvalidInput("source has no parent".into()))?,
@@ -215,7 +224,7 @@ impl SourceReplacement {
         write_file(file, bytes, Some(permissions))?;
         Ok(replacement)
     }
-    fn install(&mut self) -> Result<()> {
+    pub(crate) fn install(&mut self) -> Result<()> {
         let temp = self.temp.as_ref().ok_or_else(|| {
             Error::InvalidTransition("source replacement was already installed".into())
         })?;

--- a/crates/awr-runtime/src/work_create.rs
+++ b/crates/awr-runtime/src/work_create.rs
@@ -1,0 +1,458 @@
+//! Source-backed draft creation; a request owns one durable single-file outcome.
+use crate::mutation_apply::{
+    SourceReplacement, directory, named_lock, new_file, recovery_root, source_lock,
+};
+use awr_core::*;
+use awr_source::{
+    Manifest, SourceSnapshot, fingerprint, index_project, inspect_registered_source,
+    open_file_exact, prepare_work_creation,
+};
+use awr_store::Store;
+use cap_std::fs::Dir;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    ffi::OsStr,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CreateWorkInput {
+    pub version: u32,
+    pub request_key: String,
+    pub title: String,
+    #[serde(default)]
+    pub source_id: Option<Id>,
+}
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Plan {
+    version: u32,
+    project_id: Id,
+    project_root: PathBuf,
+    project_revision: Revision,
+    request: CreateWorkInput,
+    source: Source,
+    external_key: String,
+    before_fingerprint: String,
+    after_fingerprint: String,
+}
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Receipt {
+    plan: Plan,
+    preview_fingerprint: String,
+    phase: String,
+    work_id: Option<Id>,
+    project_revision: Revision,
+}
+pub struct CreationReport {
+    pub value: Value,
+    pub failure: Option<Error>,
+}
+
+fn validate_key(key: &str) -> Result<()> {
+    if key.trim().is_empty() || key.len() > 512 || key.chars().any(char::is_control) {
+        return Err(Error::InvalidInput(
+            "request_key requires 1..512 bytes without control characters".into(),
+        ));
+    }
+    ensure_public_text(key)
+}
+fn identity(project: Id, key: &str) -> Result<String> {
+    validate_key(key)?;
+    Ok(fingerprint(&serde_json::to_vec(&(project, key))?)
+        .trim_start_matches("sha256:")
+        .into())
+}
+fn receipt_name(project: Id, key: &str) -> Result<String> {
+    Ok(format!("work-create-{}", identity(project, key)?))
+}
+fn read(path: &Path, cap: u64) -> Result<Vec<u8>> {
+    let file = open_file_exact(path)?;
+    if !file.metadata()?.is_file() || file.metadata()?.len() > cap {
+        return Err(Error::InvalidInput(
+            "invalid or oversized creation recovery file".into(),
+        ));
+    }
+    let mut bytes = Vec::new();
+    file.take(cap + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > cap {
+        return Err(Error::InvalidInput(
+            "creation recovery file grew beyond its bound".into(),
+        ));
+    }
+    Ok(bytes)
+}
+fn load(root: &Path, project: Id, key: &str) -> Result<Option<Receipt>> {
+    let base = root
+        .join(".awr/mutations")
+        .join(receipt_name(project, key)?);
+    match std::fs::symlink_metadata(&base) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+        Ok(m) if m.file_type().is_symlink() || !m.is_dir() => {
+            return Err(Error::RuleViolation(
+                "creation recovery directory must be real".into(),
+            ));
+        }
+        _ => (),
+    }
+    let value: Receipt = serde_json::from_slice(&read(&base.join("receipt.json"), 128 * 1024)?)?;
+    if value.plan.version != 1
+        || value.plan.request.version != 1
+        || !["prepared", "applied", "completed"].contains(&value.phase.as_str())
+    {
+        return Err(Error::InvalidInput(
+            "unsupported creation receipt version or phase".into(),
+        ));
+    }
+    if value.plan.project_id != project
+        || value.plan.project_root != root
+        || value.plan.request.request_key != key
+        || fingerprint(&serde_json::to_vec(&value.plan)?) != value.preview_fingerprint
+    {
+        return Err(Error::SourceConflict(
+            "creation receipt differs from its bound project or plan".into(),
+        ));
+    }
+    Ok(Some(value))
+}
+fn save(dir: &Dir, receipt: &Receipt) -> Result<()> {
+    let temp = format!("receipt-{}.tmp", Id::new());
+    let mut file = new_file(dir, OsStr::new(&temp))?;
+    file.write_all(&serde_json::to_vec_pretty(receipt)?)?;
+    file.sync_all()?;
+    drop(file);
+    dir.rename(&temp, dir, "receipt.json")?;
+    crate::fs_sync::sync_directory(dir)
+}
+fn summary(receipt: &Receipt, replay: bool) -> Result<Value> {
+    Ok(
+        json!({"ok":receipt.phase=="completed","status":if receipt.phase=="completed"{"completed"}else{"pending_recovery"},
+        "request_key":receipt.plan.request.request_key,"external_key":receipt.plan.external_key,"work_id":receipt.work_id,
+        "project_id":receipt.plan.project_id,"project_revision":receipt.project_revision,"source_id":receipt.plan.source.id,
+        "preview_fingerprint":receipt.preview_fingerprint,"phase":receipt.phase,"already_recorded":replay,
+        "source_write_performed":false,"runtime_write_performed":false,"historical_outcome":true,
+        "write_outcome":if receipt.phase=="completed"{"applied"}else{"pending_recovery"},
+        "draft":true,"completion_claimed":false,
+        "recovery_directory":format!(".awr/mutations/{}",receipt_name(receipt.plan.project_id,&receipt.plan.request.request_key)?)}),
+    )
+}
+pub fn creation_status(store: &Store, root: &Path, key: &str) -> Result<CreationReport> {
+    let root = root.canonicalize()?;
+    let project = store.project_by_root(&root)?;
+    let receipt = load(&root, project.id, key)?;
+    let value = if let Some(r) = receipt {
+        let mut value = summary(&r, true)?;
+        value["found"] = json!(true);
+        value["read_only"] = json!(true);
+        value["current_source"] = json!(match inspect_registered_source(&root, &r.plan.source) {
+            Ok((_, _, s)) if s.fingerprint == r.plan.after_fingerprint => "after",
+            Ok((_, _, s)) if s.fingerprint == r.plan.before_fingerprint => "before",
+            Ok(_) => "externally_changed",
+            Err(_) => "unavailable_or_registration_changed",
+        });
+        value
+    } else {
+        json!({"ok":true,"found":false,"read_only":true,"source_write_performed":false,"runtime_write_performed":false})
+    };
+    Ok(CreationReport {
+        value,
+        failure: None,
+    })
+}
+
+pub fn create_work(
+    store: &mut Store,
+    root: &Path,
+    input: CreateWorkInput,
+    accept: bool,
+    expected_preview: Option<&str>,
+    expected_revision: Option<Revision>,
+) -> Result<CreationReport> {
+    let root = root.canonicalize()?;
+    let project = store.project_by_root(&root)?;
+    validate_key(&input.request_key)?;
+    ensure_public_data(&input)?;
+    if input.version != 1
+        || input.title.trim().is_empty()
+        || input.title.len() > 4096
+        || input.title.chars().any(char::is_control)
+    {
+        return Err(Error::InvalidInput(
+            "creation requires version 1 and a 1..4096 byte title without control characters"
+                .into(),
+        ));
+    }
+    let key = identity(project.id, &input.request_key)?;
+    let _request_lock = if accept {
+        Some(named_lock(&root, &format!("work-create-{key}.lock"))?)
+    } else {
+        None
+    };
+    if let Some(receipt) = load(&root, project.id, &input.request_key)? {
+        if receipt.plan.request != input {
+            return Err(Error::SourceConflict(
+                "request_key already belongs to different creation content".into(),
+            ));
+        }
+        return Ok(CreationReport {
+            value: summary(&receipt, true)?,
+            failure: (receipt.phase!="completed").then(||Error::MutationConflict("creation is pending; inspect its receipt and explicitly recover instead of replaying".into())),
+        });
+    }
+    let manifest = Manifest::load(&root)?;
+    let report = index_project(store, &root, &manifest, false)?;
+    if !report.ok {
+        return Err(Error::SourceStale(
+            "refresh every registered source before creating work".into(),
+        ));
+    }
+    let revision = store.project(project.id)?.project_revision;
+    if let Some(expected) = expected_revision
+        && expected != revision
+    {
+        return Err(Error::RevisionConflict {
+            expected,
+            actual: revision,
+        });
+    }
+    let sources = store.sources(project.id)?;
+    let candidates: Vec<_> = sources
+        .into_iter()
+        .filter(|s| {
+            s.domain == "ledger" && input.source_id.map_or(s.role == "primary", |id| s.id == id)
+        })
+        .collect();
+    if candidates.len() != 1 {
+        return Err(Error::SourceConflict(
+            "choose exactly one registered ledger source for creation".into(),
+        ));
+    }
+    let source = candidates.into_iter().next().unwrap();
+    let _source_lock = if accept {
+        Some(source_lock(&root, source.id)?)
+    } else {
+        None
+    };
+    let external_key = format!("WORK-{}", &key[..32]);
+    if store
+        .work_items(project.id)?
+        .iter()
+        .any(|w| w.item.meta.external_key == external_key)
+    {
+        return Err(Error::SourceConflict(
+            "generated work key already exists; inspect its source instead of overwriting".into(),
+        ));
+    }
+    let prepared = prepare_work_creation(&root, &source, &external_key, &input.title)?;
+    let plan = Plan {
+        version: 1,
+        project_id: project.id,
+        project_root: root.clone(),
+        project_revision: revision,
+        request: input,
+        source,
+        external_key,
+        before_fingerprint: prepared.before.fingerprint.clone(),
+        after_fingerprint: prepared.after.fingerprint.clone(),
+    };
+    let preview = fingerprint(&serde_json::to_vec(&plan)?);
+    if !accept {
+        return Ok(CreationReport {
+            value: json!({"ok":true,"status":"preview","project_revision":revision,"requires_accept":true,
+            "preview":{"fingerprint":preview,"plan":plan,"before_text":prepared.before.text()?,"after_text":prepared.after.text()?,"new_record":prepared.record},
+            "source_write_performed":false,"runtime_write_performed":true,"draft":true,"completion_claimed":false}),
+            failure: None,
+        });
+    }
+    if expected_revision.is_none() || expected_preview != Some(preview.as_str()) {
+        return Err(Error::SourceConflict(
+            "creation accept requires the exact reviewed preview and project revision".into(),
+        ));
+    }
+    let mutations = recovery_root(&root)?;
+    let name = receipt_name(project.id, &plan.request.request_key)?;
+    mutations.create_dir(&name)?;
+    let dir = directory(&mutations, &name, &root.join(".awr/mutations").join(&name))?;
+    for (name, bytes) in [
+        ("before.yaml", &prepared.before.bytes),
+        ("after.yaml", &prepared.after.bytes),
+    ] {
+        let mut file = new_file(&dir, OsStr::new(name))?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+    }
+    let mut receipt = Receipt {
+        plan,
+        preview_fingerprint: preview,
+        phase: "prepared".into(),
+        work_id: None,
+        project_revision: revision,
+    };
+    save(&dir, &receipt)?;
+    crate::fs_sync::sync_directory(&mutations)?;
+    finish(store, &root, &dir, &mut receipt, expected_revision.unwrap())
+}
+
+pub fn recover_creation(
+    store: &mut Store,
+    root: &Path,
+    key: &str,
+    expected_revision: Revision,
+) -> Result<CreationReport> {
+    let root = root.canonicalize()?;
+    let project = store.project_by_root(&root)?;
+    let _request_lock = named_lock(
+        &root,
+        &format!("work-create-{}.lock", identity(project.id, key)?),
+    )?;
+    let mut receipt =
+        load(&root, project.id, key)?.ok_or_else(|| Error::NotFound("creation receipt".into()))?;
+    if receipt.phase == "completed" {
+        return Ok(CreationReport {
+            value: summary(&receipt, true)?,
+            failure: None,
+        });
+    }
+    let _source_lock = source_lock(&root, receipt.plan.source.id)?;
+    let dir = awr_source::open_dir_exact(
+        &root
+            .join(".awr/mutations")
+            .join(receipt_name(project.id, key)?),
+    )?;
+    finish(store, &root, &dir, &mut receipt, expected_revision)
+}
+fn finish(
+    store: &mut Store,
+    root: &Path,
+    dir: &Dir,
+    receipt: &mut Receipt,
+    expected: Revision,
+) -> Result<CreationReport> {
+    let mut wrote = false;
+    let mut index_report = None;
+    let result = (|| -> Result<()> {
+        let actual = store.project(receipt.plan.project_id)?.project_revision;
+        if actual != expected {
+            return Err(Error::RevisionConflict { expected, actual });
+        }
+        let plan = &receipt.plan;
+        let base = root
+            .join(".awr/mutations")
+            .join(receipt_name(plan.project_id, &plan.request.request_key)?);
+        let before = read(&base.join("before.yaml"), awr_source::YAML_READ_CAP)?;
+        let after = read(&base.join("after.yaml"), awr_source::YAML_READ_CAP)?;
+        if fingerprint(&before) != plan.before_fingerprint
+            || fingerprint(&after) != plan.after_fingerprint
+        {
+            return Err(Error::SourceConflict(
+                "creation snapshots differ from the reviewed plan".into(),
+            ));
+        }
+        let (locator, spec, current) = inspect_registered_source(root, &plan.source)?;
+        let awr_source::Locator::File(path) = locator else {
+            return Err(Error::MutationUnsupported(
+                "creation cannot write Git sources".into(),
+            ));
+        };
+        if current.fingerprint != plan.before_fingerprint
+            && current.fingerprint != plan.after_fingerprint
+        {
+            return Err(Error::SourceConflict(
+                "creation recovery retains externally changed source bytes".into(),
+            ));
+        }
+        // Recovery also reparses its immutable after snapshot through the registered adapter.
+        use awr_source::SourceAdapter;
+        awr_source::YamlLedgerAdapter.parse(
+            &SourceSnapshot {
+                locator: current.locator.clone(),
+                bytes: after.clone(),
+                fingerprint: plan.after_fingerprint.clone(),
+            },
+            &awr_source::ParseContext {
+                source: &plan.source,
+                existing_ids: store.projection_ids(&plan.source)?,
+            },
+            &spec,
+        )?;
+        if current.fingerprint == plan.before_fingerprint {
+            let permissions = open_file_exact(&path)?.metadata()?.permissions();
+            if permissions.readonly() {
+                return Err(Error::RuleViolation("ledger is read-only".into()));
+            }
+            let mut replacement = SourceReplacement::prepare(&path, &after, permissions)?;
+            let (_, _, last) = inspect_registered_source(root, &plan.source)?;
+            if last.fingerprint != plan.before_fingerprint {
+                return Err(Error::SourceConflict(
+                    "ledger changed immediately before creation write".into(),
+                ));
+            }
+            let actual = store.project(plan.project_id)?.project_revision;
+            if actual != expected {
+                return Err(Error::RevisionConflict { expected, actual });
+            }
+            replacement.install()?;
+            wrote = true;
+        }
+        receipt.phase = "applied".into();
+        save(dir, receipt)?;
+        let indexed = index_project(store, root, &Manifest::load(root)?, false)?;
+        index_report = Some(serde_json::to_value(&indexed)?);
+        receipt.project_revision = indexed.project_revision;
+        if !indexed.ok {
+            return Err(Error::SourceStale(
+                "creation source applied but project projection is incomplete".into(),
+            ));
+        }
+        let work = store
+            .work_items(plan.project_id)?
+            .into_iter()
+            .find(|w| w.item.meta.external_key == plan.external_key)
+            .ok_or_else(|| {
+                Error::SourceConflict("created work is absent from its projection".into())
+            })?;
+        if work.source.id != plan.source.id
+            || work.source.fingerprint != plan.after_fingerprint
+            || work.item.title != plan.request.title
+        {
+            return Err(Error::SourceConflict(
+                "created work differs from the reviewed source identity".into(),
+            ));
+        }
+        let (_, _, last) = inspect_registered_source(root, &plan.source)?;
+        if last.fingerprint != plan.after_fingerprint {
+            return Err(Error::SourceConflict(
+                "ledger changed before creation finalization".into(),
+            ));
+        }
+        receipt.work_id = Some(work.item.meta.id);
+        receipt.phase = "completed".into();
+        save(dir, receipt)
+    })();
+    let mut value = summary(receipt, false)?;
+    value["source_write_performed"] = json!(wrote);
+    value["runtime_write_performed"] = json!(true);
+    value["historical_outcome"] = json!(false);
+    if let Some(report) = index_report {
+        value["index"] = report;
+    }
+    if let Err(error) = result {
+        value["ok"] = json!(false);
+        value["status"] = json!("pending_recovery");
+        value["write_outcome"] = json!("pending_recovery");
+        value["error"] = serde_json::to_value(error.report())?;
+        return Ok(CreationReport {
+            value,
+            failure: Some(error),
+        });
+    }
+    Ok(CreationReport {
+        value,
+        failure: None,
+    })
+}

--- a/crates/awr-source/src/ledger_mapping.rs
+++ b/crates/awr-source/src/ledger_mapping.rs
@@ -98,7 +98,9 @@ impl LedgerMapping {
                 || raw != raw.trim()
                 || raw.chars().any(char::is_control)
                 || status == WorkStatus::Unknown
-                || (existing != WorkStatus::Unknown && existing != status)
+                // Before draft became a built-in nonselectable state, projects could
+                // explicitly map that source spelling. Retain those prior mappings.
+                || (existing != WorkStatus::Unknown && existing != WorkStatus::Draft && existing != status)
                 || !keys.insert(key)
             {
                 return Err(Error::InvalidInput("status_map requires unique source statuses and canonical targets; canonical states cannot be redefined".into()));

--- a/crates/awr-source/src/lib.rs
+++ b/crates/awr-source/src/lib.rs
@@ -10,6 +10,7 @@ mod manifest;
 mod markdown;
 mod markdown_ledger;
 mod mutation;
+mod yaml_create;
 mod yaml_edit;
 mod yaml_ledger;
 mod yaml_mutation;
@@ -33,8 +34,11 @@ pub use markdown::{
     MarkdownHeadingAdapter, MarkdownRulesAdapter, MarkdownSection, markdown_sections,
 };
 pub use markdown_ledger::MarkdownLedgerAdapter;
-pub use mutation::{MutationSourceCheck, inspect_mutation_source, verify_mutation_source};
+pub use mutation::{
+    MutationSourceCheck, inspect_mutation_source, inspect_registered_source, verify_mutation_source,
+};
 pub use safe_fs::{open_dir_exact, open_file_exact};
+pub use yaml_create::{PreparedWorkCreation, prepare_work_creation};
 pub use yaml_ledger::YamlLedgerAdapter;
 pub use yaml_mutation::{
     PreparedYamlMutation, parse_mutation_projection, prepare_yaml_mutation,

--- a/crates/awr-source/src/mutation.rs
+++ b/crates/awr-source/src/mutation.rs
@@ -67,6 +67,19 @@ pub fn inspect_mutation_source(
             "mutation source identity/configuration differs from its binding".into(),
         ));
     }
+    let (locator, spec, snapshot) = inspect_registered_source(root, source)?;
+    if snapshot.locator != patch.target.meta.source_ref.locator {
+        return Err(Error::SourceConflict("proposal source bytes or immutable locator changed; keep the proposal for review and create a new one from current facts".into()));
+    }
+    Ok((locator, spec, snapshot))
+}
+
+/// Resolve exactly one currently registered source, retaining its bound configuration.
+/// This is a read-only observation; writers must hold their source lock and recheck bytes.
+pub fn inspect_registered_source(
+    root: &Path,
+    source: &Source,
+) -> Result<(Locator, SourceSpec, SourceSnapshot)> {
     let root = root.canonicalize()?;
     let manifest = Manifest::load(&root)?;
     let mut matches = Vec::new();
@@ -91,9 +104,7 @@ pub fn inspect_mutation_source(
                 spec,
                 manifest.project.context_profile == crate::ContextProfile::Minimal,
             );
-            if source.adapter != spec.adapter
-                || source.role != spec.role
-                || config != patch.source_config
+            if source.adapter != spec.adapter || source.role != spec.role || config != source.config
             {
                 return Err(Error::SourceConflict(
                     "proposal source mapping or adapter configuration has changed".into(),
@@ -110,8 +121,5 @@ pub fn inspect_mutation_source(
     }
     let (locator, spec) = matches.pop().unwrap();
     let snapshot = locator.read(&root, crate::source_read_cap(&spec.adapter)?)?;
-    if snapshot.locator != patch.target.meta.source_ref.locator {
-        return Err(Error::SourceConflict("proposal source bytes or immutable locator changed; keep the proposal for review and create a new one from current facts".into()));
-    }
     Ok((locator, spec, snapshot))
 }

--- a/crates/awr-source/src/yaml_create.rs
+++ b/crates/awr-source/src/yaml_create.rs
@@ -1,0 +1,124 @@
+use crate::{
+    LedgerMapping, Locator, ParseContext, SourceAdapter, SourceSnapshot, YamlLedgerAdapter,
+    fingerprint, inspect_registered_source,
+};
+use awr_core::*;
+use serde_json::{Value, json};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+pub struct PreparedWorkCreation {
+    pub path: PathBuf,
+    pub before: SourceSnapshot,
+    pub after: SourceSnapshot,
+    pub record: Value,
+}
+
+pub fn prepare_work_creation(
+    root: &Path,
+    source: &Source,
+    external_key: &str,
+    title: &str,
+) -> Result<PreparedWorkCreation> {
+    if source.adapter != "yaml-ledger-v1" || source.domain != "ledger" {
+        return Err(Error::MutationUnsupported(
+            "new work requires a registered YAML ledger".into(),
+        ));
+    }
+    if source.freshness != Freshness::Fresh {
+        return Err(Error::SourceStale(
+            "refresh the ledger before creating work".into(),
+        ));
+    }
+    let (locator, spec, before) = inspect_registered_source(root, source)?;
+    let Locator::File(path) = locator else {
+        return Err(Error::MutationUnsupported(
+            "Git sources remain read-only".into(),
+        ));
+    };
+    if path.starts_with(root.canonicalize()?.join(".awr")) {
+        return Err(Error::RuleViolation(
+            "runtime files cannot be task sources".into(),
+        ));
+    }
+    if before.fingerprint != source.fingerprint {
+        return Err(Error::SourceConflict(
+            "ledger changed before preparing new work".into(),
+        ));
+    }
+    let mapping = LedgerMapping::from_spec(&spec)?;
+    let fields = vec![
+        (mapping.source_field("id").to_owned(), json!(external_key)),
+        (mapping.source_field("title").to_owned(), json!(title)),
+        (
+            mapping.source_field("status").to_owned(),
+            mapping.write_value("status", &json!("draft"), &json!({}))?,
+        ),
+    ];
+    let record = Value::Object(fields.iter().cloned().collect());
+    let mut expected: Value = serde_yaml_ng::from_str(before.text()?)
+        .map_err(|_| Error::InvalidInput("invalid YAML ledger".into()))?;
+    match expected.get_mut("work_items") {
+        Some(Value::Array(items)) => items.push(record.clone()),
+        Some(Value::Object(items)) => {
+            if items.insert(external_key.into(), record.clone()).is_some() {
+                return Err(Error::SourceConflict("new task key already exists".into()));
+            }
+        }
+        _ => {
+            return Err(Error::MutationUnsupported(
+                "work_items requires an explicit list or keyed map".into(),
+            ));
+        }
+    }
+    let output = crate::yaml_edit::append_work(before.text()?, external_key, &fields)?;
+    crate::limits::check_source_size(output.as_bytes(), crate::YAML_READ_CAP)?;
+    let actual: Value = serde_yaml_ng::from_str(&output).map_err(|_| {
+        Error::MutationUnsupported("new record cannot preserve this YAML shape".into())
+    })?;
+    if actual != expected {
+        return Err(Error::MutationUnsupported(
+            "creation changed facts outside the new record".into(),
+        ));
+    }
+    let after = SourceSnapshot {
+        locator: before.locator.clone(),
+        fingerprint: fingerprint(output.as_bytes()),
+        bytes: output.into_bytes(),
+    };
+    // Parsing catches duplicate list keys, mapping conflicts and malformed domain fields.
+    let batch = YamlLedgerAdapter.parse(
+        &after,
+        &ParseContext {
+            source,
+            existing_ids: BTreeMap::new(),
+        },
+        &spec,
+    )?;
+    if batch
+        .work_items
+        .iter()
+        .filter(|w| w.meta.external_key == external_key)
+        .count()
+        != 1
+    {
+        return Err(Error::SourceConflict(
+            "new task must have exactly one source identity".into(),
+        ));
+    }
+    if batch
+        .work_items
+        .iter()
+        .any(|w| w.meta.external_key == external_key && w.status != WorkStatus::Draft)
+    {
+        return Err(Error::MutationUnsupported("the source maps draft to an executable state; configure one unambiguous draft spelling before creation".into()));
+    }
+    Ok(PreparedWorkCreation {
+        path,
+        before,
+        after,
+        record,
+    })
+}

--- a/crates/awr-source/src/yaml_edit.rs
+++ b/crates/awr-source/src/yaml_edit.rs
@@ -426,11 +426,7 @@ fn render(text: &str, node: &Node, value: &Value, newline: &str) -> Result<Strin
     }
 }
 
-pub(crate) fn edit_fields(
-    text: &str,
-    pointer: &str,
-    changes: &Map<String, Value>,
-) -> Result<String> {
+fn parse_tree(text: &str) -> Result<Node> {
     let offsets = text
         .char_indices()
         .map(|(i, _)| i)
@@ -451,6 +447,15 @@ pub(crate) fn edit_fields(
             "multiple YAML documents require manual editing",
         ));
     }
+    Ok(root)
+}
+
+pub(crate) fn edit_fields(
+    text: &str,
+    pointer: &str,
+    changes: &Map<String, Value>,
+) -> Result<String> {
+    let root = parse_tree(text)?;
     let mut target = &root;
     for part in pointer
         .strip_prefix('/')
@@ -526,5 +531,108 @@ pub(crate) fn edit_fields(
         boundary = range.start;
         output.replace_range(range, &replacement);
     }
+    Ok(output)
+}
+
+/// Append one record without serializing any existing record or renumbering keys.
+pub(crate) fn append_work(text: &str, key: &str, fields: &[(String, Value)]) -> Result<String> {
+    let root = parse_tree(text)?;
+    let Kind::Mapping(root_fields, ..) = &root.kind else {
+        return Err(unsupported("work creation needs a mapping document"));
+    };
+    let (_, collection) = root_fields
+        .iter()
+        .find(|(k, _)| k == "work_items")
+        .ok_or_else(|| {
+            unsupported("register a YAML ledger with an explicit work_items list or map")
+        })?;
+    let newline = if text.contains("\r\n") { "\r\n" } else { "\n" };
+    let record = Value::Object(fields.iter().cloned().collect());
+    let (at, addition) = match &collection.kind {
+        Kind::Sequence(items) if text[collection.range.start..].starts_with('[') => (
+            collection.range.end - 1,
+            format!(
+                "{}{}",
+                if items.is_empty() { "" } else { ", " },
+                json(&record)?
+            ),
+        ),
+        Kind::Sequence(items) => {
+            let first = items
+                .first()
+                .ok_or_else(|| unsupported("empty block sequences require explicit [] syntax"))?;
+            let line = text[..first.range.start].rfind('\n').map_or(0, |i| i + 1);
+            let dash = text[line..line_end(text, line)]
+                .find('-')
+                .map(|i| line + i)
+                .ok_or_else(|| unsupported("could not locate the ledger list indentation"))?;
+            if !text[line..dash].trim().is_empty() {
+                return Err(unsupported("unsupported compact ledger nesting"));
+            }
+            let indent = column(text, dash);
+            let at = if text[..collection.range.end].ends_with('\n') {
+                collection.range.end
+            } else {
+                line_end(text, collection.range.end)
+            };
+            let mut addition = if text[..at].ends_with('\n') {
+                String::new()
+            } else {
+                newline.into()
+            };
+            for (i, (field, value)) in fields.iter().enumerate() {
+                addition += &format!(
+                    "{}{}{}: {}{newline}",
+                    " ".repeat(indent),
+                    if i == 0 { "- " } else { "  " },
+                    json(&Value::String(field.clone()))?,
+                    json(value)?
+                );
+            }
+            (at, addition)
+        }
+        Kind::Mapping(items, true, _) => (
+            collection.range.end - 1,
+            format!(
+                "{}{}: {}",
+                if items.is_empty() { "" } else { ", " },
+                json(&Value::String(key.into()))?,
+                json(&record)?
+            ),
+        ),
+        Kind::Mapping(_, false, indent) => {
+            let at = if text[..collection.range.end].ends_with('\n') {
+                collection.range.end
+            } else {
+                line_end(text, collection.range.end)
+            };
+            let mut addition = if text[..at].ends_with('\n') {
+                String::new()
+            } else {
+                newline.into()
+            };
+            addition += &format!(
+                "{}{}:{newline}",
+                " ".repeat(*indent),
+                json(&Value::String(key.into()))?
+            );
+            for (field, value) in fields {
+                addition += &format!(
+                    "{}{}: {}{newline}",
+                    " ".repeat(*indent + 2),
+                    json(&Value::String(field.clone()))?,
+                    json(value)?
+                );
+            }
+            (at, addition)
+        }
+        _ => {
+            return Err(unsupported(
+                "work_items must be an explicit list or keyed map",
+            ));
+        }
+    };
+    let mut output = text.to_owned();
+    output.insert_str(at, &addition);
     Ok(output)
 }

--- a/crates/awr-store/migrations/004_draft_work.sql
+++ b/crates/awr-store/migrations/004_draft_work.sql
@@ -1,0 +1,36 @@
+-- Rebuild only the work status constraint; IDs and all existing rows are retained.
+CREATE TABLE work_items_v4 (
+ id TEXT PRIMARY KEY CHECK(length(id)=26),
+ project_id TEXT NOT NULL REFERENCES projects(id),
+ external_key TEXT NOT NULL,
+ title TEXT NOT NULL DEFAULT '',
+ source_id TEXT NOT NULL,
+ source_ref_json TEXT NOT NULL CHECK(json_valid(source_ref_json)),
+ source_revision INTEGER NOT NULL CHECK(source_revision>=0),
+ revision INTEGER NOT NULL CHECK(revision>0),
+ active INTEGER NOT NULL DEFAULT 1 CHECK(active IN (0,1)),
+ payload_json TEXT NOT NULL CHECK(json_valid(payload_json)),
+ updated_at INTEGER NOT NULL,
+ kind TEXT,
+ required INTEGER NOT NULL DEFAULT 0 CHECK(required IN (0,1)),
+ raw_status TEXT NOT NULL,
+ status TEXT NOT NULL CHECK(status IN ('draft','planned','ready','claimed','in_progress','blocked','completed','cancelled','unknown')),
+ priority TEXT,
+ milestone TEXT,
+ score INTEGER,
+ evidence_level TEXT,
+ summary TEXT NOT NULL DEFAULT '',
+ next_action TEXT NOT NULL DEFAULT '',
+ blocker TEXT,
+ acceptance_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(acceptance_json)),
+ tags_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(tags_json)),
+ paths_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(paths_json)),
+ UNIQUE(project_id,external_key),
+ UNIQUE(project_id,id),
+ FOREIGN KEY(project_id,source_id) REFERENCES sources(project_id,id)
+) STRICT;
+INSERT INTO work_items_v4 SELECT * FROM work_items;
+DROP TABLE work_items;
+ALTER TABLE work_items_v4 RENAME TO work_items;
+CREATE INDEX work_items_source ON work_items(project_id,source_id,active);
+CREATE INDEX work_status ON work_items(project_id,status,active,priority);

--- a/crates/awr-store/src/lib.rs
+++ b/crates/awr-store/src/lib.rs
@@ -43,10 +43,11 @@ use std::{path::Path, time::Duration};
 
 const APPLICATION_ID: i64 = 0x41575231;
 /// Schema written by this build. Exposed for offline host compatibility negotiation.
-pub const SCHEMA_VERSION: i64 = 3;
+pub const SCHEMA_VERSION: i64 = 4;
 const CATALOG_SQL: &str = include_str!("../migrations/001_catalog.sql");
 const DOMAIN_SQL: &str = include_str!("../migrations/002_domain.sql");
 const SEARCH_SQL: &str = include_str!("../migrations/003_search.sql");
+const DRAFT_WORK_SQL: &str = include_str!("../migrations/004_draft_work.sql");
 
 /// Domain operations own database writes; no SQL handle is exposed to callers.
 ///
@@ -239,6 +240,12 @@ impl Store {
             }
         }
         if current < SCHEMA_VERSION {
+            // SQLite table rebuild protocol: suppress FK actions only on this unexposed
+            // connection, then check all references before committing and restore enforcement.
+            conn.pragma_update(None, "foreign_keys", false)
+                .map_err(db_error)?;
+            conn.pragma_update(None, "legacy_alter_table", true)
+                .map_err(db_error)?;
             let tx = conn
                 .transaction_with_behavior(TransactionBehavior::Immediate)
                 .map_err(db_error)?;
@@ -276,10 +283,34 @@ impl Store {
                 )
                 .map_err(db_error)?;
             }
+            if version < 4 {
+                // Preserve user diagnostic indexes/triggers as well as owned schema objects.
+                let extras:Vec<String> = tx.prepare("SELECT sql FROM sqlite_master WHERE tbl_name='work_items' AND type IN ('index','trigger') AND sql IS NOT NULL AND name NOT IN ('work_items_source','work_status') ORDER BY name").map_err(db_error)?
+                    .query_map([],|row|row.get(0)).map_err(db_error)?.collect::<rusqlite::Result<_>>().map_err(db_error)?;
+                tx.execute_batch(DRAFT_WORK_SQL).map_err(db_error)?;
+                for sql in extras {
+                    tx.execute_batch(&sql).map_err(db_error)?;
+                }
+                tx.execute("INSERT INTO schema_migrations(version,name,applied_at) VALUES(4,'draft_work',?1)",[now_millis()?]).map_err(db_error)?;
+            }
             tx.pragma_update(None, "user_version", SCHEMA_VERSION)
                 .map_err(db_error)?;
             schema::verify(&tx, SCHEMA_VERSION)?;
+            if tx
+                .prepare("PRAGMA foreign_key_check")
+                .map_err(db_error)?
+                .exists([])
+                .map_err(db_error)?
+            {
+                return Err(Error::Storage(
+                    "migration would leave invalid foreign-key references".into(),
+                ));
+            }
             tx.commit().map_err(db_error)?;
+            conn.pragma_update(None, "legacy_alter_table", false)
+                .map_err(db_error)?;
+            conn.pragma_update(None, "foreign_keys", true)
+                .map_err(db_error)?;
         }
         let store = Self { conn };
         store.verify_catalog()?;

--- a/crates/awr-store/src/schema.rs
+++ b/crates/awr-store/src/schema.rs
@@ -1,5 +1,7 @@
 //! Validate the owned schema against the shipped migrations without repairing it.
-use crate::{CATALOG_SQL, DOMAIN_SQL, MigrationInfo, SCHEMA_VERSION, SEARCH_SQL, db_error};
+use crate::{
+    CATALOG_SQL, DOMAIN_SQL, DRAFT_WORK_SQL, MigrationInfo, SCHEMA_VERSION, SEARCH_SQL, db_error,
+};
 use awr_core::{Error, Result};
 use rusqlite::Connection;
 use std::{collections::BTreeMap, sync::OnceLock};
@@ -7,7 +9,7 @@ use std::{collections::BTreeMap, sync::OnceLock};
 type Definition = (String, String, String);
 type Objects = BTreeMap<String, Definition>;
 static EXPECTED: OnceLock<std::result::Result<Vec<Objects>, String>> = OnceLock::new();
-const MIGRATION_NAMES: [&str; 3] = ["catalog", "domain", "search"];
+const MIGRATION_NAMES: [&str; 4] = ["catalog", "domain", "search", "draft_work"];
 
 fn objects(conn: &Connection) -> rusqlite::Result<Objects> {
     conn.prepare("SELECT name,type,tbl_name,sql FROM sqlite_master WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%' ORDER BY name")?
@@ -20,8 +22,9 @@ fn expected() -> Result<&'static Vec<Objects>> {
         .get_or_init(|| {
             let build = || -> rusqlite::Result<Vec<Objects>> {
                 let conn = Connection::open_in_memory()?;
+                conn.pragma_update(None, "legacy_alter_table", true)?;
                 let mut versions = Vec::new();
-                for sql in [CATALOG_SQL, DOMAIN_SQL, SEARCH_SQL] {
+                for sql in [CATALOG_SQL, DOMAIN_SQL, SEARCH_SQL, DRAFT_WORK_SQL] {
                     conn.execute_batch(sql)?;
                     versions.push(objects(&conn)?);
                 }

--- a/crates/awr-store/tests/search.rs
+++ b/crates/awr-store/tests/search.rs
@@ -120,7 +120,10 @@ fn fts_and_structured_filters_return_ranked_versioned_summaries() {
     f.store.retire_source(&f.source).unwrap();
     assert!(search(&mut f, "依赖").is_empty());
     assert!(f.store.doctor().unwrap().ok);
-    assert_eq!(f.store.doctor().unwrap().schema_version, 3);
+    assert_eq!(
+        f.store.doctor().unwrap().schema_version,
+        awr_store::SCHEMA_VERSION
+    );
 }
 
 #[test]

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -166,9 +166,52 @@ expected semantics and reparse through the source adapter. See the
 [YAML writer](../../adapters/yaml-ledger/README.md) for supported shapes.
 
 Markdown adapters currently read sources; they do not authorize Markdown body or ledger
-writes. Unsupported capabilities include human-save shortcuts, new tasks, multi-file
+writes. Unsupported capabilities include human-save shortcuts, multi-file
 writes and user-confirmed completion. Never route an unsupported operation through a
 generic status patch or a second writer.
+
+## Create a task with a stable request identity
+
+```text
+awr work create --title 'Prepare the travel checklist' --request-key <host-request-id> --json
+awr work create --title 'Prepare the travel checklist' --request-key <same-id> --accept --expected-preview <fingerprint> --expected-revision <preview-project-revision> --json
+awr work create-status --key <host-request-id> --json
+awr work create-recover --key <host-request-id> --expected-revision <current-project-revision> --json
+```
+
+Alternatively, `work create --input request.json` accepts protected JSON containing
+`version: 1`, `request_key`, `title` and optional `source_id`. Without an explicit source,
+exactly one primary ledger must be registered. Creation currently supports ordinary
+YAML lists and keyed maps, including flow/empty collections, configured field/status
+names and CRLF. Existing bytes and work IDs are retained; new block records use the
+existing indentation. Unsupported YAML forms fail before writing.
+
+The request ID belongs to one project and one exact creation payload. Its stable new
+`WORK-…` key is included in the preview. Acceptance binds the request, source mapping,
+source fingerprint, before/after text and project revision. Repeated identical requests
+return the recorded work ID and outcome, even with an old preview revision. Changed
+content under an existing key is a conflict. A busy concurrent writer may return
+`MutationConflict`; query the request before another attempt. A later source change
+does not authorize reusing the same request to create or restore another task.
+
+Only a title is needed from the user. The new source status is `draft` (or its explicit
+mapped spelling), with missing execution facts left missing. It is a draft, never
+automatically executable or completed. Draft is excluded from the execution queue; normal readiness/context/domain rules still
+apply. No session, runtime claim, model call or invented acceptance is created.
+
+Creation retains a plan and before/after snapshots in the ignored mutation directory,
+shares the existing source writer lock and atomic replacement primitive, and verifies
+the resulting projection. `phase` describes the creation request, not work completion.
+`source_write_performed`/`runtime_write_performed` describe this invocation; a replay's
+historical `write_outcome` is separate. Pending results require explicit recovery.
+Recovery only installs the reviewed after snapshot when current bytes match before,
+or finishes projection when they already match after. Other bytes or changed registrations
+are retained and reported as conflicts. Recovery never rolls back newer user edits.
+
+`create-status` is read-only and distinguishes its historical receipt from the current
+source observation (`before`, `after`, `externally_changed`, or unavailable/registration
+changed). A transport failure cannot be interpreted as unwritten. Read the same request
+key first; pending writes are never automatically repeated by the create command.
 
 `work complete` retains the engineering contract: a real session/claim and evidence
 covering the source's acceptance criteria at the supplied source SHA. A source's raw
@@ -337,6 +380,13 @@ Back up matching program version, original sources, manifest and SQLite runtime
 before an upgrade. Source projections are rebuildable; events and checkpoints are
 not reconstructed by reindexing source documents. A binary downgrade alone is not a
 database rollback procedure.
+
+This development build writes schema 4, which adds the non-executable `draft` work
+state. The transactional migration preserves existing rows and references, checks
+foreign keys, and retains additional indexes and triggers. Builds that only support
+schema 3 must reject this database; restore a matching database/program snapshot
+when rolling back. Newly created drafts need an explicit source declaration before
+execution; creation itself never supplies missing execution or completion facts.
 
 One project keeps one source ledger. When replacing an existing host writer, switch
 only operations AWR actually supports, retain old runtime history as history, and

--- a/tests/platform/native_cli.py
+++ b/tests/platform/native_cli.py
@@ -85,7 +85,7 @@ def main():
 
     with closing(sqlite3.connect(db_path.as_uri() + '?mode=ro', uri=True)) as db:
         require(db.execute('PRAGMA journal_mode').fetchone()[0] == 'wal', 'WAL is not active')
-        require(db.execute('PRAGMA user_version').fetchone()[0] == 3, 'Unexpected schema version')
+        require(db.execute('PRAGMA user_version').fetchone()[0] == 4, 'Unexpected schema version')
         require(db.execute('PRAGMA integrity_check').fetchall() == [('ok',)], 'Database integrity failed')
         require(not db.execute('PRAGMA foreign_key_check').fetchall(), 'Foreign keys failed')
     report['conditions']['wal_schema_integrity'] = True

--- a/tests/recovery/doctor/database.rs
+++ b/tests/recovery/doctor/database.rs
@@ -122,7 +122,15 @@ impl Fixture {
         json!({"schema":schema,"tables":tables,"version":version,"sources":sources})
     }
     fn downgrade_to_v2(&self) {
+        self.downgrade_to_v3();
         self.sql("DROP TABLE search_fts; DROP TABLE search_state; DROP TABLE search_documents; DELETE FROM schema_migrations WHERE version=3; PRAGMA user_version=2;");
+    }
+    fn downgrade_to_v3(&self) {
+        // Build an authentic old fixture, including its original constraint definition.
+        let domain = include_str!("../../../crates/awr-store/migrations/002_domain.sql");
+        let begin = domain.find("CREATE TABLE work_items (").unwrap();
+        let end = domain[begin..].find("CREATE TABLE decisions (").unwrap() + begin;
+        self.sql(&format!("PRAGMA foreign_keys=OFF; CREATE TEMP TABLE kept_work AS SELECT * FROM work_items; DROP TABLE work_items; {} INSERT INTO work_items SELECT * FROM kept_work; DROP TABLE kept_work; CREATE INDEX work_status ON work_items(project_id,status,active,priority); DELETE FROM schema_migrations WHERE version=4; PRAGMA user_version=3;",&domain[begin..end]));
     }
     fn revision(&self) -> String {
         Connection::open_with_flags(self.db(), OpenFlags::SQLITE_OPEN_READ_ONLY)
@@ -293,13 +301,13 @@ fn case_schema_migration_catalog_checks_record_identity() {
     for sql in [
         "DELETE FROM schema_migrations WHERE version=1",
         "UPDATE schema_migrations SET name='other' WHERE version=2",
-        "INSERT INTO schema_migrations VALUES(4,'unsupported',0)",
+        "INSERT INTO schema_migrations VALUES(5,'unsupported',0)",
     ] {
         let f = Fixture::new();
         f.sql(sql);
         let before = f.snapshot();
         let report = f.problems(&["doctor", "--database-only"]);
-        assert_eq!(report["schema_version"], 3);
+        assert_eq!(report["schema_version"], awr_store::SCHEMA_VERSION);
         assert!(Store::open_existing(&f.db()).is_err());
         assert!(Store::open(&f.db()).is_err());
         assert_eq!(f.snapshot(), before);
@@ -428,7 +436,7 @@ fn case_migration_sql_failure_rolls_back_and_supported_versions_keep_history() {
     let before = f.snapshot();
     drop(Store::open(&f.db()).unwrap());
     let after = f.snapshot();
-    assert_eq!(after["version"], 3);
+    assert_eq!(after["version"], awr_store::SCHEMA_VERSION);
     assert_runtime_retained(&before, &after);
     assert_eq!(before["tables"]["sources"], after["tables"]["sources"]);
     assert_eq!(f.ok(&["doctor"])["database_ok"], true);
@@ -446,6 +454,64 @@ fn case_migration_sql_failure_rolls_back_and_supported_versions_keep_history() {
     assert!(migrated.ok);
     assert_eq!(migrated.migrations[0].applied_at, 42);
     passed("migration_success_preserves_runtime");
+}
+
+#[test]
+fn draft_state_migration_preserves_rows_references_and_extra_indexes_and_rolls_back_on_failure() {
+    let f = Fixture::new();
+    let session = f.start(false);
+    f.checkpoint(session["session"]["id"].as_str().unwrap());
+    f.downgrade_to_v3();
+    f.sql("CREATE INDEX user_work_title ON work_items(title); CREATE TRIGGER reject_draft_migration BEFORE INSERT ON schema_migrations WHEN NEW.version=4 BEGIN SELECT RAISE(ABORT,'fixture migration failure'); END;");
+    let before = f.snapshot();
+    assert!(Store::open(&f.db()).is_err());
+    assert_eq!(f.snapshot(), before);
+    f.sql("DROP TRIGGER reject_draft_migration");
+    let before = f.snapshot();
+    let store = Store::open(&f.db()).unwrap();
+    let doctor = store.doctor().unwrap();
+    assert!(doctor.ok);
+    assert!(doctor.foreign_keys);
+    drop(store);
+    let after = f.snapshot();
+    assert_runtime_retained(&before, &after);
+    for name in [
+        "projects",
+        "sources",
+        "work_items",
+        "events",
+        "sessions",
+        "claims",
+        "checkpoints",
+    ] {
+        assert_eq!(
+            before["tables"][name], after["tables"][name],
+            "migration changed {name}"
+        );
+    }
+    let db = Connection::open(f.db()).unwrap();
+    assert_eq!(
+        db.query_row(
+            "SELECT count(*) FROM sqlite_master WHERE name='user_work_title'",
+            [],
+            |r| r.get::<_, i64>(0)
+        )
+        .unwrap(),
+        1
+    );
+    // New draft values are accepted without changing any old status spelling.
+    db.execute(
+        "UPDATE work_items SET status='draft' WHERE external_key='OTHER'",
+        [],
+    )
+    .unwrap();
+    assert!(
+        db.execute(
+            "UPDATE work_items SET status='made_up' WHERE external_key='OTHER'",
+            []
+        )
+        .is_err()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Hosts can create a title-only work draft through an exact source preview and a project-scoped request key. Repeated delivery returns the retained identity, while status lookup and explicit recovery preserve newer source edits. New drafts remain outside execution queues and claims.

Adds transactional schema 4 migration for the draft state, preserving existing records, runtime references and custom indexes/triggers. Schema 3 readers reject the new database.

Validation: 55 targeted native CLI/source/store checks passed, covering creation, byte preservation, conflicts, interrupted writes, migration rollback, readiness and retained sessions/checkpoints. Earlier 72 CLI regressions also passed. This is an implementation change, not a binary release.
