### PR TITLE
feat: registered Markdown edits and source-backed drafts

### DIFF
--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -194,7 +194,17 @@ fn catalog() -> Vec<Capability> {
                 "domain_actions_still_required",
             ],
         ),
-        ("mutation.work.create", false, &[], &["not_implemented"]),
+        (
+            "mutation.work.create",
+            true,
+            &["work create", "work create-status", "work create-recover"],
+            &[
+                "registered_yaml_ledger_only",
+                "exact_preview_and_revision",
+                "stable_request_key",
+                "draft_state_not_executable",
+            ],
+        ),
         ("mutation.markdown", false, &[], &["not_implemented"]),
         ("mutation.human_save", false, &[], &["not_implemented"]),
         ("mutation.multi_file", false, &[], &["not_implemented"]),
@@ -269,7 +279,7 @@ pub fn run(args: &CapabilitiesArgs, json_output: bool) -> Result<()> {
             "os": std::env::consts::OS, "arch": std::env::consts::ARCH},
         "database": {"schema_version": awr_store::SCHEMA_VERSION,
             "read_only_schema_versions": [awr_store::SCHEMA_VERSION],
-            "migrate_from_schema_versions": [1, 2],
+            "migrate_from_schema_versions": [1, 2, 3],
             "newer_schema_policy": "reject_without_migration",
             "schema_validation_required": true},
         "source_adapters": awr_source::SOURCE_ADAPTERS.iter().map(|id| json!({

--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -205,7 +205,24 @@ fn catalog() -> Vec<Capability> {
                 "draft_state_not_executable",
             ],
         ),
-        ("mutation.markdown", false, &[], &["not_implemented"]),
+        (
+            "mutation.markdown",
+            true,
+            &["document change"],
+            &["document_bodies_only", "work_ledger_writes_unavailable"],
+        ),
+        (
+            "mutation.markdown.document",
+            true,
+            &["document change", "document status", "document recover"],
+            &[
+                "single_file",
+                "registered_sources_only",
+                "exact_preview_and_revision",
+                "preserve_identity_and_lifecycle",
+                "draft_no_clobber",
+            ],
+        ),
         ("mutation.human_save", false, &[], &["not_implemented"]),
         ("mutation.multi_file", false, &[], &["not_implemented"]),
         (
@@ -284,7 +301,7 @@ pub fn run(args: &CapabilitiesArgs, json_output: bool) -> Result<()> {
             "schema_validation_required": true},
         "source_adapters": awr_source::SOURCE_ADAPTERS.iter().map(|id| json!({
             "id": id, "read": true,
-            "write_mode": if *id == "yaml-ledger-v1" { "lossless_supported_fields" } else { "read_only" },
+            "write_mode": match *id { "yaml-ledger-v1" => "lossless_supported_fields", "markdown-ledger-v1" => "read_only", _ => "document_body_only" },
             "lossless_field_write": *id == "yaml-ledger-v1"
         })).collect::<Vec<_>>(),
         "capabilities": capabilities,

--- a/crates/awr-cli/src/document.rs
+++ b/crates/awr-cli/src/document.rs
@@ -1,0 +1,95 @@
+use awr_core::*;
+use awr_runtime::{DocumentReport, DocumentRequest};
+use awr_store::Store;
+use clap::{Args, Subcommand};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Args)]
+pub struct ChangeArgs {
+    /// Versioned document edit or new draft, including a stable request key.
+    #[arg(long)]
+    input: PathBuf,
+    #[arg(long)]
+    accept: bool,
+    #[arg(long)]
+    expected_preview: Option<String>,
+    #[arg(long)]
+    expected_revision: Option<Revision>,
+}
+#[derive(Debug, Subcommand)]
+pub enum DocumentCommand {
+    /// Preview a source-bound change; accept exactly the returned preview to write it.
+    Change(ChangeArgs),
+    /// Read a retained request outcome without indexing or writing.
+    Status {
+        #[arg(long)]
+        key: String,
+    },
+    /// Explicitly recover one interrupted document change at the current revision.
+    Recover {
+        #[arg(long)]
+        key: String,
+        #[arg(long)]
+        expected_revision: Revision,
+    },
+}
+fn output(report: DocumentReport, json_output: bool) -> Result<()> {
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&report.value)?)
+    } else {
+        println!("Document change: {}", report.value["status"])
+    }
+    match report.failure {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+pub fn run(root: &Path, command: &DocumentCommand, json_output: bool) -> Result<()> {
+    let root = root.canonicalize()?;
+    let db = crate::source::runtime_dir(&root, false)?.join("state.db");
+    match command {
+        DocumentCommand::Status { key } => output(
+            awr_runtime::document_status(&Store::open_readonly(&db)?, &root, key)?,
+            json_output,
+        ),
+        DocumentCommand::Recover {
+            key,
+            expected_revision,
+        } => output(
+            awr_runtime::recover_document(
+                &mut Store::open_existing(&db)?,
+                &root,
+                key,
+                *expected_revision,
+            )?,
+            json_output,
+        ),
+        DocumentCommand::Change(args) => {
+            let path = if args.input.is_absolute() {
+                args.input.clone()
+            } else {
+                root.join(&args.input)
+            };
+            let input: DocumentRequest = serde_json::from_slice(&awr_source::read_capped(
+                &path,
+                awr_source::MARKDOWN_READ_CAP * 3,
+            )?)
+            .map_err(|_| {
+                Error::InvalidInput(
+                    "document JSON requires version, request_key and a supported change".into(),
+                )
+            })?;
+            output(
+                awr_runtime::change_document(
+                    &mut Store::open_existing(&db)?,
+                    &root,
+                    input,
+                    args.accept,
+                    args.expected_preview.as_deref(),
+                    args.expected_revision,
+                )?,
+                json_output,
+            )
+        }
+    }
+}

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -22,6 +22,7 @@ mod session;
 mod source;
 mod source_changes;
 mod work_action;
+mod work_create;
 
 #[derive(Debug, Parser)]
 #[command(

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -7,6 +7,7 @@ mod catalog;
 mod client;
 mod context;
 mod doctor;
+mod document;
 mod drill;
 mod event_append;
 mod execution;
@@ -41,6 +42,11 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Edit registered Markdown documents or create source-backed drafts.
+    Document {
+        #[command(subcommand)]
+        command: document::DocumentCommand,
+    },
     /// Negotiate host capabilities without opening a project or its database.
     Capabilities(capabilities::CapabilitiesArgs),
     /// Preview source authority mapping; --accept initializes using the reviewed mapping.
@@ -145,6 +151,7 @@ enum Command {
 
 fn run(cli: &Cli) -> Result<()> {
     match &cli.command {
+        Some(Command::Document { command }) => document::run(&cli.project, command, cli.json),
         Some(Command::Capabilities(args)) => capabilities::run(args, cli.json),
         Some(Command::Init(args)) => onboarding::run(&cli.project, args, cli.json),
         Some(Command::Intake { command }) => onboarding::inspect(&cli.project, command, cli.json),

--- a/crates/awr-cli/src/query.rs
+++ b/crates/awr-cli/src/query.rs
@@ -7,6 +7,12 @@ use std::{collections::BTreeMap, path::Path};
 
 #[derive(Debug, Subcommand)]
 pub enum WorkCommand {
+    /// Preview or accept one new source-backed, non-executable task draft.
+    Create(crate::work_create::CreateArgs),
+    /// Read the durable outcome for a stable creation request without applying it.
+    CreateStatus(crate::work_create::StatusArgs),
+    /// Explicitly recover a pending creation while retaining externally changed bytes.
+    CreateRecover(crate::work_create::RecoverArgs),
     /// Record progress in the source ledger; requires an active owned runtime claim.
     Progress(crate::work_action::ActionArgs),
     /// Mark in-progress source work blocked with a concrete blocker.
@@ -340,6 +346,9 @@ pub fn ready(root: &Path, limit: usize, reference: Option<&str>, json_output: bo
 
 pub fn work(root: &Path, command: &WorkCommand, json_output: bool) -> Result<()> {
     match command {
+        WorkCommand::Create(args) => crate::work_create::create(root, args, json_output),
+        WorkCommand::CreateStatus(args) => crate::work_create::status(root, args, json_output),
+        WorkCommand::CreateRecover(args) => crate::work_create::recover(root, args, json_output),
         WorkCommand::Progress(args) => {
             crate::work_action::run(root, args, WorkAction::Progress, json_output)
         }

--- a/crates/awr-cli/src/session.rs
+++ b/crates/awr-cli/src/session.rs
@@ -592,6 +592,9 @@ pub fn work(root: &Path, command: &WorkCommand, json_output: bool) -> Result<()>
             )
         }
         WorkCommand::Show { .. }
+        | WorkCommand::Create(_)
+        | WorkCommand::CreateStatus(_)
+        | WorkCommand::CreateRecover(_)
         | WorkCommand::Progress(_)
         | WorkCommand::Block(_)
         | WorkCommand::Unblock(_)

--- a/crates/awr-cli/src/work_create.rs
+++ b/crates/awr-cli/src/work_create.rs
@@ -1,0 +1,105 @@
+use awr_core::*;
+use awr_runtime::{CreateWorkInput, CreationReport};
+use awr_store::Store;
+use clap::Args;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Args)]
+pub struct CreateArgs {
+    /// Protected JSON with version, request_key, title and optional source_id.
+    #[arg(long,conflicts_with_all=["title","request_key","source"])]
+    input: Option<PathBuf>,
+    #[arg(long, required_unless_present = "input")]
+    title: Option<String>,
+    /// Stable host request ID, reused only with identical creation content.
+    #[arg(long, required_unless_present = "input")]
+    request_key: Option<String>,
+    #[arg(long)]
+    source: Option<Id>,
+    #[arg(long)]
+    accept: bool,
+    #[arg(long)]
+    expected_preview: Option<String>,
+    #[arg(long)]
+    expected_revision: Option<Revision>,
+}
+#[derive(Debug, Args)]
+pub struct StatusArgs {
+    #[arg(long)]
+    key: String,
+}
+#[derive(Debug, Args)]
+pub struct RecoverArgs {
+    #[arg(long)]
+    key: String,
+    #[arg(long)]
+    expected_revision: Revision,
+}
+fn output(report: CreationReport, json_output: bool) -> Result<()> {
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&report.value)?);
+    } else {
+        println!(
+            "Work creation: {}\nWork key: {}\nReceipt: {}",
+            report.value["status"],
+            report.value["external_key"],
+            report.value["recovery_directory"]
+        );
+    }
+    match report.failure {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+pub fn create(root: &Path, args: &CreateArgs, json_output: bool) -> Result<()> {
+    let root = root.canonicalize()?;
+    let input = if let Some(path) = &args.input {
+        let path = if path.is_absolute() {
+            path.clone()
+        } else {
+            root.join(path)
+        };
+        serde_json::from_slice(&awr_source::read_capped(&path, 64 * 1024)?).map_err(|_| {
+            Error::InvalidInput(
+                "creation JSON requires version, request_key, title and optional source_id".into(),
+            )
+        })?
+    } else {
+        CreateWorkInput {
+            version: 1,
+            request_key: args.request_key.clone().unwrap(),
+            title: args.title.clone().unwrap(),
+            source_id: args.source,
+        }
+    };
+    let mut store =
+        Store::open_existing(&crate::source::runtime_dir(&root, false)?.join("state.db"))?;
+    output(
+        awr_runtime::create_work(
+            &mut store,
+            &root,
+            input,
+            args.accept,
+            args.expected_preview.as_deref(),
+            args.expected_revision,
+        )?,
+        json_output,
+    )
+}
+pub fn status(root: &Path, args: &StatusArgs, json_output: bool) -> Result<()> {
+    let root = root.canonicalize()?;
+    let store = Store::open_readonly(&crate::source::runtime_dir(&root, false)?.join("state.db"))?;
+    output(
+        awr_runtime::creation_status(&store, &root, &args.key)?,
+        json_output,
+    )
+}
+pub fn recover(root: &Path, args: &RecoverArgs, json_output: bool) -> Result<()> {
+    let root = root.canonicalize()?;
+    let mut store =
+        Store::open_existing(&crate::source::runtime_dir(&root, false)?.join("state.db"))?;
+    output(
+        awr_runtime::recover_creation(&mut store, &root, &args.key, args.expected_revision)?,
+        json_output,
+    )
+}

--- a/crates/awr-cli/tests/host_capabilities.rs
+++ b/crates/awr-cli/tests/host_capabilities.rs
@@ -118,7 +118,7 @@ fn unsupported_protocol_and_invalid_usage_keep_distinct_error_codes() {
 }
 
 #[test]
-fn yaml_lossless_support_does_not_imply_markdown_or_human_writes() {
+fn capability_modes_separate_field_document_ledger_and_human_writes() {
     let host = Host::new();
     let result = host.ok(&["--json", "capabilities"]);
     let adapters = result["source_adapters"].as_array().unwrap();
@@ -130,8 +130,10 @@ fn yaml_lossless_support_does_not_imply_markdown_or_human_writes() {
         );
         if adapter["id"] == "yaml-ledger-v1" {
             assert_eq!(adapter["write_mode"], "lossless_supported_fields");
-        } else {
+        } else if adapter["id"] == "markdown-ledger-v1" {
             assert_eq!(adapter["write_mode"], "read_only");
+        } else {
+            assert_eq!(adapter["write_mode"], "document_body_only");
         }
     }
     for id in [

--- a/crates/awr-cli/tests/host_create.rs
+++ b/crates/awr-cli/tests/host_create.rs
@@ -1,0 +1,372 @@
+//! Native CLI creation/retry checks; recovery boundary edits are synthetic fixtures.
+use awr_core::Id;
+use serde_json::{Value, json};
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+    sync::Arc,
+};
+
+struct Host(PathBuf);
+impl Host {
+    fn new(text: &str, options: &str) -> Self {
+        let h = Self(std::env::temp_dir().join(format!("awr 新增 台账 {}", Id::new())));
+        fs::create_dir(&h.0).unwrap();
+        h.write("工作.yaml", text);
+        h.write("mapping.toml",&format!("[project]\nname='Creation'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='工作.yaml'\nadapter='yaml-ledger-v1'\n{options}"));
+        h.ok(&["init", "--manifest", "mapping.toml", "--accept"]);
+        h
+    }
+    fn write(&self, path: &str, text: &str) {
+        fs::write(self.0.join(path), text).unwrap();
+    }
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_awr"))
+            .env_clear()
+            .args(["--project", self.0.to_str().unwrap(), "--json"])
+            .args(args)
+            .stdin(Stdio::null())
+            .output()
+            .unwrap()
+    }
+    fn ok(&self, args: &[&str]) -> Value {
+        let out = self.run(args);
+        assert!(
+            out.status.success(),
+            "{args:?}\n{}\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        serde_json::from_slice(&out.stdout).unwrap()
+    }
+    fn error(&self, args: &[&str], code: &str) {
+        let out = self.run(args);
+        assert!(!out.status.success(), "{args:?}");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&out.stderr).unwrap()["code"],
+            code
+        );
+    }
+    fn preview(&self, key: &str, title: &str) -> Value {
+        self.ok(&["work", "create", "--request-key", key, "--title", title])
+    }
+    fn accept(&self, key: &str, title: &str, preview: &Value) -> Value {
+        self.ok(&[
+            "work",
+            "create",
+            "--request-key",
+            key,
+            "--title",
+            title,
+            "--accept",
+            "--expected-preview",
+            preview["preview"]["fingerprint"].as_str().unwrap(),
+            "--expected-revision",
+            &preview["project_revision"].to_string(),
+        ])
+    }
+    fn revision(&self) -> String {
+        self.ok(&["session", "list"])["project_revision"].to_string()
+    }
+    fn stored(&self, created: &Value) -> (PathBuf, Value) {
+        let p = self
+            .0
+            .join(created["recovery_directory"].as_str().unwrap())
+            .join("receipt.json");
+        let value = serde_json::from_slice(&fs::read(&p).unwrap()).unwrap();
+        (p, value)
+    }
+}
+impl Drop for Host {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn title_only_creates_one_non_executable_draft_and_replays_the_same_identity() {
+    let h = Host::new("work_items: []\n", "");
+    let before = fs::read(h.0.join("工作.yaml")).unwrap();
+    let p = h.preview("one-request", "准备旅行清单");
+    assert_eq!(p["source_write_performed"], false);
+    assert_eq!(fs::read(h.0.join("工作.yaml")).unwrap(), before);
+    let saved = h.accept("one-request", "准备旅行清单", &p);
+    assert_eq!(saved["phase"], "completed");
+    let rev = h.revision();
+    let after = fs::read(h.0.join("工作.yaml")).unwrap();
+    let replay = h.accept("one-request", "准备旅行清单", &p);
+    assert_eq!(saved["work_id"], replay["work_id"]);
+    assert_eq!(replay["already_recorded"], true);
+    assert_eq!(replay["source_write_performed"], false);
+    assert_eq!(h.revision(), rev);
+    assert_eq!(fs::read(h.0.join("工作.yaml")).unwrap(), after);
+    let key = saved["external_key"].as_str().unwrap();
+    let work = h.ok(&["work", "show", key]);
+    assert_eq!(work["work"]["status"], "draft");
+    assert_eq!(work["work"]["ready"], false);
+    h.error(
+        &[
+            "session",
+            "start",
+            "--work",
+            key,
+            "--agent",
+            "fixture",
+            "--provider",
+            "fixture",
+            "--model",
+            "no-model",
+            "--claim",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "DependencyBlocked",
+    );
+    assert_eq!(h.ok(&["object", "list", "work"])["total"], 1);
+    assert_eq!(h.ok(&["session", "list"])["sessions"], json!([]));
+    let status = h.ok(&["work", "create-status", "--key", "one-request"]);
+    assert_eq!(status["work_id"], saved["work_id"]);
+    assert_eq!(status["current_source"], "after");
+    assert_eq!(h.revision(), rev);
+    h.error(
+        &[
+            "work",
+            "create",
+            "--request-key",
+            "one-request",
+            "--title",
+            "Different title",
+            "--accept",
+        ],
+        "SourceConflict",
+    );
+}
+
+#[test]
+fn list_map_flow_mapped_fields_and_crlf_retain_existing_records_and_ids() {
+    for text in [
+        "# header\nwork_items:\n- id: OLD\n  title: 'Original' # keep\n  status: planned\n# footer\n",
+        "work_items: [{id: OLD, title: 'Original', status: planned}] # keep\n",
+        "work_items:\r\n  OLD:\r\n    title: 'Original' # keep\r\n    status: planned\r\n# footer\r\n",
+        "work_items: {OLD: {title: Original, status: planned}} # keep\n",
+    ] {
+        let h = Host::new(text, "");
+        let old = h.ok(&["work", "show", "OLD"])["work"]["id"].clone();
+        let p = h.preview("new-work", "A new work");
+        h.accept("new-work", "A new work", &p);
+        assert_eq!(h.ok(&["work", "show", "OLD"])["work"]["id"], old);
+        let output = fs::read_to_string(h.0.join("工作.yaml")).unwrap();
+        assert!(output.contains("# keep"));
+        if text.contains("\r\n") {
+            assert!(!output.replace("\r\n", "").contains('\n'));
+        }
+        let prior: Value = serde_yaml_ng::from_str(text).unwrap();
+        let after: Value = serde_yaml_ng::from_str(&output).unwrap();
+        if prior["work_items"].is_array() {
+            assert_eq!(prior["work_items"][0], after["work_items"][0]);
+        } else {
+            assert_eq!(prior["work_items"]["OLD"], after["work_items"]["OLD"]);
+        }
+    }
+    let h = Host::new(
+        "work_items: []\n",
+        "[sources.options.field_map]\nid='ticket'\ntitle='name'\nstatus='phase'\n[sources.options.status_map]\nDrafting='draft'\nPending='planned'\n",
+    );
+    let p = h.preview("mapped", "映射字段");
+    let saved = h.accept("mapped", "映射字段", &p);
+    let text = fs::read_to_string(h.0.join("工作.yaml")).unwrap();
+    let value: Value = serde_yaml_ng::from_str(&text).unwrap();
+    assert_eq!(value["work_items"][0]["phase"], "Drafting");
+    assert_eq!(value["work_items"][0]["name"], "映射字段");
+    assert_eq!(value["work_items"][0]["ticket"], saved["external_key"]);
+    assert!(value["work_items"][0].get("id").is_none());
+}
+
+#[test]
+fn changed_source_or_mapping_invalidates_review_and_missing_acceptance_never_writes() {
+    for mapping in [false, true] {
+        let h = Host::new("work_items: []\n", "");
+        let p = h.preview("review", "New task");
+        let path = if mapping {
+            ".awr/project.toml"
+        } else {
+            "工作.yaml"
+        };
+        let old = fs::read_to_string(h.0.join(path)).unwrap();
+        h.write(
+            path,
+            &if mapping {
+                old.replace("role = \"primary\"", "role = \"supporting\"")
+            } else {
+                format!("{old}# external edit\n")
+            },
+        );
+        let before = fs::read(h.0.join("工作.yaml")).unwrap();
+        let out = h.run(&[
+            "work",
+            "create",
+            "--request-key",
+            "review",
+            "--title",
+            "New task",
+            "--accept",
+            "--expected-preview",
+            p["preview"]["fingerprint"].as_str().unwrap(),
+            "--expected-revision",
+            &p["project_revision"].to_string(),
+        ]);
+        assert!(!out.status.success());
+        assert_eq!(fs::read(h.0.join("工作.yaml")).unwrap(), before);
+    }
+    let h = Host::new("work_items: []\n", "");
+    h.error(
+        &[
+            "work",
+            "create",
+            "--request-key",
+            "missing-review",
+            "--title",
+            "New task",
+            "--accept",
+        ],
+        "SourceConflict",
+    );
+    assert_eq!(
+        fs::read_to_string(h.0.join("工作.yaml")).unwrap(),
+        "work_items: []\n"
+    );
+}
+
+#[test]
+fn concurrent_delivery_and_discarded_response_do_not_create_two_work_keys() {
+    let h = Arc::new(Host::new("work_items: []\n", ""));
+    let p = h.preview("parallel", "Parallel task");
+    let jobs = (0..4)
+        .map(|_| {
+            let h = h.clone();
+            let p = p.clone();
+            std::thread::spawn(move || {
+                h.run(&[
+                    "work",
+                    "create",
+                    "--request-key",
+                    "parallel",
+                    "--title",
+                    "Parallel task",
+                    "--accept",
+                    "--expected-preview",
+                    p["preview"]["fingerprint"].as_str().unwrap(),
+                    "--expected-revision",
+                    &p["project_revision"].to_string(),
+                ])
+            })
+        })
+        .collect::<Vec<_>>();
+    let outputs = jobs
+        .into_iter()
+        .map(|j| j.join().unwrap())
+        .collect::<Vec<_>>();
+    assert!(outputs.iter().any(|o| o.status.success()));
+    // The host lost/discarded successful command output. Recover through the request key.
+    let status = h.ok(&["work", "create-status", "--key", "parallel"]);
+    assert_eq!(status["phase"], "completed");
+    let replay = h.accept("parallel", "Parallel task", &p);
+    assert_eq!(replay["work_id"], status["work_id"]);
+    assert_eq!(h.ok(&["object", "list", "work"])["total"], 1);
+}
+
+#[test]
+fn persisted_boundary_recovery_never_overwrites_external_edits_or_allocates_a_second_id() {
+    let h = Host::new("work_items: []\n", "");
+    let p = h.preview("recover", "Recover task");
+    let saved = h.accept("recover", "Recover task", &p);
+    let after = fs::read(h.0.join("工作.yaml")).unwrap();
+    let (path, mut receipt) = h.stored(&saved);
+    // Synthetic boundary fixture: source installed, acknowledgement not persisted.
+    receipt["phase"] = json!("applied");
+    receipt["work_id"] = Value::Null;
+    fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+    let recovered = h.ok(&[
+        "work",
+        "create-recover",
+        "--key",
+        "recover",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    assert_eq!(recovered["work_id"], saved["work_id"]);
+    assert_eq!(recovered["source_write_performed"], false);
+    assert_eq!(fs::read(h.0.join("工作.yaml")).unwrap(), after);
+    fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+    let external = [after, b"# user added new information\n".to_vec()].concat();
+    fs::write(h.0.join("工作.yaml"), &external).unwrap();
+    h.error(
+        &[
+            "work",
+            "create-recover",
+            "--key",
+            "recover",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "SourceConflict",
+    );
+    assert_eq!(fs::read(h.0.join("工作.yaml")).unwrap(), external);
+}
+
+#[test]
+fn unsupported_shapes_and_foreign_receipts_do_not_become_task_writes() {
+    let h = Host::new("work_items: &works []\nextra: *works\n", "");
+    h.error(
+        &[
+            "work",
+            "create",
+            "--request-key",
+            "unsupported",
+            "--title",
+            "New task",
+        ],
+        "MutationUnsupported",
+    );
+    let first = Host::new("work_items: []\n", "");
+    let p = first.preview("same-key", "First project");
+    let saved = first.accept("same-key", "First project", &p);
+    let second = Host::new("work_items: []\n", "");
+    let p = second.preview("same-key", "Second project");
+    let saved2 = second.accept("same-key", "Second project", &p);
+    assert_ne!(saved["external_key"], saved2["external_key"]);
+    assert_ne!(saved["project_id"], saved2["project_id"]);
+    assert_eq!(
+        second.ok(&["work", "create-status", "--key", "same-key"])["work_id"],
+        saved2["work_id"]
+    );
+    let (path2, _) = second.stored(&saved2);
+    let (path1, _) = first.stored(&saved);
+    fs::copy(path1, path2).unwrap();
+    second.error(
+        &["work", "create-status", "--key", "same-key"],
+        "SourceConflict",
+    );
+}
+
+#[test]
+fn old_explicit_draft_spelling_mapping_is_retained_but_cannot_make_new_work_executable() {
+    let h = Host::new(
+        "work_items: [{id: OLD, title: Existing work, status: draft}]\n",
+        "[sources.options.status_map]\ndraft='planned'\n",
+    );
+    assert_eq!(h.ok(&["work", "show", "OLD"])["work"]["status"], "planned");
+    h.error(
+        &[
+            "work",
+            "create",
+            "--request-key",
+            "new",
+            "--title",
+            "New task",
+        ],
+        "MutationUnsupported",
+    );
+    assert_eq!(h.ok(&["object", "list", "work"])["total"], 1);
+}

--- a/crates/awr-cli/tests/host_documents.rs
+++ b/crates/awr-cli/tests/host_documents.rs
@@ -1,0 +1,388 @@
+//! Native document fixtures. Journal rewinds model persisted crash boundaries explicitly.
+use awr_core::Id;
+use serde_json::{Value, json};
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+};
+struct Host(PathBuf);
+impl Host {
+    fn new(text: &str) -> Self {
+        let h = Self(std::env::temp_dir().join(format!("awr 文档 {}", Id::new())));
+        fs::create_dir(&h.0).unwrap();
+        fs::create_dir(h.0.join("drafts")).unwrap();
+        h.write("GOAL.md", text);
+        h.write("work.yaml", "work_items: []\n");
+        h.write("mapping.toml","[project]\nname='Documents'\ncontext_profile='minimal'\n[[sources]]\ndomain='goal'\nrole='primary'\npath='GOAL.md'\nadapter='markdown-heading-v1'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n[[sources]]\ndomain='decisions'\nrole='primary'\npath='drafts'\nadapter='markdown-directory-v1'\n");
+        h.ok(&["init", "--manifest", "mapping.toml", "--accept"]);
+        h
+    }
+    fn write(&self, path: &str, text: &str) {
+        fs::write(self.0.join(path), text).unwrap()
+    }
+    fn text(&self, path: &str) -> String {
+        fs::read_to_string(self.0.join(path)).unwrap()
+    }
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_awr"))
+            .env_clear()
+            .args(["--project", self.0.to_str().unwrap(), "--json"])
+            .args(args)
+            .stdin(Stdio::null())
+            .output()
+            .unwrap()
+    }
+    fn ok(&self, args: &[&str]) -> Value {
+        let o = self.run(args);
+        assert!(
+            o.status.success(),
+            "{args:?}\n{}\n{}",
+            String::from_utf8_lossy(&o.stdout),
+            String::from_utf8_lossy(&o.stderr)
+        );
+        serde_json::from_slice(&o.stdout).unwrap()
+    }
+    fn error(&self, args: &[&str], code: &str) {
+        let o = self.run(args);
+        assert!(!o.status.success(), "{args:?}");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&o.stderr).unwrap()["code"],
+            code,
+            "{}",
+            String::from_utf8_lossy(&o.stderr)
+        )
+    }
+    fn revision(&self) -> String {
+        self.ok(&["session", "list"])["project_revision"].to_string()
+    }
+    fn request(&self, key: &str, edit: Value) {
+        let sources = self.ok(&["object", "list", "source"]);
+        let source = sources["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["domain"] == "goal")
+            .unwrap()
+            .clone();
+        self.write("edit.json",&json!({"version":1,"request_key":key,"change":{"operation":"edit","source_id":source["id"],"source_fingerprint":source["fingerprint"],"edit":edit}}).to_string());
+    }
+    fn draft(&self, key: &str, path: &str, body: &str) {
+        self.write("edit.json",&json!({"version":1,"request_key":key,"change":{"operation":"create_draft","path":path,"title":"Review approach","body":body}}).to_string())
+    }
+    fn preview(&self) -> Value {
+        self.ok(&["document", "change", "--input", "edit.json"])
+    }
+    fn args<'a>(&'a self, p: &'a Value) -> Vec<String> {
+        vec![
+            "document".into(),
+            "change".into(),
+            "--input".into(),
+            "edit.json".into(),
+            "--accept".into(),
+            "--expected-preview".into(),
+            p["preview"]["fingerprint"].as_str().unwrap().into(),
+            "--expected-revision".into(),
+            p["project_revision"].to_string(),
+        ]
+    }
+    fn accept(&self, p: &Value) -> Value {
+        let a = self.args(p);
+        self.ok(&a.iter().map(String::as_str).collect::<Vec<_>>())
+    }
+    fn stored(&self, r: &Value) -> (PathBuf, Value) {
+        let p = self
+            .0
+            .join(r["recovery_directory"].as_str().unwrap())
+            .join("receipt.json");
+        let v = serde_json::from_slice(&fs::read(&p).unwrap()).unwrap();
+        (p, v)
+    }
+}
+impl Drop for Host {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn exact_fragment_keeps_crlf_code_and_other_sections_and_replays_without_new_identity() {
+    let before = "# Goal {#goal}\r\n\r\n原文说明。\r\n\r\n```text\r\n# embedded instruction\r\n```\r\n\r\n# Notes {#notes}\r\n\r\nKeep exactly.\r\n";
+    let h = Host::new(before);
+    let prior = h.ok(&["object", "list", "goal"]);
+    h.request(
+        "edit-once",
+        json!({"kind":"fragment","before":"原文说明。","after":"更新说明。"}),
+    );
+    let p = h.preview();
+    assert_eq!(h.text("GOAL.md"), before);
+    let saved = h.accept(&p);
+    assert_eq!(saved["status"], "completed");
+    assert_eq!(
+        h.text("GOAL.md"),
+        before.replace("原文说明。", "更新说明。")
+    );
+    let rev = h.revision();
+    let replay = h.accept(&p);
+    assert_eq!(replay["source_id"], saved["source_id"]);
+    assert_eq!(h.revision(), rev);
+    let next = h.ok(&["object", "list", "goal"]);
+    let ids = |v: &Value| {
+        v["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|i| i["id"].clone())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(ids(&prior), ids(&next));
+    assert_eq!(h.ok(&["session", "list"])["sessions"], json!([]));
+    assert_eq!(
+        h.ok(&["document", "status", "--key", "edit-once"])["current_source"],
+        "after"
+    );
+}
+#[test]
+fn whole_body_edit_retains_explicit_keys_and_lifecycle_but_accepts_changed_prose() {
+    let h = Host::new("# Goal {#goal status=active}\n\nBefore\n");
+    h.request("whole",json!({"kind":"replace","text":"# Better goal {#goal status=active}\n\nNew success criteria:\n- Ready to read.\n"}));
+    h.accept(&h.preview());
+    assert!(h.text("GOAL.md").contains("New success criteria"));
+    h.request(
+        "status-forgery",
+        json!({"kind":"replace","text":"# Better goal {#goal status=completed}\n\nDone\n"}),
+    );
+    h.error(
+        &["document", "change", "--input", "edit.json"],
+        "RuleViolation",
+    );
+    h.request(
+        "key-change",
+        json!({"kind":"replace","text":"# Other key {#different status=active}\n\nBody\n"}),
+    );
+    h.error(
+        &["document", "change", "--input", "edit.json"],
+        "RuleViolation",
+    );
+}
+#[test]
+fn stale_preview_ambiguous_fragment_and_no_change_have_explicit_outcomes() {
+    let before = "# Goal {#goal}\n\nSame Same\n";
+    let h = Host::new(before);
+    h.request(
+        "ambiguous",
+        json!({"kind":"fragment","before":"Same","after":"Other"}),
+    );
+    h.error(
+        &["document", "change", "--input", "edit.json"],
+        "SourceConflict",
+    );
+    h.request(
+        "stale",
+        json!({"kind":"replace","text":before.replace("Same Same","New")}),
+    );
+    let p = h.preview();
+    h.write("GOAL.md", &format!("{before}\nExternal\n"));
+    let args = h.args(&p);
+    h.error(
+        &args.iter().map(String::as_str).collect::<Vec<_>>(),
+        "RevisionConflict",
+    );
+    assert!(h.text("GOAL.md").contains("External"));
+    h.request(
+        "no-change",
+        json!({"kind":"replace","text":h.text("GOAL.md")}),
+    );
+    let p = h.preview();
+    let rev = h.revision();
+    let r = h.accept(&p);
+    assert_eq!(r["status"], "no_change");
+    assert_eq!(r["source_write_performed"], false);
+    assert_eq!(h.revision(), rev);
+}
+#[test]
+fn new_draft_has_stable_source_identity_and_never_clobbers_existing_files() {
+    let h = Host::new("# Goal {#goal}\n\nKeep\n");
+    h.draft("draft-once", "drafts/方案.md", "A considered approach.\n");
+    let p = h.preview();
+    assert!(!h.0.join("drafts/方案.md").exists());
+    let saved = h.accept(&p);
+    let content = h.text("drafts/方案.md");
+    assert!(content.contains("status: proposed"));
+    assert_eq!(h.accept(&p)["source_id"], saved["source_id"]);
+    h.draft("draft-once", "drafts/方案.md", "Changed payload");
+    h.error(
+        &["document", "change", "--input", "edit.json"],
+        "SourceConflict",
+    );
+    h.draft("second", "drafts/方案.md", "Different");
+    h.error(
+        &["document", "change", "--input", "edit.json"],
+        "SourceConflict",
+    );
+    assert_eq!(h.text("drafts/方案.md"), content);
+    h.draft("outside", "outside.md", "Outside");
+    h.error(
+        &["document", "change", "--input", "edit.json"],
+        "SourceConflict",
+    );
+    h.draft("escape", "../escape.md", "Outside");
+    h.error(
+        &["document", "change", "--input", "edit.json"],
+        "RuleViolation",
+    );
+    h.draft(
+        "claimed-accepted",
+        "drafts/invalid.md",
+        "- Status: Accepted\n\nBody\n",
+    );
+    h.error(
+        &["document", "change", "--input", "edit.json"],
+        "SourceConflict",
+    );
+    assert_eq!(h.ok(&["object", "list", "decision"])["total"], 1);
+}
+#[test]
+fn conflicting_declarations_aliases_and_ledger_edits_do_not_write() {
+    let before = "---\nstatus: active\n---\n# Goal {#goal status=active}\n\nBefore\n";
+    let h = Host::new(before);
+    h.request(
+        "contradiction",
+        json!({"kind":"replace","text":before.replace("status: active","status: completed")}),
+    );
+    h.error(
+        &["document", "change", "--input", "edit.json"],
+        "SourceConflict",
+    );
+    assert_eq!(h.text("GOAL.md"), before);
+    let sources = h.ok(&["object", "list", "source"]);
+    let source = sources["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["domain"] == "ledger")
+        .unwrap();
+    h.write("edit.json", &json!({"version":1,"request_key":"ledger-bypass","change":{"operation":"edit","source_id":source["id"],"source_fingerprint":source["fingerprint"],"edit":{"kind":"replace","text":"work_items: []\n"}}}).to_string());
+    h.error(
+        &["document", "change", "--input", "edit.json"],
+        "MutationUnsupported",
+    );
+    h.request(
+        "alias",
+        json!({"kind":"fragment","before":"Before","after":"After"}),
+    );
+    h.write(".awr/project.toml",&(h.text(".awr/project.toml")+"\n[[sources]]\ndomain='plan'\nrole='supporting'\npath='GOAL.md'\nadapter='markdown-heading-v1'\n"));
+    h.error(
+        &["document", "change", "--input", "edit.json"],
+        "SourceConflict",
+    );
+    assert_eq!(h.text("GOAL.md"), before);
+}
+#[test]
+fn persisted_recovery_retains_third_party_bytes_and_rejects_foreign_receipts() {
+    let before = "# Goal {#goal}\n\nBefore\n";
+    let h = Host::new(before);
+    h.request(
+        "recover",
+        json!({"kind":"fragment","before":"Before","after":"After"}),
+    );
+    let p = h.preview();
+    let saved = h.accept(&p);
+    let after = h.text("GOAL.md");
+    let (path, mut receipt) = h.stored(&saved);
+    receipt["phase"] = json!("applied");
+    fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+    let r = h.ok(&[
+        "document",
+        "recover",
+        "--key",
+        "recover",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    assert_eq!(r["source_write_performed"], false);
+    assert_eq!(r["source_id"], saved["source_id"]);
+    receipt["phase"] = json!("prepared");
+    fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+    h.write("GOAL.md", before);
+    let recovered = h.ok(&[
+        "document",
+        "recover",
+        "--key",
+        "recover",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    assert_eq!(recovered["source_write_performed"], true);
+    assert_eq!(h.text("GOAL.md"), after);
+    fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+    h.write("GOAL.md", "External newer document\n");
+    h.error(
+        &[
+            "document",
+            "recover",
+            "--key",
+            "recover",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "SourceConflict",
+    );
+    assert_eq!(h.text("GOAL.md"), "External newer document\n");
+    h.write("GOAL.md", &after);
+    receipt["plan"]["root"] = json!("/foreign/project");
+    fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+    h.error(
+        &["document", "status", "--key", "recover"],
+        "SourceConflict",
+    );
+}
+
+#[test]
+fn architecture_kind_and_readonly_or_concurrent_destinations_are_explicit() {
+    let h = Host::new("# Architecture {#architecture}\n\nExecution structure.\n");
+    let manifest =
+        h.text(".awr/project.toml")
+            .replacen("domain = \"goal\"", "domain = \"plan\"", 1);
+    // The accepted manifest retains TOML formatting; parse it instead of depending on whitespace.
+    let mut config: toml::Value = toml::from_str(&manifest).unwrap();
+    config["sources"][0]["domain"] = toml::Value::String("plan".into());
+    config["sources"][0]["options"] = toml::Value::Table(toml::Table::from_iter([(
+        "kind".into(),
+        toml::Value::String("architecture".into()),
+    )]));
+    h.write(".awr/project.toml", &toml::to_string(&config).unwrap());
+    let plans = h.ok(&["object", "list", "plan"]);
+    assert_eq!(plans["items"][0]["kind"], "architecture");
+    h.draft("concurrent", "drafts/contended.md", "Reviewed draft\n");
+    let p = h.preview();
+    h.write("drafts/contended.md", "# Existing\n\nConcurrent contents\n");
+    let args = h.args(&p);
+    let out = h.run(&args.iter().map(String::as_str).collect::<Vec<_>>());
+    assert!(!out.status.success());
+    assert_eq!(
+        h.text("drafts/contended.md"),
+        "# Existing\n\nConcurrent contents\n"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let s = h.ok(&["object", "list", "source"]);
+        let source = s["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["domain"] == "plan")
+            .unwrap();
+        h.write("edit.json",&json!({"version":1,"request_key":"readonly","change":{"operation":"edit","source_id":source["id"],"source_fingerprint":source["fingerprint"],"edit":{"kind":"fragment","before":"Execution structure.","after":"Changed."}}}).to_string());
+        let p = h.preview();
+        fs::set_permissions(h.0.join("GOAL.md"), fs::Permissions::from_mode(0o444)).unwrap();
+        let args = h.args(&p);
+        h.error(
+            &args.iter().map(String::as_str).collect::<Vec<_>>(),
+            "RuleViolation",
+        );
+        assert!(h.text("GOAL.md").contains("Execution structure."));
+        fs::set_permissions(h.0.join("GOAL.md"), fs::Permissions::from_mode(0o600)).unwrap();
+    }
+}

--- a/crates/awr-cli/tests/work_cli.rs
+++ b/crates/awr-cli/tests/work_cli.rs
@@ -112,7 +112,7 @@ fn search_cli_combines_text_and_structured_filters() {
     let diagnosed = f.run(&["doctor"]);
     assert!(!diagnosed.status.success());
     let diagnosis: Value = serde_json::from_slice(&diagnosed.stdout).unwrap();
-    assert_eq!(diagnosis["schema_version"], 3);
+    assert_eq!(diagnosis["schema_version"], awr_store::SCHEMA_VERSION);
     assert_eq!(diagnosis["database_ok"], true);
     assert!(
         diagnosis["findings"]

--- a/crates/awr-core/src/model.rs
+++ b/crates/awr-core/src/model.rs
@@ -32,6 +32,7 @@ pub enum Freshness {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkStatus {
+    Draft,
     Planned,
     Ready,
     Claimed,
@@ -45,6 +46,7 @@ pub enum WorkStatus {
 impl WorkStatus {
     pub fn normalize(raw: &str) -> Self {
         match raw {
+            "draft" => Self::Draft,
             "planned" => Self::Planned,
             "ready" => Self::Ready,
             "claimed" => Self::Claimed,

--- a/crates/awr-runtime/src/document.rs
+++ b/crates/awr-runtime/src/document.rs
@@ -1,0 +1,503 @@
+//! Durable single-file document operations for local hosts.
+use crate::mutation_apply::{
+    SourceReplacement, directory, named_lock, new_file, recovery_root, source_lock,
+};
+use awr_core::*;
+use awr_source::*;
+use awr_store::Store;
+use cap_std::fs::Dir;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    ffi::OsStr,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DocumentRequest {
+    pub version: u32,
+    pub request_key: String,
+    pub change: DocumentAction,
+}
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Plan {
+    version: u32,
+    project_id: Id,
+    root: PathBuf,
+    project_revision: Revision,
+    request: DocumentRequest,
+    manifest_fingerprint: String,
+    path: PathBuf,
+    source: Option<Source>,
+    spec: SourceSpec,
+    before_fingerprint: Option<String>,
+    after_fingerprint: String,
+}
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Receipt {
+    plan: Plan,
+    fingerprint: String,
+    phase: String,
+    project_revision: Revision,
+    source_id: Option<Id>,
+}
+pub struct DocumentReport {
+    pub value: Value,
+    pub failure: Option<Error>,
+}
+fn identity(project: Id, key: &str) -> Result<String> {
+    if key.trim().is_empty() || key.len() > 512 || key.chars().any(char::is_control) {
+        return Err(Error::InvalidInput(
+            "request key requires 1..512 bytes without controls".into(),
+        ));
+    }
+    ensure_public_text(key)?;
+    Ok(fingerprint(&serde_json::to_vec(&(project, key))?)
+        .trim_start_matches("sha256:")
+        .into())
+}
+fn name(project: Id, key: &str) -> Result<String> {
+    Ok(format!("document-{}", identity(project, key)?))
+}
+fn read(path: &Path, cap: u64) -> Result<Vec<u8>> {
+    let file = open_file_exact(path)?;
+    if !file.metadata()?.is_file() || file.metadata()?.len() > cap {
+        return Err(Error::InvalidInput(
+            "invalid or oversized document recovery file".into(),
+        ));
+    }
+    let mut bytes = Vec::new();
+    file.take(cap + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > cap {
+        return Err(Error::InvalidInput(
+            "document recovery file exceeded its bound".into(),
+        ));
+    }
+    Ok(bytes)
+}
+fn manifest_hash(root: &Path) -> Result<String> {
+    Ok(fingerprint(&read(
+        &root.join(".awr/project.toml"),
+        64 * 1024,
+    )?))
+}
+fn load(root: &Path, project: Id, key: &str) -> Result<Option<Receipt>> {
+    let base = root.join(".awr/mutations").join(name(project, key)?);
+    match std::fs::symlink_metadata(&base) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+        Ok(m) if !m.is_dir() || m.file_type().is_symlink() => {
+            return Err(Error::RuleViolation(
+                "invalid document receipt directory".into(),
+            ));
+        }
+        _ => (),
+    }
+    let r: Receipt =
+        serde_json::from_slice(&read(&base.join("receipt.json"), MARKDOWN_READ_CAP * 3)?)?;
+    if r.plan.version != 1
+        || r.plan.request.version != 1
+        || r.plan.project_id != project
+        || r.plan.root != root
+        || r.plan.request.request_key != key
+        || fingerprint(&serde_json::to_vec(&r.plan)?) != r.fingerprint
+        || !["prepared", "applied", "completed", "no_change"].contains(&r.phase.as_str())
+    {
+        return Err(Error::SourceConflict(
+            "document receipt differs from its bound project, version or plan".into(),
+        ));
+    }
+    Ok(Some(r))
+}
+fn save(dir: &Dir, r: &Receipt) -> Result<()> {
+    let temp = format!("receipt-{}.tmp", Id::new());
+    let mut f = new_file(dir, OsStr::new(&temp))?;
+    f.write_all(&serde_json::to_vec_pretty(r)?)?;
+    f.sync_all()?;
+    drop(f);
+    dir.rename(&temp, dir, "receipt.json")?;
+    crate::fs_sync::sync_directory(dir)
+}
+fn done(r: &Receipt) -> bool {
+    ["completed", "no_change"].contains(&r.phase.as_str())
+}
+fn report(r: &Receipt, replay: bool) -> Result<Value> {
+    Ok(
+        json!({"ok":done(r),"status":if r.phase=="no_change"{"no_change"}else if done(r){"completed"}else{"pending_recovery"},
+        "request_key":r.plan.request.request_key,"project_id":r.plan.project_id,"project_revision":r.project_revision,"source_id":r.source_id,
+        "preview_fingerprint":r.fingerprint,"phase":r.phase,"already_recorded":replay,"historical_outcome":replay,
+        "source_write_performed":false,"runtime_write_performed":false,"write_outcome":if r.phase=="no_change"{"no_change"}else if done(r){"applied"}else{"pending_recovery"},
+        "recovery_directory":format!(".awr/mutations/{}",name(r.plan.project_id,&r.plan.request.request_key)?)}),
+    )
+}
+fn current(root: &Path, plan: &Plan) -> Result<Option<String>> {
+    if manifest_hash(root)? != plan.manifest_fingerprint {
+        return Err(Error::SourceConflict(
+            "document source registration changed".into(),
+        ));
+    }
+    let spec = document_path_registration(root, &plan.path)?;
+    if serde_json::to_value(spec)? != serde_json::to_value(&plan.spec)? {
+        return Err(Error::SourceConflict("document mapping changed".into()));
+    }
+    if let Some(source) = &plan.source {
+        let (_, _, snapshot) = inspect_registered_source(root, source)?;
+        return Ok(Some(snapshot.fingerprint));
+    }
+    match std::fs::symlink_metadata(&plan.path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.into()),
+        Ok(_) => Ok(Some(fingerprint(&read(&plan.path, MARKDOWN_READ_CAP)?))),
+    }
+}
+pub fn document_status(store: &Store, root: &Path, key: &str) -> Result<DocumentReport> {
+    let root = root.canonicalize()?;
+    let p = store.project_by_root(&root)?;
+    let value = if let Some(r) = load(&root, p.id, key)? {
+        let mut v = report(&r, true)?;
+        v["found"] = json!(true);
+        v["read_only"] = json!(true);
+        v["current_source"] = json!(match current(&root, &r.plan) {
+            Ok(Some(s)) if s == r.plan.after_fingerprint => "after",
+            Ok(s) if s == r.plan.before_fingerprint => "before",
+            Ok(_) => "externally_changed",
+            Err(_) => "unavailable_or_registration_changed",
+        });
+        v
+    } else {
+        json!({"ok":true,"found":false,"read_only":true,"source_write_performed":false,"runtime_write_performed":false})
+    };
+    Ok(DocumentReport {
+        value,
+        failure: None,
+    })
+}
+pub fn change_document(
+    store: &mut Store,
+    root: &Path,
+    request: DocumentRequest,
+    accept: bool,
+    expected_preview: Option<&str>,
+    expected_revision: Option<Revision>,
+) -> Result<DocumentReport> {
+    let root = root.canonicalize()?;
+    let project = store.project_by_root(&root)?;
+    let key = identity(project.id, &request.request_key)?;
+    ensure_public_data(&request)?;
+    if request.version != 1 {
+        return Err(Error::InvalidInput(
+            "document request requires version 1".into(),
+        ));
+    }
+    let _lock = if accept {
+        Some(named_lock(&root, &format!("document-{key}.lock"))?)
+    } else {
+        None
+    };
+    if let Some(r) = load(&root, project.id, &request.request_key)? {
+        if r.plan.request != request {
+            return Err(Error::SourceConflict(
+                "document request key already belongs to different content".into(),
+            ));
+        }
+        return Ok(DocumentReport {
+            value: report(&r, true)?,
+            failure: (!done(&r)).then(|| {
+                Error::MutationConflict(
+                    "inspect and explicitly recover the pending document operation".into(),
+                )
+            }),
+        });
+    }
+    let indexed = index_project(store, &root, &Manifest::load(&root)?, false)?;
+    if !indexed.ok {
+        return Err(Error::SourceStale(
+            "refresh registered sources before editing a document".into(),
+        ));
+    }
+    let revision = store.project(project.id)?.project_revision;
+    if let Some(expected) = expected_revision
+        && expected != revision
+    {
+        return Err(Error::RevisionConflict {
+            expected,
+            actual: revision,
+        });
+    }
+    let prepared = match &request.change {
+        DocumentAction::Edit {
+            source_id,
+            source_fingerprint,
+            edit,
+        } => {
+            let source = store.source(project.id, *source_id)?;
+            prepare_document_edit(
+                &root,
+                &source,
+                source_fingerprint,
+                edit,
+                store.projection_ids(&source)?,
+            )?
+        }
+        DocumentAction::CreateDraft { path, title, body } => prepare_document_draft(
+            &root,
+            project.id,
+            path,
+            title,
+            body,
+            &format!("DOC-{}", &key[..32]),
+        )?,
+    };
+    let _path_lock = if accept {
+        Some(named_lock(
+            &root,
+            &format!(
+                "document-path-{}.lock",
+                fingerprint(prepared.path.to_string_lossy().as_bytes())
+                    .trim_start_matches("sha256:")
+            ),
+        )?)
+    } else {
+        None
+    };
+    let _source_lock = if accept && prepared.before.is_some() {
+        Some(source_lock(&root, prepared.source.id)?)
+    } else {
+        None
+    };
+    let plan = Plan {
+        version: 1,
+        project_id: project.id,
+        root: root.clone(),
+        project_revision: revision,
+        request,
+        manifest_fingerprint: manifest_hash(&root)?,
+        path: prepared.path,
+        source: prepared.before.as_ref().map(|_| prepared.source),
+        spec: prepared.spec,
+        before_fingerprint: prepared.before.as_ref().map(|s| s.fingerprint.clone()),
+        after_fingerprint: prepared.after.fingerprint.clone(),
+    };
+    let preview = fingerprint(&serde_json::to_vec(&plan)?);
+    if !accept {
+        return Ok(DocumentReport {
+            value: json!({"ok":true,"status":"preview","requires_accept":true,"project_revision":revision,
+        "preview":{"fingerprint":preview,"plan":plan,"before_text":prepared.before.as_ref().map(|s|s.text()).transpose()?,"after_text":prepared.after.text()?},
+        "source_write_performed":false,"runtime_write_performed":true}),
+            failure: None,
+        });
+    }
+    if expected_preview != Some(preview.as_str()) || expected_revision.is_none() {
+        return Err(Error::SourceConflict(
+            "document acceptance requires exact reviewed preview and project revision".into(),
+        ));
+    }
+    let mutations = recovery_root(&root)?;
+    let name = name(project.id, &plan.request.request_key)?;
+    mutations.create_dir(&name)?;
+    let dir = directory(&mutations, &name, &root.join(".awr/mutations").join(&name))?;
+    for (name, bytes) in [
+        (
+            "before.md",
+            prepared
+                .before
+                .as_ref()
+                .map(|s| s.bytes.as_slice())
+                .unwrap_or(&[]),
+        ),
+        ("after.md", prepared.after.bytes.as_slice()),
+    ] {
+        let mut f = new_file(&dir, OsStr::new(name))?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    let mut receipt = Receipt {
+        source_id: plan.source.as_ref().map(|s| s.id),
+        plan,
+        fingerprint: preview,
+        phase: "prepared".into(),
+        project_revision: revision,
+    };
+    save(&dir, &receipt)?;
+    crate::fs_sync::sync_directory(&mutations)?;
+    finish(store, &root, &dir, &mut receipt, revision)
+}
+pub fn recover_document(
+    store: &mut Store,
+    root: &Path,
+    key: &str,
+    expected: Revision,
+) -> Result<DocumentReport> {
+    let root = root.canonicalize()?;
+    let project = store.project_by_root(&root)?;
+    let _lock = named_lock(
+        &root,
+        &format!("document-{}.lock", identity(project.id, key)?),
+    )?;
+    let mut r =
+        load(&root, project.id, key)?.ok_or_else(|| Error::NotFound("document receipt".into()))?;
+    if done(&r) {
+        return Ok(DocumentReport {
+            value: report(&r, true)?,
+            failure: None,
+        });
+    }
+    let _path_lock = named_lock(
+        &root,
+        &format!(
+            "document-path-{}.lock",
+            fingerprint(r.plan.path.to_string_lossy().as_bytes()).trim_start_matches("sha256:")
+        ),
+    )?;
+    let _source_lock = r
+        .plan
+        .source
+        .as_ref()
+        .map(|s| source_lock(&root, s.id))
+        .transpose()?;
+    let dir = open_dir_exact(&root.join(".awr/mutations").join(name(project.id, key)?))?;
+    finish(store, &root, &dir, &mut r, expected)
+}
+fn finish(
+    store: &mut Store,
+    root: &Path,
+    dir: &Dir,
+    r: &mut Receipt,
+    expected: Revision,
+) -> Result<DocumentReport> {
+    let mut wrote = false;
+    let mut indexed = None;
+    let result = (|| -> Result<()> {
+        let actual = store.project(r.plan.project_id)?.project_revision;
+        if actual != expected {
+            return Err(Error::RevisionConflict { expected, actual });
+        }
+        let plan = &r.plan;
+        let base = root
+            .join(".awr/mutations")
+            .join(name(plan.project_id, &plan.request.request_key)?);
+        let before = read(&base.join("before.md"), MARKDOWN_READ_CAP)?;
+        let after = read(&base.join("after.md"), MARKDOWN_READ_CAP)?;
+        if plan
+            .before_fingerprint
+            .as_ref()
+            .is_some_and(|s| *s != fingerprint(&before))
+            || fingerprint(&after) != plan.after_fingerprint
+        {
+            return Err(Error::SourceConflict(
+                "document recovery snapshots differ from the reviewed plan".into(),
+            ));
+        }
+        let observed = current(root, plan)?;
+        if observed != plan.before_fingerprint && observed != Some(plan.after_fingerprint.clone()) {
+            return Err(Error::SourceConflict(
+                "document recovery preserves externally changed files".into(),
+            ));
+        }
+        if observed == plan.before_fingerprint && observed != Some(plan.after_fingerprint.clone()) {
+            let permissions = if plan.before_fingerprint.is_some() {
+                open_file_exact(&plan.path)?.metadata()?.permissions()
+            } else {
+                if open_dir_exact(plan.path.parent().unwrap())?
+                    .dir_metadata()?
+                    .permissions()
+                    .readonly()
+                {
+                    return Err(Error::RuleViolation(
+                        "document directory is read-only".into(),
+                    ));
+                }
+                new_permissions()?
+            };
+            if permissions.readonly() {
+                return Err(Error::RuleViolation(
+                    "document destination is read-only".into(),
+                ));
+            }
+            let mut replacement = SourceReplacement::prepare(&plan.path, &after, permissions)?;
+            if current(root, plan)? != observed {
+                return Err(Error::SourceConflict(
+                    "document changed immediately before writing".into(),
+                ));
+            }
+            let actual = store.project(plan.project_id)?.project_revision;
+            if actual != expected {
+                return Err(Error::RevisionConflict { expected, actual });
+            }
+            if plan.before_fingerprint.is_some() {
+                replacement.install()?;
+                replacement.sync_parent()?
+            } else {
+                replacement.install_new()?
+            }
+            wrote = true;
+        }
+        if plan.before_fingerprint.as_ref() == Some(&plan.after_fingerprint) {
+            r.phase = "no_change".into();
+            return save(dir, r);
+        }
+        r.phase = "applied".into();
+        save(dir, r)?;
+        let result = index_project(store, root, &Manifest::load(root)?, false)?;
+        r.project_revision = result.project_revision;
+        indexed = Some(serde_json::to_value(&result)?);
+        if !result.ok {
+            return Err(Error::SourceStale(
+                "document was applied but projections require recovery".into(),
+            ));
+        }
+        let locator = Locator::File(plan.path.clone()).identity()?;
+        let sources = store.sources(plan.project_id)?;
+        let matching: Vec<_> = sources
+            .iter()
+            .filter(|s| {
+                s.locator == locator
+                    && s.adapter == plan.spec.adapter
+                    && s.domain == plan.spec.domain
+            })
+            .collect();
+        if matching.len() != 1
+            || matching[0].fingerprint != plan.after_fingerprint
+            || current(root, plan)? != Some(plan.after_fingerprint.clone())
+        {
+            return Err(Error::SourceConflict(
+                "document projection differs from the applied source".into(),
+            ));
+        }
+        r.source_id = Some(matching[0].id);
+        r.phase = "completed".into();
+        save(dir, r)
+    })();
+    let mut value = report(r, false)?;
+    value["source_write_performed"] = json!(wrote);
+    value["runtime_write_performed"] = json!(true);
+    if let Some(index) = indexed {
+        value["index"] = index
+    }
+    let failure = result.err();
+    if let Some(e) = &failure {
+        value["ok"] = json!(false);
+        value["status"] = json!("pending_recovery");
+        value["write_outcome"] = json!("pending_recovery");
+        value["error"] = serde_json::to_value(e.report())?
+    }
+    Ok(DocumentReport { value, failure })
+}
+fn new_permissions() -> Result<std::fs::Permissions> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        Ok(std::fs::Permissions::from_mode(0o600))
+    }
+    #[cfg(not(unix))]
+    {
+        let file = std::env::current_exe()?;
+        let mut p = std::fs::metadata(file)?.permissions();
+        p.set_readonly(false);
+        Ok(p)
+    }
+}

--- a/crates/awr-runtime/src/lib.rs
+++ b/crates/awr-runtime/src/lib.rs
@@ -15,6 +15,7 @@ mod organization;
 mod read;
 mod resume;
 mod work_action;
+mod work_create;
 pub use artifact::ArtifactFile;
 use awr_store::Store;
 pub use awr_store::{BranchFilter, EventCursor, EventPage, EventQuery};
@@ -30,6 +31,9 @@ pub use mutation::{
 pub use organization::{OrganizationReport, OrganizationState, inspect_organization};
 pub use resume::{ResumeReport, ResumeRequest, resume_session};
 pub use work_action::{WorkActionRequest, perform_work_action};
+pub use work_create::{
+    CreateWorkInput, CreationReport, create_work, creation_status, recover_creation,
+};
 
 /// Hard ceilings; a caller may select a smaller budget, never raise these limits.
 pub const ARTIFACT_IMPORT_CAP: u64 = 64 * 1024 * 1024;

--- a/crates/awr-runtime/src/lib.rs
+++ b/crates/awr-runtime/src/lib.rs
@@ -7,6 +7,10 @@ mod branch;
 mod branch_close;
 mod completion;
 mod doctor;
+mod document;
+pub use document::{
+    DocumentReport, DocumentRequest, change_document, document_status, recover_document,
+};
 mod execution;
 mod fs_sync;
 mod mutation;

--- a/crates/awr-runtime/src/mutation_apply.rs
+++ b/crates/awr-runtime/src/mutation_apply.rs
@@ -15,7 +15,7 @@ use std::{
     path::Path,
 };
 
-fn directory(parent: &Dir, name: &str, path: &Path) -> Result<Dir> {
+pub(crate) fn directory(parent: &Dir, name: &str, path: &Path) -> Result<Dir> {
     match parent.create_dir(name) {
         Ok(()) => (),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => (),
@@ -30,7 +30,7 @@ fn directory(parent: &Dir, name: &str, path: &Path) -> Result<Dir> {
     }
     Ok(parent.open_dir_nofollow(name)?)
 }
-fn recovery_root(root: &Path) -> Result<Dir> {
+pub(crate) fn recovery_root(root: &Path) -> Result<Dir> {
     let runtime = root.join(".awr");
     let project = open_dir_exact(root)?;
     let meta = project.symlink_metadata(".awr")?;
@@ -45,7 +45,7 @@ fn recovery_root(root: &Path) -> Result<Dir> {
         .map_err(|e| Error::SourceUnavailable(format!("{}: {e}", runtime.display())))?;
     directory(&runtime_dir, "mutations", &runtime.join("mutations"))
 }
-struct SourceLock(File);
+pub(crate) struct SourceLock(File);
 impl Drop for SourceLock {
     fn drop(&mut self) {
         // Release this writer's reservation explicitly. A concurrent process spawn
@@ -54,9 +54,18 @@ impl Drop for SourceLock {
         let _ = self.0.unlock();
     }
 }
-fn source_lock(root: &Path, source: Id) -> Result<SourceLock> {
+pub(crate) fn source_lock(root: &Path, source: Id) -> Result<SourceLock> {
+    named_lock(root, &format!("{source}.lock"))
+}
+pub(crate) fn named_lock(root: &Path, name: &str) -> Result<SourceLock> {
+    if name.len() > 100
+        || !name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b".-".contains(&b))
+    {
+        return Err(Error::InvalidInput("invalid mutation lock name".into()));
+    }
     let directory = recovery_root(root)?;
-    let name = format!("{source}.lock");
     let path = root.join(".awr/mutations").join(&name);
     if directory
         .symlink_metadata(&name)
@@ -92,7 +101,7 @@ fn source_lock(root: &Path, source: Id) -> Result<SourceLock> {
     })?;
     Ok(SourceLock(file))
 }
-fn new_file(directory: &Dir, name: &OsStr) -> Result<File> {
+pub(crate) fn new_file(directory: &Dir, name: &OsStr) -> Result<File> {
     let mut options = OpenOptions::new();
     options.create_new(true).write(true);
     #[cfg(unix)]
@@ -190,13 +199,13 @@ fn stored_after(root: &Path, plan: &MutationWritePlan) -> Result<Vec<u8>> {
 
 /// Hold one approved source directory for temp creation, replacement and cleanup.
 /// Domain fingerprint/revision checks still run immediately before install.
-struct SourceReplacement {
+pub(crate) struct SourceReplacement {
     directory: Dir,
     name: OsString,
     temp: Option<OsString>,
 }
 impl SourceReplacement {
-    fn prepare(path: &Path, bytes: &[u8], permissions: fs::Permissions) -> Result<Self> {
+    pub(crate) fn prepare(path: &Path, bytes: &[u8], permissions: fs::Permissions) -> Result<Self> {
         let directory = open_dir_exact(
             path.parent()
                 .ok_or_else(|| Error::InvalidInput("source has no parent".into()))?,
@@ -215,7 +224,7 @@ impl SourceReplacement {
         write_file(file, bytes, Some(permissions))?;
         Ok(replacement)
     }
-    fn install(&mut self) -> Result<()> {
+    pub(crate) fn install(&mut self) -> Result<()> {
         let temp = self.temp.as_ref().ok_or_else(|| {
             Error::InvalidTransition("source replacement was already installed".into())
         })?;

--- a/crates/awr-runtime/src/mutation_apply.rs
+++ b/crates/awr-runtime/src/mutation_apply.rs
@@ -232,6 +232,21 @@ impl SourceReplacement {
         self.temp = None;
         Ok(())
     }
+    /// Publish a fully written new file without replacing a concurrent creator.
+    pub(crate) fn install_new(&mut self) -> Result<()> {
+        let temp = self
+            .temp
+            .as_ref()
+            .ok_or_else(|| Error::InvalidTransition("source was already installed".into()))?;
+        self.directory
+            .hard_link(temp, &self.directory, &self.name)?;
+        self.directory.remove_file(temp)?;
+        self.temp = None;
+        crate::fs_sync::sync_directory(&self.directory)
+    }
+    pub(crate) fn sync_parent(&self) -> Result<()> {
+        crate::fs_sync::sync_directory(&self.directory)
+    }
 }
 impl Drop for SourceReplacement {
     fn drop(&mut self) {

--- a/crates/awr-runtime/src/work_create.rs
+++ b/crates/awr-runtime/src/work_create.rs
@@ -1,0 +1,458 @@
+//! Source-backed draft creation; a request owns one durable single-file outcome.
+use crate::mutation_apply::{
+    SourceReplacement, directory, named_lock, new_file, recovery_root, source_lock,
+};
+use awr_core::*;
+use awr_source::{
+    Manifest, SourceSnapshot, fingerprint, index_project, inspect_registered_source,
+    open_file_exact, prepare_work_creation,
+};
+use awr_store::Store;
+use cap_std::fs::Dir;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    ffi::OsStr,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CreateWorkInput {
+    pub version: u32,
+    pub request_key: String,
+    pub title: String,
+    #[serde(default)]
+    pub source_id: Option<Id>,
+}
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Plan {
+    version: u32,
+    project_id: Id,
+    project_root: PathBuf,
+    project_revision: Revision,
+    request: CreateWorkInput,
+    source: Source,
+    external_key: String,
+    before_fingerprint: String,
+    after_fingerprint: String,
+}
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Receipt {
+    plan: Plan,
+    preview_fingerprint: String,
+    phase: String,
+    work_id: Option<Id>,
+    project_revision: Revision,
+}
+pub struct CreationReport {
+    pub value: Value,
+    pub failure: Option<Error>,
+}
+
+fn validate_key(key: &str) -> Result<()> {
+    if key.trim().is_empty() || key.len() > 512 || key.chars().any(char::is_control) {
+        return Err(Error::InvalidInput(
+            "request_key requires 1..512 bytes without control characters".into(),
+        ));
+    }
+    ensure_public_text(key)
+}
+fn identity(project: Id, key: &str) -> Result<String> {
+    validate_key(key)?;
+    Ok(fingerprint(&serde_json::to_vec(&(project, key))?)
+        .trim_start_matches("sha256:")
+        .into())
+}
+fn receipt_name(project: Id, key: &str) -> Result<String> {
+    Ok(format!("work-create-{}", identity(project, key)?))
+}
+fn read(path: &Path, cap: u64) -> Result<Vec<u8>> {
+    let file = open_file_exact(path)?;
+    if !file.metadata()?.is_file() || file.metadata()?.len() > cap {
+        return Err(Error::InvalidInput(
+            "invalid or oversized creation recovery file".into(),
+        ));
+    }
+    let mut bytes = Vec::new();
+    file.take(cap + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > cap {
+        return Err(Error::InvalidInput(
+            "creation recovery file grew beyond its bound".into(),
+        ));
+    }
+    Ok(bytes)
+}
+fn load(root: &Path, project: Id, key: &str) -> Result<Option<Receipt>> {
+    let base = root
+        .join(".awr/mutations")
+        .join(receipt_name(project, key)?);
+    match std::fs::symlink_metadata(&base) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+        Ok(m) if m.file_type().is_symlink() || !m.is_dir() => {
+            return Err(Error::RuleViolation(
+                "creation recovery directory must be real".into(),
+            ));
+        }
+        _ => (),
+    }
+    let value: Receipt = serde_json::from_slice(&read(&base.join("receipt.json"), 128 * 1024)?)?;
+    if value.plan.version != 1
+        || value.plan.request.version != 1
+        || !["prepared", "applied", "completed"].contains(&value.phase.as_str())
+    {
+        return Err(Error::InvalidInput(
+            "unsupported creation receipt version or phase".into(),
+        ));
+    }
+    if value.plan.project_id != project
+        || value.plan.project_root != root
+        || value.plan.request.request_key != key
+        || fingerprint(&serde_json::to_vec(&value.plan)?) != value.preview_fingerprint
+    {
+        return Err(Error::SourceConflict(
+            "creation receipt differs from its bound project or plan".into(),
+        ));
+    }
+    Ok(Some(value))
+}
+fn save(dir: &Dir, receipt: &Receipt) -> Result<()> {
+    let temp = format!("receipt-{}.tmp", Id::new());
+    let mut file = new_file(dir, OsStr::new(&temp))?;
+    file.write_all(&serde_json::to_vec_pretty(receipt)?)?;
+    file.sync_all()?;
+    drop(file);
+    dir.rename(&temp, dir, "receipt.json")?;
+    crate::fs_sync::sync_directory(dir)
+}
+fn summary(receipt: &Receipt, replay: bool) -> Result<Value> {
+    Ok(
+        json!({"ok":receipt.phase=="completed","status":if receipt.phase=="completed"{"completed"}else{"pending_recovery"},
+        "request_key":receipt.plan.request.request_key,"external_key":receipt.plan.external_key,"work_id":receipt.work_id,
+        "project_id":receipt.plan.project_id,"project_revision":receipt.project_revision,"source_id":receipt.plan.source.id,
+        "preview_fingerprint":receipt.preview_fingerprint,"phase":receipt.phase,"already_recorded":replay,
+        "source_write_performed":false,"runtime_write_performed":false,"historical_outcome":true,
+        "write_outcome":if receipt.phase=="completed"{"applied"}else{"pending_recovery"},
+        "draft":true,"completion_claimed":false,
+        "recovery_directory":format!(".awr/mutations/{}",receipt_name(receipt.plan.project_id,&receipt.plan.request.request_key)?)}),
+    )
+}
+pub fn creation_status(store: &Store, root: &Path, key: &str) -> Result<CreationReport> {
+    let root = root.canonicalize()?;
+    let project = store.project_by_root(&root)?;
+    let receipt = load(&root, project.id, key)?;
+    let value = if let Some(r) = receipt {
+        let mut value = summary(&r, true)?;
+        value["found"] = json!(true);
+        value["read_only"] = json!(true);
+        value["current_source"] = json!(match inspect_registered_source(&root, &r.plan.source) {
+            Ok((_, _, s)) if s.fingerprint == r.plan.after_fingerprint => "after",
+            Ok((_, _, s)) if s.fingerprint == r.plan.before_fingerprint => "before",
+            Ok(_) => "externally_changed",
+            Err(_) => "unavailable_or_registration_changed",
+        });
+        value
+    } else {
+        json!({"ok":true,"found":false,"read_only":true,"source_write_performed":false,"runtime_write_performed":false})
+    };
+    Ok(CreationReport {
+        value,
+        failure: None,
+    })
+}
+
+pub fn create_work(
+    store: &mut Store,
+    root: &Path,
+    input: CreateWorkInput,
+    accept: bool,
+    expected_preview: Option<&str>,
+    expected_revision: Option<Revision>,
+) -> Result<CreationReport> {
+    let root = root.canonicalize()?;
+    let project = store.project_by_root(&root)?;
+    validate_key(&input.request_key)?;
+    ensure_public_data(&input)?;
+    if input.version != 1
+        || input.title.trim().is_empty()
+        || input.title.len() > 4096
+        || input.title.chars().any(char::is_control)
+    {
+        return Err(Error::InvalidInput(
+            "creation requires version 1 and a 1..4096 byte title without control characters"
+                .into(),
+        ));
+    }
+    let key = identity(project.id, &input.request_key)?;
+    let _request_lock = if accept {
+        Some(named_lock(&root, &format!("work-create-{key}.lock"))?)
+    } else {
+        None
+    };
+    if let Some(receipt) = load(&root, project.id, &input.request_key)? {
+        if receipt.plan.request != input {
+            return Err(Error::SourceConflict(
+                "request_key already belongs to different creation content".into(),
+            ));
+        }
+        return Ok(CreationReport {
+            value: summary(&receipt, true)?,
+            failure: (receipt.phase!="completed").then(||Error::MutationConflict("creation is pending; inspect its receipt and explicitly recover instead of replaying".into())),
+        });
+    }
+    let manifest = Manifest::load(&root)?;
+    let report = index_project(store, &root, &manifest, false)?;
+    if !report.ok {
+        return Err(Error::SourceStale(
+            "refresh every registered source before creating work".into(),
+        ));
+    }
+    let revision = store.project(project.id)?.project_revision;
+    if let Some(expected) = expected_revision
+        && expected != revision
+    {
+        return Err(Error::RevisionConflict {
+            expected,
+            actual: revision,
+        });
+    }
+    let sources = store.sources(project.id)?;
+    let candidates: Vec<_> = sources
+        .into_iter()
+        .filter(|s| {
+            s.domain == "ledger" && input.source_id.map_or(s.role == "primary", |id| s.id == id)
+        })
+        .collect();
+    if candidates.len() != 1 {
+        return Err(Error::SourceConflict(
+            "choose exactly one registered ledger source for creation".into(),
+        ));
+    }
+    let source = candidates.into_iter().next().unwrap();
+    let _source_lock = if accept {
+        Some(source_lock(&root, source.id)?)
+    } else {
+        None
+    };
+    let external_key = format!("WORK-{}", &key[..32]);
+    if store
+        .work_items(project.id)?
+        .iter()
+        .any(|w| w.item.meta.external_key == external_key)
+    {
+        return Err(Error::SourceConflict(
+            "generated work key already exists; inspect its source instead of overwriting".into(),
+        ));
+    }
+    let prepared = prepare_work_creation(&root, &source, &external_key, &input.title)?;
+    let plan = Plan {
+        version: 1,
+        project_id: project.id,
+        project_root: root.clone(),
+        project_revision: revision,
+        request: input,
+        source,
+        external_key,
+        before_fingerprint: prepared.before.fingerprint.clone(),
+        after_fingerprint: prepared.after.fingerprint.clone(),
+    };
+    let preview = fingerprint(&serde_json::to_vec(&plan)?);
+    if !accept {
+        return Ok(CreationReport {
+            value: json!({"ok":true,"status":"preview","project_revision":revision,"requires_accept":true,
+            "preview":{"fingerprint":preview,"plan":plan,"before_text":prepared.before.text()?,"after_text":prepared.after.text()?,"new_record":prepared.record},
+            "source_write_performed":false,"runtime_write_performed":true,"draft":true,"completion_claimed":false}),
+            failure: None,
+        });
+    }
+    if expected_revision.is_none() || expected_preview != Some(preview.as_str()) {
+        return Err(Error::SourceConflict(
+            "creation accept requires the exact reviewed preview and project revision".into(),
+        ));
+    }
+    let mutations = recovery_root(&root)?;
+    let name = receipt_name(project.id, &plan.request.request_key)?;
+    mutations.create_dir(&name)?;
+    let dir = directory(&mutations, &name, &root.join(".awr/mutations").join(&name))?;
+    for (name, bytes) in [
+        ("before.yaml", &prepared.before.bytes),
+        ("after.yaml", &prepared.after.bytes),
+    ] {
+        let mut file = new_file(&dir, OsStr::new(name))?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+    }
+    let mut receipt = Receipt {
+        plan,
+        preview_fingerprint: preview,
+        phase: "prepared".into(),
+        work_id: None,
+        project_revision: revision,
+    };
+    save(&dir, &receipt)?;
+    crate::fs_sync::sync_directory(&mutations)?;
+    finish(store, &root, &dir, &mut receipt, expected_revision.unwrap())
+}
+
+pub fn recover_creation(
+    store: &mut Store,
+    root: &Path,
+    key: &str,
+    expected_revision: Revision,
+) -> Result<CreationReport> {
+    let root = root.canonicalize()?;
+    let project = store.project_by_root(&root)?;
+    let _request_lock = named_lock(
+        &root,
+        &format!("work-create-{}.lock", identity(project.id, key)?),
+    )?;
+    let mut receipt =
+        load(&root, project.id, key)?.ok_or_else(|| Error::NotFound("creation receipt".into()))?;
+    if receipt.phase == "completed" {
+        return Ok(CreationReport {
+            value: summary(&receipt, true)?,
+            failure: None,
+        });
+    }
+    let _source_lock = source_lock(&root, receipt.plan.source.id)?;
+    let dir = awr_source::open_dir_exact(
+        &root
+            .join(".awr/mutations")
+            .join(receipt_name(project.id, key)?),
+    )?;
+    finish(store, &root, &dir, &mut receipt, expected_revision)
+}
+fn finish(
+    store: &mut Store,
+    root: &Path,
+    dir: &Dir,
+    receipt: &mut Receipt,
+    expected: Revision,
+) -> Result<CreationReport> {
+    let mut wrote = false;
+    let mut index_report = None;
+    let result = (|| -> Result<()> {
+        let actual = store.project(receipt.plan.project_id)?.project_revision;
+        if actual != expected {
+            return Err(Error::RevisionConflict { expected, actual });
+        }
+        let plan = &receipt.plan;
+        let base = root
+            .join(".awr/mutations")
+            .join(receipt_name(plan.project_id, &plan.request.request_key)?);
+        let before = read(&base.join("before.yaml"), awr_source::YAML_READ_CAP)?;
+        let after = read(&base.join("after.yaml"), awr_source::YAML_READ_CAP)?;
+        if fingerprint(&before) != plan.before_fingerprint
+            || fingerprint(&after) != plan.after_fingerprint
+        {
+            return Err(Error::SourceConflict(
+                "creation snapshots differ from the reviewed plan".into(),
+            ));
+        }
+        let (locator, spec, current) = inspect_registered_source(root, &plan.source)?;
+        let awr_source::Locator::File(path) = locator else {
+            return Err(Error::MutationUnsupported(
+                "creation cannot write Git sources".into(),
+            ));
+        };
+        if current.fingerprint != plan.before_fingerprint
+            && current.fingerprint != plan.after_fingerprint
+        {
+            return Err(Error::SourceConflict(
+                "creation recovery retains externally changed source bytes".into(),
+            ));
+        }
+        // Recovery also reparses its immutable after snapshot through the registered adapter.
+        use awr_source::SourceAdapter;
+        awr_source::YamlLedgerAdapter.parse(
+            &SourceSnapshot {
+                locator: current.locator.clone(),
+                bytes: after.clone(),
+                fingerprint: plan.after_fingerprint.clone(),
+            },
+            &awr_source::ParseContext {
+                source: &plan.source,
+                existing_ids: store.projection_ids(&plan.source)?,
+            },
+            &spec,
+        )?;
+        if current.fingerprint == plan.before_fingerprint {
+            let permissions = open_file_exact(&path)?.metadata()?.permissions();
+            if permissions.readonly() {
+                return Err(Error::RuleViolation("ledger is read-only".into()));
+            }
+            let mut replacement = SourceReplacement::prepare(&path, &after, permissions)?;
+            let (_, _, last) = inspect_registered_source(root, &plan.source)?;
+            if last.fingerprint != plan.before_fingerprint {
+                return Err(Error::SourceConflict(
+                    "ledger changed immediately before creation write".into(),
+                ));
+            }
+            let actual = store.project(plan.project_id)?.project_revision;
+            if actual != expected {
+                return Err(Error::RevisionConflict { expected, actual });
+            }
+            replacement.install()?;
+            wrote = true;
+        }
+        receipt.phase = "applied".into();
+        save(dir, receipt)?;
+        let indexed = index_project(store, root, &Manifest::load(root)?, false)?;
+        index_report = Some(serde_json::to_value(&indexed)?);
+        receipt.project_revision = indexed.project_revision;
+        if !indexed.ok {
+            return Err(Error::SourceStale(
+                "creation source applied but project projection is incomplete".into(),
+            ));
+        }
+        let work = store
+            .work_items(plan.project_id)?
+            .into_iter()
+            .find(|w| w.item.meta.external_key == plan.external_key)
+            .ok_or_else(|| {
+                Error::SourceConflict("created work is absent from its projection".into())
+            })?;
+        if work.source.id != plan.source.id
+            || work.source.fingerprint != plan.after_fingerprint
+            || work.item.title != plan.request.title
+        {
+            return Err(Error::SourceConflict(
+                "created work differs from the reviewed source identity".into(),
+            ));
+        }
+        let (_, _, last) = inspect_registered_source(root, &plan.source)?;
+        if last.fingerprint != plan.after_fingerprint {
+            return Err(Error::SourceConflict(
+                "ledger changed before creation finalization".into(),
+            ));
+        }
+        receipt.work_id = Some(work.item.meta.id);
+        receipt.phase = "completed".into();
+        save(dir, receipt)
+    })();
+    let mut value = summary(receipt, false)?;
+    value["source_write_performed"] = json!(wrote);
+    value["runtime_write_performed"] = json!(true);
+    value["historical_outcome"] = json!(false);
+    if let Some(report) = index_report {
+        value["index"] = report;
+    }
+    if let Err(error) = result {
+        value["ok"] = json!(false);
+        value["status"] = json!("pending_recovery");
+        value["write_outcome"] = json!("pending_recovery");
+        value["error"] = serde_json::to_value(error.report())?;
+        return Ok(CreationReport {
+            value,
+            failure: Some(error),
+        });
+    }
+    Ok(CreationReport {
+        value,
+        failure: None,
+    })
+}

--- a/crates/awr-source/src/directory.rs
+++ b/crates/awr-source/src/directory.rs
@@ -344,7 +344,7 @@ fn git_files(root: &Path, revision: &str, path: &Path, recursive: bool) -> Resul
     Ok(files)
 }
 
-fn frontmatter(text: &str) -> Result<Value> {
+pub(crate) fn frontmatter(text: &str) -> Result<Value> {
     let mut lines = text.split_inclusive('\n');
     if lines.next().is_none_or(|line| line.trim() != "---") {
         return Ok(serde_json::json!({}));
@@ -393,7 +393,7 @@ fn metadata_strings(value: &Value, key: &str) -> Result<Vec<String>> {
         _ => Err(Error::InvalidInput(format!("ADR {key} must be a list"))),
     }
 }
-fn header_fields(body: &str) -> Result<BTreeMap<String, String>> {
+pub(crate) fn header_fields(body: &str) -> Result<BTreeMap<String, String>> {
     let mut fields = BTreeMap::new();
     for line in body.lines() {
         if line.trim().is_empty() {
@@ -478,7 +478,7 @@ fn metadata_equal(key: &str, left: &Value, right: &Value) -> bool {
     }
     left == right
 }
-fn insert_metadata(metadata: &mut Value, key: &str, value: Value) -> Result<()> {
+pub(crate) fn insert_metadata(metadata: &mut Value, key: &str, value: Value) -> Result<()> {
     if let Some(previous) = metadata.get(key) {
         if !metadata_equal(key, previous, &value) {
             return Err(Error::SourceConflict(

--- a/crates/awr-source/src/document.rs
+++ b/crates/awr-source/src/document.rs
@@ -1,0 +1,293 @@
+//! Exact document edits. Prose is opaque; the registered adapter owns its metadata.
+use crate::*;
+use awr_core::{DecisionStatus, EntityKind, Freshness, Id, Source};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    collections::BTreeMap,
+    path::{Component, Path, PathBuf},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DocumentEdit {
+    Replace { text: String },
+    Fragment { before: String, after: String },
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DocumentAction {
+    Edit {
+        source_id: Id,
+        source_fingerprint: String,
+        edit: DocumentEdit,
+    },
+    CreateDraft {
+        path: PathBuf,
+        title: String,
+        body: String,
+    },
+}
+pub struct PreparedDocument {
+    pub path: PathBuf,
+    pub source: Source,
+    pub spec: SourceSpec,
+    pub before: Option<SourceSnapshot>,
+    pub after: SourceSnapshot,
+}
+fn snapshot(path: &Path, text: String) -> Result<SourceSnapshot> {
+    let bytes = text.into_bytes();
+    crate::limits::check_source_size(&bytes, MARKDOWN_READ_CAP)?;
+    awr_core::ensure_public_text(
+        std::str::from_utf8(&bytes).map_err(|e| Error::InvalidInput(e.to_string()))?,
+    )?;
+    Ok(SourceSnapshot {
+        locator: Locator::File(path.into()).identity()?,
+        fingerprint: fingerprint(&bytes),
+        bytes,
+    })
+}
+fn invariant(batch: &ProjectionBatch) -> BTreeMap<(EntityKind, String), Value> {
+    let mut values = BTreeMap::new();
+    for g in &batch.goals {
+        values.insert(
+            (EntityKind::Goal, g.meta.external_key.clone()),
+            json!([g.status]),
+        );
+    }
+    for p in &batch.plans {
+        values.insert(
+            (EntityKind::Plan, p.meta.external_key.clone()),
+            json!([p.status, p.kind]),
+        );
+    }
+    for r in &batch.rules {
+        values.insert(
+            (EntityKind::Rule, r.meta.external_key.clone()),
+            json!([r.severity, r.scope]),
+        );
+    }
+    for d in &batch.decisions {
+        values.insert(
+            (EntityKind::Decision, d.meta.external_key.clone()),
+            json!([d.status, d.raw_status]),
+        );
+    }
+    values
+}
+/// Only one registered mapping may own the target path, including aliases in other domains.
+pub fn document_path_registration(root: &Path, path: &Path) -> Result<SourceSpec> {
+    let manifest = Manifest::load(root)?;
+    let mut matches = Vec::new();
+    for spec in &manifest.sources {
+        let Locator::File(base) = Locator::from_spec(root, &manifest, spec)? else {
+            continue;
+        };
+        let matches_path = if spec.adapter == "markdown-directory-v1" {
+            path.strip_prefix(&base).ok().is_some_and(|relative| {
+                !relative.as_os_str().is_empty()
+                    && relative.components().all(|part| matches!(part,Component::Normal(name) if !name.to_string_lossy().starts_with('.')))
+                    && (spec.options.get("recursive").and_then(toml::Value::as_bool).unwrap_or(true) || relative.components().count()==1)
+            })
+        } else {
+            base == path
+        };
+        if matches_path {
+            matches.push(spec.clone());
+        }
+    }
+    if matches.len() != 1 {
+        return Err(Error::SourceConflict(format!(
+            "document target requires exactly one registered mapping; found {}",
+            matches.len()
+        )));
+    }
+    let spec = matches.pop().unwrap();
+    if ![
+        "markdown-heading-v1",
+        "markdown-rules-v1",
+        "markdown-directory-v1",
+    ]
+    .contains(&spec.adapter.as_str())
+    {
+        return Err(Error::MutationUnsupported(
+            "document editing excludes work ledgers and unrecognized adapters".into(),
+        ));
+    }
+    Ok(spec)
+}
+/// Re-validate declarations even where a heading adapter does not consume front matter.
+fn declarations(snapshot: &SourceSnapshot, spec: &SourceSpec) -> Result<()> {
+    let sections = markdown_sections(snapshot)?;
+    let mut meta = crate::directory::frontmatter(snapshot.text()?)?;
+    if let Some(header) = sections.iter().find(|s| s.level > 0) {
+        for (key, value) in crate::directory::header_fields(&header.body)? {
+            if ["status", "id", "title"].contains(&key.as_str()) {
+                crate::directory::insert_metadata(&mut meta, &key, json!(value))?;
+            }
+        }
+        if let Some(status) = header.attributes.get("status") {
+            crate::directory::insert_metadata(&mut meta, "status", json!(status))?;
+        }
+    }
+    // A heading source cannot silently ignore an alternate document status declaration.
+    if spec.adapter != "markdown-directory-v1" && !meta["status"].is_null() {
+        let effective = sections
+            .iter()
+            .find(|s| s.level > 0)
+            .and_then(|s| s.attributes.get("status").map(String::as_str))
+            .or_else(|| spec.options.get("status").and_then(toml::Value::as_str))
+            .unwrap_or("unknown");
+        if meta["status"].as_str() != Some(effective) {
+            return Err(Error::SourceConflict("document metadata status differs from the registered heading declaration; select and reconcile the locations first".into()));
+        }
+    }
+    Ok(())
+}
+pub fn prepare_document_edit(
+    root: &Path,
+    source: &Source,
+    expected: &str,
+    edit: &DocumentEdit,
+    ids: BTreeMap<(EntityKind, String), Id>,
+) -> Result<PreparedDocument> {
+    let (locator, spec, before) = inspect_registered_source(root, source)?;
+    let Locator::File(path) = locator else {
+        return Err(Error::MutationUnsupported(
+            "Git document snapshots are read-only".into(),
+        ));
+    };
+    document_path_registration(root, &path)?;
+    if expected != before.fingerprint || source.fingerprint != before.fingerprint {
+        return Err(Error::SourceConflict(
+            "document source changed since the edit was prepared".into(),
+        ));
+    }
+    let text = before.text()?;
+    let new_text = match edit {
+        DocumentEdit::Replace { text } => text.clone(),
+        DocumentEdit::Fragment { before, after } => {
+            if before.is_empty() || text.match_indices(before).count() != 1 {
+                return Err(Error::SourceConflict(
+                    "document fragment must match exactly once; use an explicit longer fragment"
+                        .into(),
+                ));
+            }
+            text.replacen(before, after, 1)
+        }
+    };
+    let after = snapshot(&path, new_text)?;
+    declarations(&before, &spec)?;
+    declarations(&after, &spec)?;
+    let adapter = source_adapter(&spec.adapter)?;
+    let context = ParseContext {
+        source,
+        existing_ids: ids,
+    };
+    let prior = adapter.parse(&before, &context, &spec)?;
+    let next = adapter.parse(&after, &context, &spec)?;
+    if invariant(&prior) != invariant(&next) {
+        return Err(Error::RuleViolation("document body edits must retain object keys, status and rule constraints; adoption and lifecycle changes require explicit domain actions".into()));
+    }
+    Ok(PreparedDocument {
+        path,
+        source: source.clone(),
+        spec,
+        before: Some(before),
+        after,
+    })
+}
+pub fn prepare_document_draft(
+    root: &Path,
+    project: Id,
+    path: &Path,
+    title: &str,
+    body: &str,
+    key: &str,
+) -> Result<PreparedDocument> {
+    if path.is_absolute() || path.components().any(|part|!matches!(part,Component::Normal(name) if !name.to_string_lossy().starts_with('.'))) {
+        return Err(Error::RuleViolation("draft path must be a visible relative path inside its registered directory".into()));
+    }
+    if !path
+        .extension()
+        .and_then(|s| s.to_str())
+        .is_some_and(|s| s.eq_ignore_ascii_case("md") || s.eq_ignore_ascii_case("markdown"))
+    {
+        return Err(Error::InvalidInput(
+            "draft requires a Markdown file extension".into(),
+        ));
+    }
+    if title.trim().is_empty() || title.len() > 4096 || title.chars().any(char::is_control) {
+        return Err(Error::InvalidInput(
+            "draft requires a bounded single-line title".into(),
+        ));
+    }
+    let path = root.join(path);
+    let parent = path
+        .parent()
+        .ok_or_else(|| Error::InvalidInput("draft has no parent".into()))?;
+    open_dir_exact(parent)?;
+    let spec = document_path_registration(root, &path)?;
+    if spec.adapter != "markdown-directory-v1" {
+        return Err(Error::MutationUnsupported(
+            "new drafts require an explicitly registered Markdown decisions directory".into(),
+        ));
+    }
+    match std::fs::symlink_metadata(&path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => (),
+        Err(e) => return Err(e.into()),
+        Ok(_) => {
+            return Err(Error::SourceConflict(
+                "draft destination already exists; existing files are never overwritten".into(),
+            ));
+        }
+    }
+    let text = format!(
+        "---\nid: {}\ntitle: {}\nstatus: proposed\n---\n# {}\n\n{}",
+        serde_json::to_string(key)?,
+        serde_json::to_string(title)?,
+        title,
+        body
+    );
+    let after = snapshot(&path, text)?;
+    let source = Source {
+        id: Id::new(),
+        project_id: project,
+        domain: spec.domain.clone(),
+        role: spec.role.clone(),
+        locator: after.locator.clone(),
+        format: "markdown".into(),
+        adapter: spec.adapter.clone(),
+        revision: 0,
+        fingerprint: String::new(),
+        freshness: Freshness::Fresh,
+        config: source_configuration(
+            &spec,
+            Manifest::load(root)?.project.context_profile == ContextProfile::Minimal,
+        ),
+    };
+    declarations(&after, &spec)?;
+    let batch = source_adapter(&spec.adapter)?.parse(
+        &after,
+        &ParseContext {
+            source: &source,
+            existing_ids: BTreeMap::new(),
+        },
+        &spec,
+    )?;
+    if batch.decisions.len() != 1
+        || batch.decisions[0].status != DecisionStatus::Proposed
+        || batch.decisions[0].meta.external_key != key
+    {
+        return Err(Error::RuleViolation(
+            "new document must remain the requested draft".into(),
+        ));
+    }
+    Ok(PreparedDocument {
+        path,
+        source,
+        spec,
+        before: None,
+        after,
+    })
+}

--- a/crates/awr-source/src/ledger_mapping.rs
+++ b/crates/awr-source/src/ledger_mapping.rs
@@ -98,7 +98,9 @@ impl LedgerMapping {
                 || raw != raw.trim()
                 || raw.chars().any(char::is_control)
                 || status == WorkStatus::Unknown
-                || (existing != WorkStatus::Unknown && existing != status)
+                // Before draft became a built-in nonselectable state, projects could
+                // explicitly map that source spelling. Retain those prior mappings.
+                || (existing != WorkStatus::Unknown && existing != WorkStatus::Draft && existing != status)
                 || !keys.insert(key)
             {
                 return Err(Error::InvalidInput("status_map requires unique source statuses and canonical targets; canonical states cannot be redefined".into()));

--- a/crates/awr-source/src/lib.rs
+++ b/crates/awr-source/src/lib.rs
@@ -10,6 +10,7 @@ mod manifest;
 mod markdown;
 mod markdown_ledger;
 mod mutation;
+mod yaml_create;
 mod yaml_edit;
 mod yaml_ledger;
 mod yaml_mutation;
@@ -33,8 +34,11 @@ pub use markdown::{
     MarkdownHeadingAdapter, MarkdownRulesAdapter, MarkdownSection, markdown_sections,
 };
 pub use markdown_ledger::MarkdownLedgerAdapter;
-pub use mutation::{MutationSourceCheck, inspect_mutation_source, verify_mutation_source};
+pub use mutation::{
+    MutationSourceCheck, inspect_mutation_source, inspect_registered_source, verify_mutation_source,
+};
 pub use safe_fs::{open_dir_exact, open_file_exact};
+pub use yaml_create::{PreparedWorkCreation, prepare_work_creation};
 pub use yaml_ledger::YamlLedgerAdapter;
 pub use yaml_mutation::{
     PreparedYamlMutation, parse_mutation_projection, prepare_yaml_mutation,

--- a/crates/awr-source/src/lib.rs
+++ b/crates/awr-source/src/lib.rs
@@ -1,6 +1,7 @@
 //! Authoritative project source configuration and adapter contracts.
 mod adapter;
 mod directory;
+mod document;
 mod freshness;
 mod indexer;
 mod ledger_mapping;
@@ -18,6 +19,10 @@ mod yaml_mutation;
 pub use adapter::{ParseContext, ProjectionBatch, SourceAdapter};
 pub use awr_core::{Error, Result};
 pub use directory::{DirectoryDelta, DirectoryInventory, MarkdownDirectoryAdapter};
+pub use document::{
+    DocumentAction, DocumentEdit, PreparedDocument, document_path_registration,
+    prepare_document_draft, prepare_document_edit,
+};
 pub use freshness::{SourceObservation, observe_source};
 pub use indexer::{
     IndexIssue, IndexReport, IndexedSource, index_project, scan_project, source_adapter,

--- a/crates/awr-source/src/markdown.rs
+++ b/crates/awr-source/src/markdown.rs
@@ -182,6 +182,8 @@ struct MarkdownOptions {
     severity: Option<String>,
     scope: Option<String>,
     value: Option<String>,
+    /// Optional host-facing plan document type, such as architecture.
+    kind: Option<String>,
 }
 impl MarkdownOptions {
     fn load(spec: &SourceSpec) -> Result<Self> {
@@ -267,7 +269,12 @@ impl SourceAdapter for MarkdownHeadingAdapter {
                     meta: meta(context, snapshot, EntityKind::Plan, &section, &options)?,
                     title: section.title,
                     status,
-                    kind: Some("markdown_section".into()),
+                    kind: Some(
+                        options
+                            .kind
+                            .clone()
+                            .unwrap_or_else(|| "markdown_section".into()),
+                    ),
                     summary: section.body,
                     scope: vec![],
                     acceptance: vec![],

--- a/crates/awr-source/src/mutation.rs
+++ b/crates/awr-source/src/mutation.rs
@@ -67,6 +67,19 @@ pub fn inspect_mutation_source(
             "mutation source identity/configuration differs from its binding".into(),
         ));
     }
+    let (locator, spec, snapshot) = inspect_registered_source(root, source)?;
+    if snapshot.locator != patch.target.meta.source_ref.locator {
+        return Err(Error::SourceConflict("proposal source bytes or immutable locator changed; keep the proposal for review and create a new one from current facts".into()));
+    }
+    Ok((locator, spec, snapshot))
+}
+
+/// Resolve exactly one currently registered source, retaining its bound configuration.
+/// This is a read-only observation; writers must hold their source lock and recheck bytes.
+pub fn inspect_registered_source(
+    root: &Path,
+    source: &Source,
+) -> Result<(Locator, SourceSpec, SourceSnapshot)> {
     let root = root.canonicalize()?;
     let manifest = Manifest::load(&root)?;
     let mut matches = Vec::new();
@@ -91,9 +104,7 @@ pub fn inspect_mutation_source(
                 spec,
                 manifest.project.context_profile == crate::ContextProfile::Minimal,
             );
-            if source.adapter != spec.adapter
-                || source.role != spec.role
-                || config != patch.source_config
+            if source.adapter != spec.adapter || source.role != spec.role || config != source.config
             {
                 return Err(Error::SourceConflict(
                     "proposal source mapping or adapter configuration has changed".into(),
@@ -110,8 +121,5 @@ pub fn inspect_mutation_source(
     }
     let (locator, spec) = matches.pop().unwrap();
     let snapshot = locator.read(&root, crate::source_read_cap(&spec.adapter)?)?;
-    if snapshot.locator != patch.target.meta.source_ref.locator {
-        return Err(Error::SourceConflict("proposal source bytes or immutable locator changed; keep the proposal for review and create a new one from current facts".into()));
-    }
     Ok((locator, spec, snapshot))
 }

--- a/crates/awr-source/src/yaml_create.rs
+++ b/crates/awr-source/src/yaml_create.rs
@@ -1,0 +1,124 @@
+use crate::{
+    LedgerMapping, Locator, ParseContext, SourceAdapter, SourceSnapshot, YamlLedgerAdapter,
+    fingerprint, inspect_registered_source,
+};
+use awr_core::*;
+use serde_json::{Value, json};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+pub struct PreparedWorkCreation {
+    pub path: PathBuf,
+    pub before: SourceSnapshot,
+    pub after: SourceSnapshot,
+    pub record: Value,
+}
+
+pub fn prepare_work_creation(
+    root: &Path,
+    source: &Source,
+    external_key: &str,
+    title: &str,
+) -> Result<PreparedWorkCreation> {
+    if source.adapter != "yaml-ledger-v1" || source.domain != "ledger" {
+        return Err(Error::MutationUnsupported(
+            "new work requires a registered YAML ledger".into(),
+        ));
+    }
+    if source.freshness != Freshness::Fresh {
+        return Err(Error::SourceStale(
+            "refresh the ledger before creating work".into(),
+        ));
+    }
+    let (locator, spec, before) = inspect_registered_source(root, source)?;
+    let Locator::File(path) = locator else {
+        return Err(Error::MutationUnsupported(
+            "Git sources remain read-only".into(),
+        ));
+    };
+    if path.starts_with(root.canonicalize()?.join(".awr")) {
+        return Err(Error::RuleViolation(
+            "runtime files cannot be task sources".into(),
+        ));
+    }
+    if before.fingerprint != source.fingerprint {
+        return Err(Error::SourceConflict(
+            "ledger changed before preparing new work".into(),
+        ));
+    }
+    let mapping = LedgerMapping::from_spec(&spec)?;
+    let fields = vec![
+        (mapping.source_field("id").to_owned(), json!(external_key)),
+        (mapping.source_field("title").to_owned(), json!(title)),
+        (
+            mapping.source_field("status").to_owned(),
+            mapping.write_value("status", &json!("draft"), &json!({}))?,
+        ),
+    ];
+    let record = Value::Object(fields.iter().cloned().collect());
+    let mut expected: Value = serde_yaml_ng::from_str(before.text()?)
+        .map_err(|_| Error::InvalidInput("invalid YAML ledger".into()))?;
+    match expected.get_mut("work_items") {
+        Some(Value::Array(items)) => items.push(record.clone()),
+        Some(Value::Object(items)) => {
+            if items.insert(external_key.into(), record.clone()).is_some() {
+                return Err(Error::SourceConflict("new task key already exists".into()));
+            }
+        }
+        _ => {
+            return Err(Error::MutationUnsupported(
+                "work_items requires an explicit list or keyed map".into(),
+            ));
+        }
+    }
+    let output = crate::yaml_edit::append_work(before.text()?, external_key, &fields)?;
+    crate::limits::check_source_size(output.as_bytes(), crate::YAML_READ_CAP)?;
+    let actual: Value = serde_yaml_ng::from_str(&output).map_err(|_| {
+        Error::MutationUnsupported("new record cannot preserve this YAML shape".into())
+    })?;
+    if actual != expected {
+        return Err(Error::MutationUnsupported(
+            "creation changed facts outside the new record".into(),
+        ));
+    }
+    let after = SourceSnapshot {
+        locator: before.locator.clone(),
+        fingerprint: fingerprint(output.as_bytes()),
+        bytes: output.into_bytes(),
+    };
+    // Parsing catches duplicate list keys, mapping conflicts and malformed domain fields.
+    let batch = YamlLedgerAdapter.parse(
+        &after,
+        &ParseContext {
+            source,
+            existing_ids: BTreeMap::new(),
+        },
+        &spec,
+    )?;
+    if batch
+        .work_items
+        .iter()
+        .filter(|w| w.meta.external_key == external_key)
+        .count()
+        != 1
+    {
+        return Err(Error::SourceConflict(
+            "new task must have exactly one source identity".into(),
+        ));
+    }
+    if batch
+        .work_items
+        .iter()
+        .any(|w| w.meta.external_key == external_key && w.status != WorkStatus::Draft)
+    {
+        return Err(Error::MutationUnsupported("the source maps draft to an executable state; configure one unambiguous draft spelling before creation".into()));
+    }
+    Ok(PreparedWorkCreation {
+        path,
+        before,
+        after,
+        record,
+    })
+}

--- a/crates/awr-source/src/yaml_edit.rs
+++ b/crates/awr-source/src/yaml_edit.rs
@@ -426,11 +426,7 @@ fn render(text: &str, node: &Node, value: &Value, newline: &str) -> Result<Strin
     }
 }
 
-pub(crate) fn edit_fields(
-    text: &str,
-    pointer: &str,
-    changes: &Map<String, Value>,
-) -> Result<String> {
+fn parse_tree(text: &str) -> Result<Node> {
     let offsets = text
         .char_indices()
         .map(|(i, _)| i)
@@ -451,6 +447,15 @@ pub(crate) fn edit_fields(
             "multiple YAML documents require manual editing",
         ));
     }
+    Ok(root)
+}
+
+pub(crate) fn edit_fields(
+    text: &str,
+    pointer: &str,
+    changes: &Map<String, Value>,
+) -> Result<String> {
+    let root = parse_tree(text)?;
     let mut target = &root;
     for part in pointer
         .strip_prefix('/')
@@ -526,5 +531,108 @@ pub(crate) fn edit_fields(
         boundary = range.start;
         output.replace_range(range, &replacement);
     }
+    Ok(output)
+}
+
+/// Append one record without serializing any existing record or renumbering keys.
+pub(crate) fn append_work(text: &str, key: &str, fields: &[(String, Value)]) -> Result<String> {
+    let root = parse_tree(text)?;
+    let Kind::Mapping(root_fields, ..) = &root.kind else {
+        return Err(unsupported("work creation needs a mapping document"));
+    };
+    let (_, collection) = root_fields
+        .iter()
+        .find(|(k, _)| k == "work_items")
+        .ok_or_else(|| {
+            unsupported("register a YAML ledger with an explicit work_items list or map")
+        })?;
+    let newline = if text.contains("\r\n") { "\r\n" } else { "\n" };
+    let record = Value::Object(fields.iter().cloned().collect());
+    let (at, addition) = match &collection.kind {
+        Kind::Sequence(items) if text[collection.range.start..].starts_with('[') => (
+            collection.range.end - 1,
+            format!(
+                "{}{}",
+                if items.is_empty() { "" } else { ", " },
+                json(&record)?
+            ),
+        ),
+        Kind::Sequence(items) => {
+            let first = items
+                .first()
+                .ok_or_else(|| unsupported("empty block sequences require explicit [] syntax"))?;
+            let line = text[..first.range.start].rfind('\n').map_or(0, |i| i + 1);
+            let dash = text[line..line_end(text, line)]
+                .find('-')
+                .map(|i| line + i)
+                .ok_or_else(|| unsupported("could not locate the ledger list indentation"))?;
+            if !text[line..dash].trim().is_empty() {
+                return Err(unsupported("unsupported compact ledger nesting"));
+            }
+            let indent = column(text, dash);
+            let at = if text[..collection.range.end].ends_with('\n') {
+                collection.range.end
+            } else {
+                line_end(text, collection.range.end)
+            };
+            let mut addition = if text[..at].ends_with('\n') {
+                String::new()
+            } else {
+                newline.into()
+            };
+            for (i, (field, value)) in fields.iter().enumerate() {
+                addition += &format!(
+                    "{}{}{}: {}{newline}",
+                    " ".repeat(indent),
+                    if i == 0 { "- " } else { "  " },
+                    json(&Value::String(field.clone()))?,
+                    json(value)?
+                );
+            }
+            (at, addition)
+        }
+        Kind::Mapping(items, true, _) => (
+            collection.range.end - 1,
+            format!(
+                "{}{}: {}",
+                if items.is_empty() { "" } else { ", " },
+                json(&Value::String(key.into()))?,
+                json(&record)?
+            ),
+        ),
+        Kind::Mapping(_, false, indent) => {
+            let at = if text[..collection.range.end].ends_with('\n') {
+                collection.range.end
+            } else {
+                line_end(text, collection.range.end)
+            };
+            let mut addition = if text[..at].ends_with('\n') {
+                String::new()
+            } else {
+                newline.into()
+            };
+            addition += &format!(
+                "{}{}:{newline}",
+                " ".repeat(*indent),
+                json(&Value::String(key.into()))?
+            );
+            for (field, value) in fields {
+                addition += &format!(
+                    "{}{}: {}{newline}",
+                    " ".repeat(*indent + 2),
+                    json(&Value::String(field.clone()))?,
+                    json(value)?
+                );
+            }
+            (at, addition)
+        }
+        _ => {
+            return Err(unsupported(
+                "work_items must be an explicit list or keyed map",
+            ));
+        }
+    };
+    let mut output = text.to_owned();
+    output.insert_str(at, &addition);
     Ok(output)
 }

--- a/crates/awr-store/migrations/004_draft_work.sql
+++ b/crates/awr-store/migrations/004_draft_work.sql
@@ -1,0 +1,36 @@
+-- Rebuild only the work status constraint; IDs and all existing rows are retained.
+CREATE TABLE work_items_v4 (
+ id TEXT PRIMARY KEY CHECK(length(id)=26),
+ project_id TEXT NOT NULL REFERENCES projects(id),
+ external_key TEXT NOT NULL,
+ title TEXT NOT NULL DEFAULT '',
+ source_id TEXT NOT NULL,
+ source_ref_json TEXT NOT NULL CHECK(json_valid(source_ref_json)),
+ source_revision INTEGER NOT NULL CHECK(source_revision>=0),
+ revision INTEGER NOT NULL CHECK(revision>0),
+ active INTEGER NOT NULL DEFAULT 1 CHECK(active IN (0,1)),
+ payload_json TEXT NOT NULL CHECK(json_valid(payload_json)),
+ updated_at INTEGER NOT NULL,
+ kind TEXT,
+ required INTEGER NOT NULL DEFAULT 0 CHECK(required IN (0,1)),
+ raw_status TEXT NOT NULL,
+ status TEXT NOT NULL CHECK(status IN ('draft','planned','ready','claimed','in_progress','blocked','completed','cancelled','unknown')),
+ priority TEXT,
+ milestone TEXT,
+ score INTEGER,
+ evidence_level TEXT,
+ summary TEXT NOT NULL DEFAULT '',
+ next_action TEXT NOT NULL DEFAULT '',
+ blocker TEXT,
+ acceptance_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(acceptance_json)),
+ tags_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(tags_json)),
+ paths_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(paths_json)),
+ UNIQUE(project_id,external_key),
+ UNIQUE(project_id,id),
+ FOREIGN KEY(project_id,source_id) REFERENCES sources(project_id,id)
+) STRICT;
+INSERT INTO work_items_v4 SELECT * FROM work_items;
+DROP TABLE work_items;
+ALTER TABLE work_items_v4 RENAME TO work_items;
+CREATE INDEX work_items_source ON work_items(project_id,source_id,active);
+CREATE INDEX work_status ON work_items(project_id,status,active,priority);

--- a/crates/awr-store/src/lib.rs
+++ b/crates/awr-store/src/lib.rs
@@ -43,10 +43,11 @@ use std::{path::Path, time::Duration};
 
 const APPLICATION_ID: i64 = 0x41575231;
 /// Schema written by this build. Exposed for offline host compatibility negotiation.
-pub const SCHEMA_VERSION: i64 = 3;
+pub const SCHEMA_VERSION: i64 = 4;
 const CATALOG_SQL: &str = include_str!("../migrations/001_catalog.sql");
 const DOMAIN_SQL: &str = include_str!("../migrations/002_domain.sql");
 const SEARCH_SQL: &str = include_str!("../migrations/003_search.sql");
+const DRAFT_WORK_SQL: &str = include_str!("../migrations/004_draft_work.sql");
 
 /// Domain operations own database writes; no SQL handle is exposed to callers.
 ///
@@ -239,6 +240,12 @@ impl Store {
             }
         }
         if current < SCHEMA_VERSION {
+            // SQLite table rebuild protocol: suppress FK actions only on this unexposed
+            // connection, then check all references before committing and restore enforcement.
+            conn.pragma_update(None, "foreign_keys", false)
+                .map_err(db_error)?;
+            conn.pragma_update(None, "legacy_alter_table", true)
+                .map_err(db_error)?;
             let tx = conn
                 .transaction_with_behavior(TransactionBehavior::Immediate)
                 .map_err(db_error)?;
@@ -276,10 +283,34 @@ impl Store {
                 )
                 .map_err(db_error)?;
             }
+            if version < 4 {
+                // Preserve user diagnostic indexes/triggers as well as owned schema objects.
+                let extras:Vec<String> = tx.prepare("SELECT sql FROM sqlite_master WHERE tbl_name='work_items' AND type IN ('index','trigger') AND sql IS NOT NULL AND name NOT IN ('work_items_source','work_status') ORDER BY name").map_err(db_error)?
+                    .query_map([],|row|row.get(0)).map_err(db_error)?.collect::<rusqlite::Result<_>>().map_err(db_error)?;
+                tx.execute_batch(DRAFT_WORK_SQL).map_err(db_error)?;
+                for sql in extras {
+                    tx.execute_batch(&sql).map_err(db_error)?;
+                }
+                tx.execute("INSERT INTO schema_migrations(version,name,applied_at) VALUES(4,'draft_work',?1)",[now_millis()?]).map_err(db_error)?;
+            }
             tx.pragma_update(None, "user_version", SCHEMA_VERSION)
                 .map_err(db_error)?;
             schema::verify(&tx, SCHEMA_VERSION)?;
+            if tx
+                .prepare("PRAGMA foreign_key_check")
+                .map_err(db_error)?
+                .exists([])
+                .map_err(db_error)?
+            {
+                return Err(Error::Storage(
+                    "migration would leave invalid foreign-key references".into(),
+                ));
+            }
             tx.commit().map_err(db_error)?;
+            conn.pragma_update(None, "legacy_alter_table", false)
+                .map_err(db_error)?;
+            conn.pragma_update(None, "foreign_keys", true)
+                .map_err(db_error)?;
         }
         let store = Self { conn };
         store.verify_catalog()?;

--- a/crates/awr-store/src/schema.rs
+++ b/crates/awr-store/src/schema.rs
@@ -1,5 +1,7 @@
 //! Validate the owned schema against the shipped migrations without repairing it.
-use crate::{CATALOG_SQL, DOMAIN_SQL, MigrationInfo, SCHEMA_VERSION, SEARCH_SQL, db_error};
+use crate::{
+    CATALOG_SQL, DOMAIN_SQL, DRAFT_WORK_SQL, MigrationInfo, SCHEMA_VERSION, SEARCH_SQL, db_error,
+};
 use awr_core::{Error, Result};
 use rusqlite::Connection;
 use std::{collections::BTreeMap, sync::OnceLock};
@@ -7,7 +9,7 @@ use std::{collections::BTreeMap, sync::OnceLock};
 type Definition = (String, String, String);
 type Objects = BTreeMap<String, Definition>;
 static EXPECTED: OnceLock<std::result::Result<Vec<Objects>, String>> = OnceLock::new();
-const MIGRATION_NAMES: [&str; 3] = ["catalog", "domain", "search"];
+const MIGRATION_NAMES: [&str; 4] = ["catalog", "domain", "search", "draft_work"];
 
 fn objects(conn: &Connection) -> rusqlite::Result<Objects> {
     conn.prepare("SELECT name,type,tbl_name,sql FROM sqlite_master WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%' ORDER BY name")?
@@ -20,8 +22,9 @@ fn expected() -> Result<&'static Vec<Objects>> {
         .get_or_init(|| {
             let build = || -> rusqlite::Result<Vec<Objects>> {
                 let conn = Connection::open_in_memory()?;
+                conn.pragma_update(None, "legacy_alter_table", true)?;
                 let mut versions = Vec::new();
-                for sql in [CATALOG_SQL, DOMAIN_SQL, SEARCH_SQL] {
+                for sql in [CATALOG_SQL, DOMAIN_SQL, SEARCH_SQL, DRAFT_WORK_SQL] {
                     conn.execute_batch(sql)?;
                     versions.push(objects(&conn)?);
                 }

--- a/crates/awr-store/tests/search.rs
+++ b/crates/awr-store/tests/search.rs
@@ -120,7 +120,10 @@ fn fts_and_structured_filters_return_ranked_versioned_summaries() {
     f.store.retire_source(&f.source).unwrap();
     assert!(search(&mut f, "依赖").is_empty());
     assert!(f.store.doctor().unwrap().ok);
-    assert_eq!(f.store.doctor().unwrap().schema_version, 3);
+    assert_eq!(
+        f.store.doctor().unwrap().schema_version,
+        awr_store::SCHEMA_VERSION
+    );
 }
 
 #[test]

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -166,9 +166,52 @@ expected semantics and reparse through the source adapter. See the
 [YAML writer](../../adapters/yaml-ledger/README.md) for supported shapes.
 
 Markdown adapters currently read sources; they do not authorize Markdown body or ledger
-writes. Unsupported capabilities include human-save shortcuts, new tasks, multi-file
+writes. Unsupported capabilities include human-save shortcuts, multi-file
 writes and user-confirmed completion. Never route an unsupported operation through a
 generic status patch or a second writer.
+
+## Create a task with a stable request identity
+
+```text
+awr work create --title 'Prepare the travel checklist' --request-key <host-request-id> --json
+awr work create --title 'Prepare the travel checklist' --request-key <same-id> --accept --expected-preview <fingerprint> --expected-revision <preview-project-revision> --json
+awr work create-status --key <host-request-id> --json
+awr work create-recover --key <host-request-id> --expected-revision <current-project-revision> --json
+```
+
+Alternatively, `work create --input request.json` accepts protected JSON containing
+`version: 1`, `request_key`, `title` and optional `source_id`. Without an explicit source,
+exactly one primary ledger must be registered. Creation currently supports ordinary
+YAML lists and keyed maps, including flow/empty collections, configured field/status
+names and CRLF. Existing bytes and work IDs are retained; new block records use the
+existing indentation. Unsupported YAML forms fail before writing.
+
+The request ID belongs to one project and one exact creation payload. Its stable new
+`WORK-…` key is included in the preview. Acceptance binds the request, source mapping,
+source fingerprint, before/after text and project revision. Repeated identical requests
+return the recorded work ID and outcome, even with an old preview revision. Changed
+content under an existing key is a conflict. A busy concurrent writer may return
+`MutationConflict`; query the request before another attempt. A later source change
+does not authorize reusing the same request to create or restore another task.
+
+Only a title is needed from the user. The new source status is `draft` (or its explicit
+mapped spelling), with missing execution facts left missing. It is a draft, never
+automatically executable or completed. Draft is excluded from the execution queue; normal readiness/context/domain rules still
+apply. No session, runtime claim, model call or invented acceptance is created.
+
+Creation retains a plan and before/after snapshots in the ignored mutation directory,
+shares the existing source writer lock and atomic replacement primitive, and verifies
+the resulting projection. `phase` describes the creation request, not work completion.
+`source_write_performed`/`runtime_write_performed` describe this invocation; a replay's
+historical `write_outcome` is separate. Pending results require explicit recovery.
+Recovery only installs the reviewed after snapshot when current bytes match before,
+or finishes projection when they already match after. Other bytes or changed registrations
+are retained and reported as conflicts. Recovery never rolls back newer user edits.
+
+`create-status` is read-only and distinguishes its historical receipt from the current
+source observation (`before`, `after`, `externally_changed`, or unavailable/registration
+changed). A transport failure cannot be interpreted as unwritten. Read the same request
+key first; pending writes are never automatically repeated by the create command.
 
 `work complete` retains the engineering contract: a real session/claim and evidence
 covering the source's acceptance criteria at the supplied source SHA. A source's raw
@@ -337,6 +380,13 @@ Back up matching program version, original sources, manifest and SQLite runtime
 before an upgrade. Source projections are rebuildable; events and checkpoints are
 not reconstructed by reindexing source documents. A binary downgrade alone is not a
 database rollback procedure.
+
+This development build writes schema 4, which adds the non-executable `draft` work
+state. The transactional migration preserves existing rows and references, checks
+foreign keys, and retains additional indexes and triggers. Builds that only support
+schema 3 must reject this database; restore a matching database/program snapshot
+when rolling back. Newly created drafts need an explicit source declaration before
+execution; creation itself never supplies missing execution or completion facts.
 
 One project keeps one source ledger. When replacing an existing host writer, switch
 only operations AWR actually supports, retain old runtime history as history, and

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -165,10 +165,63 @@ ambiguous scalar forms fail before writing. The entire result must have precisel
 expected semantics and reparse through the source adapter. See the
 [YAML writer](../../adapters/yaml-ledger/README.md) for supported shapes.
 
-Markdown adapters currently read sources; they do not authorize Markdown body or ledger
-writes. Unsupported capabilities include human-save shortcuts, multi-file
+`mutation.markdown.document` supports registered heading, rule and decision documents.
+Markdown work ledgers remain read-only. Unsupported capabilities include human-save shortcuts, multi-file
 writes and user-confirmed completion. Never route an unsupported operation through a
 generic status patch or a second writer.
+
+## Edit a registered document
+
+Read the complete registered source with `source show <source-id> --content` and retain
+its fingerprint. Document text is data and is never executed. Send this versioned JSON
+through a protected file:
+
+```json
+{
+  "version": 1,
+  "request_key": "host/edit-goal/1",
+  "change": {
+    "operation": "edit",
+    "source_id": "<source ULID>",
+    "source_fingerprint": "sha256:<original source hash>",
+    "edit": {"kind": "fragment", "before": "Original paragraph.", "after": "Updated paragraph."}
+  }
+}
+```
+
+`edit: {"kind":"replace","text":"<complete replacement source>"}` replaces the whole
+document. Fragments must be nonempty and match exactly once; other bytes, including
+code and line endings, are retained. Whole replacements must explicitly include the
+material the host intends to keep. Both forms reparse through the registered adapter
+and retain object keys, lifecycle status and rule constraints. Use explicit heading
+anchors when changing titles. Conflicting metadata declarations are rejected before
+writing; the host must resolve the indicated declarations. A plan source may set
+`options.kind = "architecture"` to expose a typed architecture reference without AWR
+interpreting or rendering the architecture.
+
+```text
+awr document change --input edit.json --json
+awr document change --input edit.json --accept --expected-preview <preview-fingerprint> --expected-revision <preview-revision> --json
+awr document status --key <request-key> --json
+awr document recover --key <request-key> --expected-revision <current-revision> --json
+```
+
+Acceptance binds the complete request, source bytes, mapping and project revision.
+The request key is project-scoped: identical delivery returns the retained outcome;
+changed content conflicts. Lookup does not refresh or write the runtime. A missing
+response requires lookup first; pending operations need explicit recovery. Recovery
+only writes at the recorded before state or completes projection at the recorded after
+state; external changes are retained. A request's `completed` phase describes that
+document operation, not completion or adoption of any project work.
+
+For a new draft, use `change: {"operation":"create_draft","path":"decisions/new.md",
+"title":"Proposed approach","body":"Draft text."}`. Its parent directory must already
+exist inside exactly one registered Markdown decisions directory. AWR allocates a
+stable `DOC-…` key and writes source status `proposed`. Publication uses an atomic
+no-clobber operation: a same-name file, including a concurrent creator, is never
+overwritten. Relative visible Markdown paths are required; registration does not expand
+implicitly. An unchanged document save returns `no_change` without a source write or
+new business event when projections are current. No Agent session or model is created.
 
 ## Create a task with a stable request identity
 

--- a/tests/platform/native_cli.py
+++ b/tests/platform/native_cli.py
@@ -85,7 +85,7 @@ def main():
 
     with closing(sqlite3.connect(db_path.as_uri() + '?mode=ro', uri=True)) as db:
         require(db.execute('PRAGMA journal_mode').fetchone()[0] == 'wal', 'WAL is not active')
-        require(db.execute('PRAGMA user_version').fetchone()[0] == 3, 'Unexpected schema version')
+        require(db.execute('PRAGMA user_version').fetchone()[0] == 4, 'Unexpected schema version')
         require(db.execute('PRAGMA integrity_check').fetchall() == [('ok',)], 'Database integrity failed')
         require(not db.execute('PRAGMA foreign_key_check').fetchall(), 'Foreign keys failed')
     report['conditions']['wal_schema_integrity'] = True

--- a/tests/recovery/doctor/database.rs
+++ b/tests/recovery/doctor/database.rs
@@ -122,7 +122,15 @@ impl Fixture {
         json!({"schema":schema,"tables":tables,"version":version,"sources":sources})
     }
     fn downgrade_to_v2(&self) {
+        self.downgrade_to_v3();
         self.sql("DROP TABLE search_fts; DROP TABLE search_state; DROP TABLE search_documents; DELETE FROM schema_migrations WHERE version=3; PRAGMA user_version=2;");
+    }
+    fn downgrade_to_v3(&self) {
+        // Build an authentic old fixture, including its original constraint definition.
+        let domain = include_str!("../../../crates/awr-store/migrations/002_domain.sql");
+        let begin = domain.find("CREATE TABLE work_items (").unwrap();
+        let end = domain[begin..].find("CREATE TABLE decisions (").unwrap() + begin;
+        self.sql(&format!("PRAGMA foreign_keys=OFF; CREATE TEMP TABLE kept_work AS SELECT * FROM work_items; DROP TABLE work_items; {} INSERT INTO work_items SELECT * FROM kept_work; DROP TABLE kept_work; CREATE INDEX work_status ON work_items(project_id,status,active,priority); DELETE FROM schema_migrations WHERE version=4; PRAGMA user_version=3;",&domain[begin..end]));
     }
     fn revision(&self) -> String {
         Connection::open_with_flags(self.db(), OpenFlags::SQLITE_OPEN_READ_ONLY)
@@ -293,13 +301,13 @@ fn case_schema_migration_catalog_checks_record_identity() {
     for sql in [
         "DELETE FROM schema_migrations WHERE version=1",
         "UPDATE schema_migrations SET name='other' WHERE version=2",
-        "INSERT INTO schema_migrations VALUES(4,'unsupported',0)",
+        "INSERT INTO schema_migrations VALUES(5,'unsupported',0)",
     ] {
         let f = Fixture::new();
         f.sql(sql);
         let before = f.snapshot();
         let report = f.problems(&["doctor", "--database-only"]);
-        assert_eq!(report["schema_version"], 3);
+        assert_eq!(report["schema_version"], awr_store::SCHEMA_VERSION);
         assert!(Store::open_existing(&f.db()).is_err());
         assert!(Store::open(&f.db()).is_err());
         assert_eq!(f.snapshot(), before);
@@ -428,7 +436,7 @@ fn case_migration_sql_failure_rolls_back_and_supported_versions_keep_history() {
     let before = f.snapshot();
     drop(Store::open(&f.db()).unwrap());
     let after = f.snapshot();
-    assert_eq!(after["version"], 3);
+    assert_eq!(after["version"], awr_store::SCHEMA_VERSION);
     assert_runtime_retained(&before, &after);
     assert_eq!(before["tables"]["sources"], after["tables"]["sources"]);
     assert_eq!(f.ok(&["doctor"])["database_ok"], true);
@@ -446,6 +454,64 @@ fn case_migration_sql_failure_rolls_back_and_supported_versions_keep_history() {
     assert!(migrated.ok);
     assert_eq!(migrated.migrations[0].applied_at, 42);
     passed("migration_success_preserves_runtime");
+}
+
+#[test]
+fn draft_state_migration_preserves_rows_references_and_extra_indexes_and_rolls_back_on_failure() {
+    let f = Fixture::new();
+    let session = f.start(false);
+    f.checkpoint(session["session"]["id"].as_str().unwrap());
+    f.downgrade_to_v3();
+    f.sql("CREATE INDEX user_work_title ON work_items(title); CREATE TRIGGER reject_draft_migration BEFORE INSERT ON schema_migrations WHEN NEW.version=4 BEGIN SELECT RAISE(ABORT,'fixture migration failure'); END;");
+    let before = f.snapshot();
+    assert!(Store::open(&f.db()).is_err());
+    assert_eq!(f.snapshot(), before);
+    f.sql("DROP TRIGGER reject_draft_migration");
+    let before = f.snapshot();
+    let store = Store::open(&f.db()).unwrap();
+    let doctor = store.doctor().unwrap();
+    assert!(doctor.ok);
+    assert!(doctor.foreign_keys);
+    drop(store);
+    let after = f.snapshot();
+    assert_runtime_retained(&before, &after);
+    for name in [
+        "projects",
+        "sources",
+        "work_items",
+        "events",
+        "sessions",
+        "claims",
+        "checkpoints",
+    ] {
+        assert_eq!(
+            before["tables"][name], after["tables"][name],
+            "migration changed {name}"
+        );
+    }
+    let db = Connection::open(f.db()).unwrap();
+    assert_eq!(
+        db.query_row(
+            "SELECT count(*) FROM sqlite_master WHERE name='user_work_title'",
+            [],
+            |r| r.get::<_, i64>(0)
+        )
+        .unwrap(),
+        1
+    );
+    // New draft values are accepted without changing any old status spelling.
+    db.execute(
+        "UPDATE work_items SET status='draft' WHERE external_key='OTHER'",
+        [],
+    )
+    .unwrap();
+    assert!(
+        db.execute(
+            "UPDATE work_items SET status='made_up' WHERE external_key='OTHER'",
+            []
+        )
+        .is_err()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Hosts can edit a registered Markdown document by replacing its complete body or one exact fragment, then apply the reviewed source/version-bound preview. The adapter rebuilds its projections while preserving object identity and lifecycle constraints. New decision drafts receive stable request identities and cannot overwrite an existing destination.

Adds request outcome lookup and explicit single-file recovery that preserves external edits, plus a typed architecture option for plan sources. Document edits do not create Agent sessions or invoke models.

Validation: 33 native CLI and source checks passed, covering unchanged bytes/CRLF/code, metadata conflicts, stable identities, drafts, concurrent destinations, read-only files, interrupted-write recovery and existing proposal behavior.
