### PR TITLE
Add recoverable host saves and explicit draft activation

### DIFF
--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -223,7 +223,33 @@ fn catalog() -> Vec<Capability> {
                 "draft_no_clobber",
             ],
         ),
-        ("mutation.human_save", false, &[], &["not_implemented"]),
+        (
+            "mutation.human_save",
+            true,
+            &["host save", "host status", "host recover"],
+            &[
+                "registered_sources_only",
+                "provenance_is_not_authentication",
+                "domain_guards_retained",
+                "single_file",
+            ],
+        ),
+        (
+            "mutation.ai_apply",
+            true,
+            &["host preview", "host save"],
+            &["exact_reviewed_preview_required", "stable_request_identity"],
+        ),
+        (
+            "mutation.work.activate_draft",
+            true,
+            &["host save"],
+            &[
+                "draft_only",
+                "declared_structure_and_dependencies_required",
+                "not_completion",
+            ],
+        ),
         ("mutation.multi_file", false, &[], &["not_implemented"]),
         (
             "completion.engineering",

--- a/crates/awr-cli/src/host_save.rs
+++ b/crates/awr-cli/src/host_save.rs
@@ -1,0 +1,102 @@
+use awr_core::*;
+use awr_runtime::{HostSaveReport, HostSaveRequest};
+use awr_store::Store;
+use clap::Subcommand;
+use std::path::{Path, PathBuf};
+#[derive(Debug, Subcommand)]
+pub enum HostCommand {
+    /// Preview exactly the edit and provenance that the host will apply.
+    Preview {
+        #[arg(long)]
+        input: PathBuf,
+    },
+    /// One human Save, or one AI application bound to a previously reviewed preview.
+    Save {
+        #[arg(long)]
+        input: PathBuf,
+        #[arg(long)]
+        expected_revision: Revision,
+        #[arg(long)]
+        expected_preview: Option<String>,
+    },
+    /// Read the saved request and its underlying proposal/document outcome.
+    Status {
+        #[arg(long)]
+        key: String,
+    },
+    /// Explicitly resume a recorded host action without repeating a completed write.
+    Recover {
+        #[arg(long)]
+        key: String,
+        #[arg(long)]
+        expected_revision: Revision,
+    },
+}
+fn input(root: &Path, path: &Path) -> Result<HostSaveRequest> {
+    let path = if path.is_absolute() {
+        path.to_owned()
+    } else {
+        root.join(path)
+    };
+    serde_json::from_slice(&awr_source::read_capped(
+        &path,
+        awr_source::MARKDOWN_READ_CAP,
+    )?)
+    .map_err(|_| {
+        Error::InvalidInput(
+            "host JSON requires version, request_key, actor, reason and one supported change"
+                .into(),
+        )
+    })
+}
+fn output(report: HostSaveReport, json_output: bool) -> Result<()> {
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&report.value)?)
+    } else {
+        println!("Host save: {}", report.value["status"])
+    }
+    match report.failure {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+pub fn run(root: &Path, command: &HostCommand, json_output: bool) -> Result<()> {
+    let root = root.canonicalize()?;
+    let db = crate::source::runtime_dir(&root, false)?.join("state.db");
+    match command {
+        HostCommand::Status { key } => output(
+            awr_runtime::host_status(&Store::open_readonly(&db)?, &root, key)?,
+            json_output,
+        ),
+        HostCommand::Preview { input: path } => output(
+            awr_runtime::host_preview(&mut Store::open_existing(&db)?, &root, input(&root, path)?)?,
+            json_output,
+        ),
+        HostCommand::Save {
+            input: path,
+            expected_revision,
+            expected_preview,
+        } => output(
+            awr_runtime::host_save(
+                &mut Store::open_existing(&db)?,
+                &root,
+                input(&root, path)?,
+                *expected_revision,
+                expected_preview.as_deref(),
+            )?,
+            json_output,
+        ),
+        HostCommand::Recover {
+            key,
+            expected_revision,
+        } => output(
+            awr_runtime::host_recover(
+                &mut Store::open_existing(&db)?,
+                &root,
+                key,
+                *expected_revision,
+            )?,
+            json_output,
+        ),
+    }
+}

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -11,6 +11,7 @@ mod document;
 mod drill;
 mod event_append;
 mod execution;
+mod host_save;
 mod intake_plan;
 mod mutation;
 mod onboarding;
@@ -42,6 +43,11 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Save explicit host edits with durable request identity and provenance.
+    Host {
+        #[command(subcommand)]
+        command: host_save::HostCommand,
+    },
     /// Edit registered Markdown documents or create source-backed drafts.
     Document {
         #[command(subcommand)]
@@ -151,6 +157,7 @@ enum Command {
 
 fn run(cli: &Cli) -> Result<()> {
     match &cli.command {
+        Some(Command::Host { command }) => host_save::run(&cli.project, command, cli.json),
         Some(Command::Document { command }) => document::run(&cli.project, command, cli.json),
         Some(Command::Capabilities(args)) => capabilities::run(args, cli.json),
         Some(Command::Init(args)) => onboarding::run(&cli.project, args, cli.json),

--- a/crates/awr-cli/tests/branch_close_cli.rs
+++ b/crates/awr-cli/tests/branch_close_cli.rs
@@ -264,6 +264,7 @@ fn outstanding_source_proposals_must_be_settled_and_are_not_silently_discarded()
                     source_config: target.source.config,
                     intent: input.reason,
                     changes,
+                    host_edit: None,
                     work_action: Some(binding),
                 },
                 created_by_session: Some(sid.parse().unwrap()),

--- a/crates/awr-cli/tests/host_capabilities.rs
+++ b/crates/awr-cli/tests/host_capabilities.rs
@@ -118,7 +118,7 @@ fn unsupported_protocol_and_invalid_usage_keep_distinct_error_codes() {
 }
 
 #[test]
-fn capability_modes_separate_field_document_ledger_and_human_writes() {
+fn capability_modes_separate_supported_writers_from_unavailable_multi_file_writes() {
     let host = Host::new();
     let result = host.ok(&["--json", "capabilities"]);
     let adapters = result["source_adapters"].as_array().unwrap();
@@ -136,11 +136,7 @@ fn capability_modes_separate_field_document_ledger_and_human_writes() {
             assert_eq!(adapter["write_mode"], "document_body_only");
         }
     }
-    for id in [
-        "mutation.human_save",
-        "mutation.multi_file",
-        "completion.user_confirmation",
-    ] {
+    for id in ["mutation.multi_file", "completion.user_confirmation"] {
         let capability = result["capabilities"]
             .as_array()
             .unwrap()

--- a/crates/awr-cli/tests/host_save.rs
+++ b/crates/awr-cli/tests/host_save.rs
@@ -1,0 +1,510 @@
+//! Native host-save fixtures, including a real interrupted final receipt.
+use awr_core::Id;
+use serde_json::{Value, json};
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+};
+struct Host(PathBuf);
+impl Host {
+    fn new() -> Self {
+        let h = Self(std::env::temp_dir().join(format!("awr 一次 保存 {}", Id::new())));
+        fs::create_dir(&h.0).unwrap();
+        h.write("work.yaml","# keep this comment\ngoals:\n- id: G\n  title: Reading project\n  status: active\n  summary: Prepare useful reading notes.\nwork_items:\n- id: W\n  title: Read an article\n  status: planned\n  goal: G\n  acceptance: [A useful note is available]\n  next_action: Write the note\n  unknown: keep-me\n- id: D\n  title: Draft task\n  status: draft\n");
+        h.write(
+            "GOAL.md",
+            "# Reading {#reading}\n\nKeep the useful ideas.\n",
+        );
+        h.write("mapping.toml","[project]\nname='Host save'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n[[sources]]\ndomain='goal'\nrole='supporting'\npath='GOAL.md'\nadapter='markdown-heading-v1'\n");
+        h.ok(&["init", "--manifest", "mapping.toml", "--accept"]);
+        h
+    }
+    fn write(&self, path: &str, text: &str) {
+        fs::write(self.0.join(path), text).unwrap()
+    }
+    fn text(&self, path: &str) -> String {
+        fs::read_to_string(self.0.join(path)).unwrap()
+    }
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_awr"))
+            .env_clear()
+            .args(["--project", self.0.to_str().unwrap(), "--json"])
+            .args(args)
+            .stdin(Stdio::null())
+            .output()
+            .unwrap()
+    }
+    fn ok(&self, args: &[&str]) -> Value {
+        let o = self.run(args);
+        assert!(
+            o.status.success(),
+            "{args:?}\n{}\n{}",
+            String::from_utf8_lossy(&o.stdout),
+            String::from_utf8_lossy(&o.stderr)
+        );
+        serde_json::from_slice(&o.stdout).unwrap()
+    }
+    fn error(&self, args: &[&str], code: &str) -> Output {
+        let o = self.run(args);
+        assert!(!o.status.success(), "{args:?}");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&o.stderr).unwrap()["code"],
+            code,
+            "{}",
+            String::from_utf8_lossy(&o.stderr)
+        );
+        o
+    }
+    fn revision(&self) -> String {
+        self.ok(&["session", "list"])["project_revision"].to_string()
+    }
+    fn envelope(&self, key: &str, origin: &str, change: Value) {
+        self.write("save.json",&json!({"version":1,"request_key":key,"actor":{"host":"fixture-desktop","subject":"fixture-user","origin":origin},"reason":"Save the explicit edit shown in the fixture host","change":change}).to_string())
+    }
+    fn fields(&self, key: &str, origin: &str, work: &str, fields: Value) {
+        let w = self.ok(&["work", "show", work]);
+        self.envelope(key,origin,json!({"operation":"fields","kind":"work_item","target":work,"source_fingerprint":w["source_ref"]["source_fingerprint"],"fields":fields}))
+    }
+    fn activate(&self, key: &str, work: &str) {
+        let w = self.ok(&["work", "show", work]);
+        self.envelope(key,"human",json!({"operation":"activate_draft","work":work,"source_fingerprint":w["source_ref"]["source_fingerprint"]}))
+    }
+    fn save(&self) -> Value {
+        self.ok(&[
+            "host",
+            "save",
+            "--input",
+            "save.json",
+            "--expected-revision",
+            &self.revision(),
+        ])
+    }
+    fn stored(&self, r: &Value) -> (PathBuf, Value) {
+        let path = self
+            .0
+            .join(r["recovery_directory"].as_str().unwrap())
+            .join("receipt.json");
+        let value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        (path, value)
+    }
+    fn sql(&self, sql: &str) {
+        rusqlite::Connection::open(self.0.join(".awr/state.db"))
+            .unwrap()
+            .execute_batch(sql)
+            .unwrap()
+    }
+}
+
+#[test]
+fn delegated_edits_keep_the_actual_agent_origin_and_require_exact_review() {
+    let h = Host::new();
+    h.fields(
+        "delegated-edit",
+        "delegated_agent",
+        "W",
+        json!({"next_action":"Review the delegated draft"}),
+    );
+    let mut input: Value = serde_json::from_str(&h.text("save.json")).unwrap();
+    input["actor"]["subject"] = json!("fixture-delegated-agent");
+    h.write("save.json", &input.to_string());
+    h.error(
+        &[
+            "host",
+            "save",
+            "--input",
+            "save.json",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "SourceConflict",
+    );
+    let p = h.ok(&["host", "preview", "--input", "save.json"]);
+    let saved = h.ok(&[
+        "host",
+        "save",
+        "--input",
+        "save.json",
+        "--expected-revision",
+        &h.revision(),
+        "--expected-preview",
+        p["preview"]["fingerprint"].as_str().unwrap(),
+    ]);
+    assert_eq!(saved["actor"]["origin"], "delegated_agent");
+    assert_eq!(saved["actor"]["subject"], "fixture-delegated-agent");
+    assert_eq!(h.ok(&["session", "list"])["sessions"], json!([]));
+}
+impl Drop for Host {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn one_human_save_preserves_bytes_has_no_fake_agent_and_reuses_one_proposal() {
+    let h = Host::new();
+    let before = h.text("work.yaml");
+    h.fields(
+        "human-edit",
+        "human",
+        "W",
+        json!({"title":"Read and annotate the article"}),
+    );
+    let revision = h.revision();
+    let saved = h.save();
+    assert_eq!(saved["status"], "completed");
+    assert_eq!(
+        h.text("work.yaml"),
+        before.replace(
+            "title: Read an article",
+            "title: Read and annotate the article"
+        )
+    );
+    let current = h.revision();
+    let replay = h.ok(&[
+        "host",
+        "save",
+        "--input",
+        "save.json",
+        "--expected-revision",
+        &revision,
+    ]);
+    assert_eq!(replay["proposal_id"], saved["proposal_id"]);
+    assert_eq!(h.revision(), current);
+    assert_eq!(h.ok(&["session", "list"])["sessions"], json!([]));
+    let status = h.ok(&["host", "status", "--key", "human-edit"]);
+    assert_eq!(status["actor"]["subject"], "fixture-user");
+    assert_eq!(status["provenance_is_authentication"], false);
+    assert!(status["current_proposal"]["created_by_session"].is_null());
+    assert_eq!(
+        status["current_proposal"]["patch"]["host_edit"]["request_key"],
+        "human-edit"
+    );
+    assert_eq!(h.revision(), current);
+    h.fields(
+        "human-edit",
+        "human",
+        "W",
+        json!({"title":"A different edit"}),
+    );
+    h.error(
+        &[
+            "host",
+            "save",
+            "--input",
+            "save.json",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "SourceConflict",
+    );
+}
+#[test]
+fn ai_requires_the_exact_preview_and_changed_source_or_target_cannot_be_applied() {
+    let h = Host::new();
+    h.fields(
+        "ai-edit",
+        "ai_accepted",
+        "W",
+        json!({"next_action":"Review the saved note"}),
+    );
+    h.error(
+        &[
+            "host",
+            "save",
+            "--input",
+            "save.json",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "SourceConflict",
+    );
+    let p = h.ok(&["host", "preview", "--input", "save.json"]);
+    let fp = p["preview"]["fingerprint"].as_str().unwrap();
+    let saved = h.ok(&[
+        "host",
+        "save",
+        "--input",
+        "save.json",
+        "--expected-revision",
+        &p["project_revision"].to_string(),
+        "--expected-preview",
+        fp,
+    ]);
+    assert_eq!(saved["status"], "completed");
+    h.fields(
+        "ai-stale",
+        "ai_accepted",
+        "W",
+        json!({"title":"Reviewed title"}),
+    );
+    let p = h.ok(&["host", "preview", "--input", "save.json"]);
+    h.write("work.yaml", &(h.text("work.yaml") + "# external edit\n"));
+    let newer = h.text("work.yaml");
+    h.error(
+        &[
+            "host",
+            "save",
+            "--input",
+            "save.json",
+            "--expected-revision",
+            &p["project_revision"].to_string(),
+            "--expected-preview",
+            p["preview"]["fingerprint"].as_str().unwrap(),
+        ],
+        "SourceConflict",
+    );
+    assert_eq!(h.text("work.yaml"), newer);
+    h.fields(
+        "ai-tampered",
+        "ai_accepted",
+        "W",
+        json!({"title":"Reviewed title"}),
+    );
+    let preview = h.ok(&["host", "preview", "--input", "save.json"]);
+    let mut request: Value = serde_json::from_str(&h.text("save.json")).unwrap();
+    request["change"]["fields"]["title"] = json!("Unreviewed replacement");
+    h.write("save.json", &request.to_string());
+    h.error(
+        &[
+            "host",
+            "save",
+            "--input",
+            "save.json",
+            "--expected-revision",
+            &h.revision(),
+            "--expected-preview",
+            preview["preview"]["fingerprint"].as_str().unwrap(),
+        ],
+        "SourceConflict",
+    );
+}
+#[test]
+fn unchanged_saves_do_not_emit_business_events_and_human_labels_cannot_complete_work() {
+    let h = Host::new();
+    h.fields(
+        "unchanged",
+        "human",
+        "W",
+        json!({"title":"Read an article"}),
+    );
+    let revision = h.revision();
+    let source = h.text("work.yaml");
+    let r = h.save();
+    assert_eq!(r["status"], "no_change");
+    assert_eq!(r["source_write_performed"], false);
+    assert_eq!(h.revision(), revision);
+    assert_eq!(h.text("work.yaml"), source);
+    for fields in [
+        json!({"status":"completed"}),
+        json!({"owner":"pretend-agent"}),
+        json!({"evidence_level":"externally_verified"}),
+        json!({"id":"replaced"}),
+    ] {
+        h.fields(
+            &format!(
+                "forgery-{}",
+                fields.as_object().unwrap().keys().next().unwrap()
+            ),
+            "human",
+            "W",
+            fields,
+        );
+        let out = h.run(&[
+            "host",
+            "save",
+            "--input",
+            "save.json",
+            "--expected-revision",
+            &h.revision(),
+        ]);
+        assert!(!out.status.success());
+        assert_eq!(h.text("work.yaml"), source);
+    }
+}
+#[test]
+fn complete_draft_declarations_can_activate_without_invented_session_or_completion() {
+    let h = Host::new();
+    assert!(awr_core::is_domain_event_type("work.draft_activated"));
+    let old = h.revision();
+    let forged = h.run(&[
+        "event",
+        "append",
+        "--type",
+        "work.draft_activated",
+        "--summary",
+        "Pretend activation",
+        "--expected-revision",
+        &old,
+    ]);
+    assert!(!forged.status.success());
+    assert_eq!(h.revision(), old);
+    h.activate("incomplete", "D");
+    let out = h.run(&[
+        "host",
+        "save",
+        "--input",
+        "save.json",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    assert!(!out.status.success());
+    assert_eq!(h.ok(&["work", "show", "D"])["work"]["status"], "draft");
+    h.fields("fill-draft","human","D",json!({"acceptance":["A useful note is available"],"next_action":"Prepare the note","goal":"G"}));
+    h.save();
+    h.fields("blocked-draft", "human", "D", json!({"depends_on":["W"]}));
+    h.save();
+    h.activate("blocked-activation", "D");
+    h.error(
+        &[
+            "host",
+            "save",
+            "--input",
+            "save.json",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "DependencyBlocked",
+    );
+    h.fields("clear-dependency", "human", "D", json!({"depends_on":[]}));
+    h.save();
+    assert_eq!(h.ok(&["work", "show", "D"])["work"]["ready"], false);
+    h.activate("activate-draft", "D");
+    let r = h.save();
+    assert_eq!(r["status"], "completed");
+    let work = h.ok(&["work", "show", "D"]);
+    assert_eq!(work["work"]["status"], "planned");
+    assert_eq!(work["work"]["ready"], true);
+    assert_eq!(h.ok(&["session", "list"])["sessions"], json!([]));
+    h.activate("repeat-transition", "D");
+    h.error(
+        &[
+            "host",
+            "save",
+            "--input",
+            "save.json",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "InvalidTransition",
+    );
+}
+#[test]
+fn document_saves_share_exact_writers_and_record_host_provenance() {
+    let h = Host::new();
+    let sources = h.ok(&["object", "list", "source"]);
+    let source = sources["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["domain"] == "goal")
+        .unwrap();
+    let change = json!({"operation":"document","change":{"operation":"edit","source_id":source["id"],"source_fingerprint":source["fingerprint"],"edit":{"kind":"fragment","before":"Keep the useful ideas.","after":"Keep the useful ideas and references."}}});
+    h.envelope("document-human", "human", change);
+    let r = h.save();
+    assert_eq!(r["status"], "completed");
+    assert!(h.text("GOAL.md").contains("and references"));
+    let rev = h.revision();
+    assert_eq!(h.save()["source_write_performed"], false);
+    assert_eq!(h.revision(), rev);
+    let status = h.ok(&["host", "status", "--key", "document-human"]);
+    assert_eq!(status["current_document"]["current_source"], "after");
+    assert_eq!(status["actor"]["host"], "fixture-desktop");
+}
+#[test]
+fn interrupted_receipt_is_queryable_and_explicit_recovery_does_not_repeat_source_write() {
+    let h = Host::new();
+    h.fields(
+        "receipt-failure",
+        "human",
+        "W",
+        json!({"title":"Recover the note"}),
+    );
+    h.sql("CREATE TRIGGER fail_host_receipt BEFORE INSERT ON events WHEN NEW.event_type='proposal.applied' BEGIN SELECT RAISE(ABORT,'fixture final receipt failure'); END;");
+    let out = h.run(&[
+        "host",
+        "save",
+        "--input",
+        "save.json",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    assert!(!out.status.success());
+    let partial: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(partial["status"], "pending_recovery");
+    assert!(h.text("work.yaml").contains("Recover the note"));
+    let status = h.ok(&["host", "status", "--key", "receipt-failure"]);
+    assert_eq!(status["found"], true);
+    h.sql("DROP TRIGGER fail_host_receipt;");
+    let r = h.ok(&[
+        "host",
+        "recover",
+        "--key",
+        "receipt-failure",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    assert_eq!(r["status"], "completed");
+    assert_eq!(r["source_write_performed"], false);
+    assert_eq!(r["proposal_id"], partial["proposal_id"]);
+    let (path, mut receipt) = h.stored(&r);
+    receipt["phase"] = json!("prepared");
+    receipt["proposal_id"] = Value::Null;
+    fs::write(path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+    let before = h.text("work.yaml");
+    let r = h.ok(&[
+        "host",
+        "recover",
+        "--key",
+        "receipt-failure",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    assert_eq!(r["source_write_performed"], false);
+    assert_eq!(h.text("work.yaml"), before);
+}
+#[test]
+fn recovery_preserves_external_edits_and_request_keys_are_project_scoped() {
+    let h = Host::new();
+    let other = Host::new();
+    for host in [&h, &other] {
+        host.fields(
+            "same-request",
+            "human",
+            "W",
+            json!({"title":"Project-local edit"}),
+        );
+    }
+    let a = h.save();
+    let b = other.save();
+    assert_ne!(a["proposal_id"], b["proposal_id"]);
+    h.fields(
+        "conflicted-recovery",
+        "human",
+        "W",
+        json!({"title":"Incomplete edit"}),
+    );
+    h.sql("CREATE TRIGGER fail_host_receipt BEFORE INSERT ON events WHEN NEW.event_type='proposal.applied' BEGIN SELECT RAISE(ABORT,'fixture failure'); END;");
+    let out = h.run(&[
+        "host",
+        "save",
+        "--input",
+        "save.json",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    assert!(!out.status.success());
+    h.sql("DROP TRIGGER fail_host_receipt;");
+    h.write("work.yaml", &(h.text("work.yaml") + "# newer user edits\n"));
+    let newer = h.text("work.yaml");
+    let out = h.run(&[
+        "host",
+        "recover",
+        "--key",
+        "conflicted-recovery",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    assert!(!out.status.success());
+    assert_eq!(h.text("work.yaml"), newer);
+}

--- a/crates/awr-cli/tests/work_action_cli.rs
+++ b/crates/awr-cli/tests/work_action_cli.rs
@@ -149,6 +149,7 @@ impl Fixture {
                 source_config: target.source.config,
                 intent: input.reason,
                 changes,
+                host_edit: None,
                 work_action: Some(binding),
             },
             created_by_session: session,

--- a/crates/awr-cli/tests/work_complete_cli.rs
+++ b/crates/awr-cli/tests/work_complete_cli.rs
@@ -207,6 +207,7 @@ impl Fixture {
             source_config: target.source.config.clone(),
             intent: "Complete the reviewed report".into(),
             changes: json!({"status":"completed"}),
+            host_edit: None,
             work_action: None,
         };
         let record =

--- a/crates/awr-core/src/event_payload.rs
+++ b/crates/awr-core/src/event_payload.rs
@@ -51,6 +51,7 @@ pub fn is_domain_event_type(kind: &str) -> bool {
                 | "work.cancelled"
                 | "work.reopened"
                 | "work.completed"
+                | "work.draft_activated"
                 | "claim.released"
                 | "claim.expired"
                 | "artifact.recorded"
@@ -127,8 +128,9 @@ fn domain_fields(kind: &str, payload: &Value) -> Result<()> {
             | "work.cancelled"
             | "work.reopened"
             | "work.completed"
+            | "work.draft_activated"
     ) {
-        "proposal_id source_id attempt_event_id write_plan_id before_fingerprint after_fingerprint target_after_hash source_revision target_revision actor reason work_action action_reason creating_session_id released_claim_ids"
+        "proposal_id source_id attempt_event_id write_plan_id before_fingerprint after_fingerprint target_after_hash source_revision target_revision actor reason work_action host_edit action_reason creating_session_id released_claim_ids"
     } else if matches!(kind, "proposal.apply_conflict" | "proposal.apply_failed") {
         "proposal_id source_id attempt_event_id write_plan_id actor reason"
     } else if matches!(
@@ -199,6 +201,9 @@ fn domain_fields(kind: &str, payload: &Value) -> Result<()> {
         | "work.cancelled" | "work.reopened" | "work.completed" => {
             "proposal_id source_id attempt_event_id write_plan_id source_revision target_revision"
         }
+        "work.draft_activated" => {
+            "proposal_id source_id attempt_event_id write_plan_id source_revision target_revision host_edit"
+        }
         "proposal.apply_conflict" | "proposal.apply_failed" => {
             "proposal_id source_id attempt_event_id write_plan_id"
         }
@@ -256,6 +261,12 @@ fn domain_fields(kind: &str, payload: &Value) -> Result<()> {
             continue;
         }
         let valid = match key.as_str() {
+            "host_edit" => serde_json::from_value::<crate::HostEditBinding>(value.clone())
+                .is_ok_and(|h| {
+                    h.validate().is_ok()
+                        && (kind != "work.draft_activated"
+                            || h.action == crate::HostEditAction::ActivateDraft)
+                }),
             "agent_id" => value.is_string(),
             key if key.ends_with("_id") => id(value),
             key if key.ends_with("_ids") => value.as_array().is_some_and(|v| v.iter().all(id)),

--- a/crates/awr-core/src/mutation.rs
+++ b/crates/awr-core/src/mutation.rs
@@ -23,6 +23,73 @@ pub struct MutationPatch {
     pub changes: Value,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub work_action: Option<crate::WorkActionBinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_edit: Option<HostEditBinding>,
+}
+
+/// Caller-supplied provenance, never authentication or permission to bypass a domain gate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HostEditBinding {
+    pub version: u32,
+    pub request_key: String,
+    pub request_hash: String,
+    pub actor: HostActor,
+    pub action: HostEditAction,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HostActor {
+    pub host: String,
+    pub subject: String,
+    pub origin: HostEditOrigin,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostEditOrigin {
+    Human,
+    AiAccepted,
+    DelegatedAgent,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostEditAction {
+    Fields,
+    ActivateDraft,
+}
+impl HostActor {
+    pub fn validate(&self) -> Result<()> {
+        crate::ensure_public_data(self)?;
+        if self.host.len() + self.subject.len() + 1 > 256 {
+            return Err(Error::InvalidInput(
+                "combined host and subject must fit the 256-byte actor receipt limit".into(),
+            ));
+        }
+        for value in [&self.host, &self.subject] {
+            if value.trim().is_empty() || value.len() > 512 || value.chars().any(char::is_control) {
+                return Err(Error::InvalidInput(
+                    "host and subject require bounded provenance identifiers".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+impl HostEditBinding {
+    pub fn validate(&self) -> Result<()> {
+        self.actor.validate()?;
+        if self.version != 1
+            || self.request_key.trim().is_empty()
+            || self.request_key.len() > 512
+            || self.request_key.chars().any(char::is_control)
+            || !crate::is_sha256_hash(&self.request_hash)
+        {
+            return Err(Error::InvalidInput(
+                "host edit requires version, bounded request key and exact request hash".into(),
+            ));
+        }
+        Ok(())
+    }
 }
 impl MutationPatch {
     pub fn mutation_type(&self) -> &'static str {
@@ -72,6 +139,22 @@ impl MutationPatch {
                 ));
             }
             binding.validate(&self.changes)?;
+        }
+        if let Some(binding) = &self.host_edit {
+            binding.validate()?;
+            if self.work_action.is_some() {
+                return Err(Error::InvalidInput(
+                    "host edits cannot impersonate Agent work actions".into(),
+                ));
+            }
+            if binding.action == HostEditAction::ActivateDraft
+                && (self.target.kind != EntityKind::WorkItem
+                    || self.changes != serde_json::json!({"status":"planned"}))
+            {
+                return Err(Error::RuleViolation(
+                    "draft activation only declares the planned state of one work item".into(),
+                ));
+            }
         }
         let meta = &self.target.meta;
         let source = &meta.source_ref;

--- a/crates/awr-runtime/src/completion.rs
+++ b/crates/awr-runtime/src/completion.rs
@@ -92,6 +92,7 @@ pub(crate) fn verify_completion_proof(
                 source_config: target.source.config.clone(),
                 intent: "Verify completion evidence source".into(),
                 changes: serde_json::json!({"summary":"read only verification"}),
+                host_edit: None,
                 work_action: None,
             };
             verify_mutation_source(root, &target.source, &probe)?;
@@ -166,6 +167,7 @@ pub fn complete_work(
         source_config: target.source.config.clone(),
         intent: request.reason.clone(),
         changes: serde_json::json!({"status":"completed"}),
+        host_edit: None,
         work_action: None,
     };
     verify_mutation_source(&root, &target.source, &patch)?;

--- a/crates/awr-runtime/src/host_save.rs
+++ b/crates/awr-runtime/src/host_save.rs
@@ -1,0 +1,636 @@
+//! One host action orchestrates existing source writers; provenance confers no authority.
+use crate::mutation_apply::{directory, named_lock, new_file, recovery_root};
+use crate::{DocumentRequest, ReviewProposalAction, ReviewProposalRequest};
+use awr_core::*;
+use awr_source::*;
+use awr_store::Store;
+use cap_std::fs::Dir;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    ffi::OsStr,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HostSaveRequest {
+    pub version: u32,
+    pub request_key: String,
+    pub actor: HostActor,
+    pub reason: String,
+    pub change: HostChange,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
+pub enum HostChange {
+    Fields {
+        kind: EntityKind,
+        target: String,
+        source_fingerprint: String,
+        fields: Value,
+    },
+    ActivateDraft {
+        work: String,
+        source_fingerprint: String,
+    },
+    Document {
+        change: DocumentAction,
+    },
+}
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "backend", rename_all = "snake_case", deny_unknown_fields)]
+enum Backend {
+    Fields {
+        patch: MutationPatch,
+        before_text: String,
+        after_text: String,
+    },
+    Document {
+        input: DocumentRequest,
+        preview: Value,
+    },
+    NoChange,
+}
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Plan {
+    version: u32,
+    project_id: Id,
+    root: PathBuf,
+    request: HostSaveRequest,
+    request_hash: String,
+    project_revision: Revision,
+    backend: Backend,
+}
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Receipt {
+    plan: Plan,
+    preview_fingerprint: String,
+    phase: String,
+    project_revision: Revision,
+    proposal_id: Option<Id>,
+    outcome: Option<Value>,
+}
+pub struct HostSaveReport {
+    pub value: Value,
+    pub failure: Option<Error>,
+}
+fn hash(value: &impl Serialize) -> Result<String> {
+    Ok(fingerprint(&serde_json::to_vec(value)?)
+        .trim_start_matches("sha256:")
+        .into())
+}
+fn name(project: Id, key: &str) -> Result<String> {
+    if key.trim().is_empty() || key.len() > 512 || key.chars().any(char::is_control) {
+        return Err(Error::InvalidInput(
+            "host request key requires 1..512 bytes without controls".into(),
+        ));
+    }
+    ensure_public_text(key)?;
+    Ok(format!("host-save-{}", hash(&(project, key))?))
+}
+fn validate(r: &HostSaveRequest) -> Result<()> {
+    ensure_public_data(r)?;
+    r.actor.validate()?;
+    if r.version != 1
+        || r.request_key.trim().is_empty()
+        || r.request_key.len() > 512
+        || r.request_key.chars().any(char::is_control)
+        || r.reason.trim().is_empty()
+        || r.reason.len() > 4096
+        || serde_json::to_vec(r)?.len() > MARKDOWN_READ_CAP as usize
+    {
+        return Err(Error::InvalidInput(
+            "host save needs version 1, bounded request identity, reason and one source change"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+fn load(root: &Path, project: Id, key: &str) -> Result<Option<Receipt>> {
+    let base = root.join(".awr/mutations").join(name(project, key)?);
+    match std::fs::symlink_metadata(&base) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+        Ok(m) if !m.is_dir() || m.file_type().is_symlink() => {
+            return Err(Error::RuleViolation(
+                "host save receipt directory is invalid".into(),
+            ));
+        }
+        _ => (),
+    }
+    let r: Receipt = serde_json::from_slice(&read_capped(
+        &base.join("receipt.json"),
+        MARKDOWN_READ_CAP * 5,
+    )?)?;
+    if r.plan.version != 1
+        || r.plan.project_id != project
+        || r.plan.root != root
+        || r.plan.request.request_key != key
+        || r.plan.request_hash != hash(&(project, &r.plan.request))?
+        || r.preview_fingerprint != hash(&r.plan)?
+        || !["prepared", "completed", "no_change"].contains(&r.phase.as_str())
+    {
+        return Err(Error::SourceConflict(
+            "host save receipt has a different project, request or plan".into(),
+        ));
+    }
+    validate(&r.plan.request)?;
+    Ok(Some(r))
+}
+fn save(dir: &Dir, r: &Receipt) -> Result<()> {
+    let name = format!("receipt-{}.tmp", Id::new());
+    let mut f = new_file(dir, OsStr::new(&name))?;
+    f.write_all(&serde_json::to_vec_pretty(r)?)?;
+    f.sync_all()?;
+    drop(f);
+    dir.rename(&name, dir, "receipt.json")?;
+    crate::fs_sync::sync_directory(dir)
+}
+fn summary(r: &Receipt, replay: bool) -> Result<Value> {
+    let stopped = r.phase == "prepared"
+        && r.outcome.as_ref().is_some_and(|v| {
+            matches!(
+                v["proposal"]["status"].as_str(),
+                Some("failed" | "conflict" | "rejected")
+            )
+        });
+    Ok(
+        json!({"ok":r.phase!="prepared","status":if stopped{"requires_review"}else if r.phase=="prepared"{"pending_recovery"}else{r.phase.as_str()},"project_id":r.plan.project_id,
+        "project_revision":r.project_revision,"request_key":r.plan.request.request_key,"actor":r.plan.request.actor,"provenance_is_authentication":false,
+        "proposal_id":r.proposal_id,"preview_fingerprint":r.preview_fingerprint,"already_recorded":replay,"historical_outcome":replay,
+        "source_write_performed":false,"runtime_write_performed":false,"write_outcome":if stopped{"stopped"}else if r.phase=="prepared"{"pending_recovery"}else if r.phase=="no_change"{"no_change"}else{"applied"},
+        "outcome":r.outcome,"recovery_directory":format!(".awr/mutations/{}",name(r.plan.project_id,&r.plan.request.request_key)?)}),
+    )
+}
+fn preview_fields(
+    store: &Store,
+    root: &Path,
+    project: Id,
+    request: &HostSaveRequest,
+    kind: EntityKind,
+    target: &str,
+    source_fp: &str,
+    changes: Value,
+    action: HostEditAction,
+) -> Result<Backend> {
+    let target = store.mutation_target(project, kind, target)?;
+    if target.source.fingerprint != source_fp {
+        return Err(Error::SourceConflict(
+            "host editor source fingerprint is obsolete".into(),
+        ));
+    }
+    let patch = MutationPatch {
+        version: 1,
+        target: MutationTarget {
+            kind,
+            meta: serde_json::from_value(target.item)?,
+        },
+        source_config: target.source.config.clone(),
+        intent: request.reason.clone(),
+        changes,
+        work_action: None,
+        host_edit: Some(HostEditBinding {
+            version: 1,
+            request_key: request.request_key.clone(),
+            request_hash: hash(&(project, request))?,
+            actor: request.actor.clone(),
+            action,
+        }),
+    };
+    patch.validate()?;
+    verify_mutation_source(root, &target.source, &patch)?;
+    if action == HostEditAction::Fields {
+        if patch
+            .changes
+            .as_object()
+            .unwrap()
+            .keys()
+            .any(|k| !yaml_field_writable(kind, k))
+        {
+            return Err(Error::MutationUnsupported(
+                "host field saves retain the existing field and lifecycle restrictions".into(),
+            ));
+        }
+        let record = read_yaml_mutation_record(root, &target.source, &patch)?;
+        if patch
+            .changes
+            .as_object()
+            .unwrap()
+            .iter()
+            .all(|(k, v)| record.get(k) == Some(v))
+        {
+            return Ok(Backend::NoChange);
+        }
+    }
+    let proposal = MutationProposal {
+        id: Id::new(),
+        project_id: project,
+        work_item_id: (kind == EntityKind::WorkItem).then_some(patch.target.meta.id),
+        source_id: target.source.id,
+        base_fingerprint: source_fp.into(),
+        expected_revision: store.project(project)?.project_revision,
+        mutation_type: patch.mutation_type().into(),
+        patch: serde_json::to_value(&patch)?,
+        status: ProposalStatus::Draft,
+        created_by_session: None,
+        revision: 1,
+    };
+    store.check_work_proposal(project, &proposal)?;
+    crate::work_action::verify_work_dependencies(store, root, project, &patch)?;
+    let prepared = prepare_yaml_mutation(
+        root,
+        &target.source,
+        &proposal,
+        store.projection_ids(&target.source)?,
+    )?;
+    if open_file_exact(&prepared.path)?
+        .metadata()?
+        .permissions()
+        .readonly()
+    {
+        return Err(Error::RuleViolation("host source is read-only".into()));
+    }
+    Ok(Backend::Fields {
+        patch,
+        before_text: prepared.before.text()?.into(),
+        after_text: prepared.after.text()?.into(),
+    })
+}
+fn prepare(store: &mut Store, root: &Path, request: HostSaveRequest) -> Result<Plan> {
+    validate(&request)?;
+    let project = store.project_by_root(root)?;
+    let backend = match &request.change {
+        HostChange::Fields {
+            kind,
+            target,
+            source_fingerprint,
+            fields,
+        } => preview_fields(
+            store,
+            root,
+            project.id,
+            &request,
+            *kind,
+            target,
+            source_fingerprint,
+            fields.clone(),
+            HostEditAction::Fields,
+        )?,
+        HostChange::ActivateDraft {
+            work,
+            source_fingerprint,
+        } => preview_fields(
+            store,
+            root,
+            project.id,
+            &request,
+            EntityKind::WorkItem,
+            work,
+            source_fingerprint,
+            json!({"status":"planned"}),
+            HostEditAction::ActivateDraft,
+        )?,
+        HostChange::Document { change } => {
+            let unchanged = if let DocumentAction::Edit {
+                source_id,
+                source_fingerprint,
+                edit,
+            } = change
+            {
+                let source = store.source(project.id, *source_id)?;
+                let p = prepare_document_edit(
+                    root,
+                    &source,
+                    source_fingerprint,
+                    edit,
+                    store.projection_ids(&source)?,
+                )?;
+                p.before
+                    .as_ref()
+                    .is_some_and(|s| s.fingerprint == p.after.fingerprint)
+            } else {
+                false
+            };
+            if unchanged {
+                Backend::NoChange
+            } else {
+                let input = DocumentRequest {
+                    version: 1,
+                    request_key: format!("host/{}", hash(&(project.id, &request.request_key))?),
+                    change: change.clone(),
+                };
+                let preview =
+                    crate::change_document(store, root, input.clone(), false, None, None)?;
+                if let Some(e) = preview.failure {
+                    return Err(e);
+                }
+                Backend::Document {
+                    input,
+                    preview: preview.value,
+                }
+            }
+        }
+    };
+    Ok(Plan {
+        version: 1,
+        project_id: project.id,
+        root: root.into(),
+        request_hash: hash(&(project.id, &request))?,
+        request,
+        project_revision: store.project(project.id)?.project_revision,
+        backend,
+    })
+}
+pub fn host_preview(
+    store: &mut Store,
+    root: &Path,
+    request: HostSaveRequest,
+) -> Result<HostSaveReport> {
+    let root = root.canonicalize()?;
+    let plan = prepare(store, &root, request)?;
+    Ok(HostSaveReport {
+        value: json!({"ok":true,"status":"preview","project_revision":plan.project_revision,"preview":{"fingerprint":hash(&plan)?,"plan":plan},"source_write_performed":false}),
+        failure: None,
+    })
+}
+pub fn host_status(store: &Store, root: &Path, key: &str) -> Result<HostSaveReport> {
+    let root = root.canonicalize()?;
+    let project = store.project_by_root(&root)?;
+    let value = if let Some(r) = load(&root, project.id, key)? {
+        let mut value = summary(&r, true)?;
+        value["found"] = json!(true);
+        value["read_only"] = json!(true);
+        if let Some(p) = store.host_proposal(project.id, key)? {
+            if r.phase == "prepared"
+                && matches!(
+                    p.status,
+                    ProposalStatus::Failed | ProposalStatus::Conflict | ProposalStatus::Rejected
+                )
+            {
+                value["status"] = json!("requires_review");
+                value["write_outcome"] = json!("stopped");
+            }
+            value["current_proposal"] = json!(p)
+        }
+        if let Backend::Fields {
+            patch,
+            before_text,
+            after_text,
+        } = &r.plan.backend
+        {
+            let observed = (|| -> Result<String> {
+                let source = store.source(project.id, patch.target.meta.source_ref.source_id)?;
+                if source.config != patch.source_config {
+                    return Err(Error::SourceConflict("source mapping changed".into()));
+                }
+                Ok(inspect_registered_source(&root, &source)?.2.fingerprint)
+            })();
+            value["current_source"] = json!(match observed {
+                Ok(fp) if fp == fingerprint(after_text.as_bytes()) => "after",
+                Ok(fp) if fp == fingerprint(before_text.as_bytes()) => "before",
+                Ok(_) => "externally_changed",
+                Err(_) => "unavailable_or_registration_changed",
+            });
+        }
+        if let Backend::Document { input, .. } = &r.plan.backend {
+            value["current_document"] =
+                crate::document_status(store, &root, &input.request_key)?.value
+        }
+        value
+    } else {
+        json!({"ok":true,"found":false,"read_only":true,"source_write_performed":false,"runtime_write_performed":false})
+    };
+    Ok(HostSaveReport {
+        value,
+        failure: None,
+    })
+}
+/// A human Save already selects exact fields/source bytes. AI application additionally
+/// requires the fingerprint of the complete preview actually shown by the host.
+pub fn host_save(
+    store: &mut Store,
+    root: &Path,
+    request: HostSaveRequest,
+    expected: Revision,
+    reviewed: Option<&str>,
+) -> Result<HostSaveReport> {
+    let root = root.canonicalize()?;
+    validate(&request)?;
+    let project = store.project_by_root(&root)?;
+    let name = name(project.id, &request.request_key)?;
+    let _lock = named_lock(&root, &format!("{name}.lock"))?;
+    if let Some(r) = load(&root, project.id, &request.request_key)? {
+        if r.plan.request_hash != hash(&(project.id, &request))? {
+            return Err(Error::SourceConflict(
+                "host request identity belongs to a different edit or actor".into(),
+            ));
+        }
+        return Ok(HostSaveReport {
+            value: summary(&r, true)?,
+            failure: (r.phase == "prepared").then(|| {
+                Error::MutationConflict(
+                    "inspect the existing host request and explicitly recover it".into(),
+                )
+            }),
+        });
+    }
+    if project.project_revision != expected {
+        return Err(Error::RevisionConflict {
+            expected,
+            actual: project.project_revision,
+        });
+    }
+    let plan = prepare(store, &root, request)?;
+    let fingerprint = hash(&plan)?;
+    if plan.project_revision != expected {
+        return Err(Error::RevisionConflict {
+            expected,
+            actual: plan.project_revision,
+        });
+    }
+    if (plan.request.actor.origin != HostEditOrigin::Human || reviewed.is_some())
+        && reviewed != Some(fingerprint.as_str())
+    {
+        return Err(Error::SourceConflict(
+            "AI application requires the exact reviewed host preview".into(),
+        ));
+    }
+    let mutations = recovery_root(&root)?;
+    mutations.create_dir(&name)?;
+    let dir = directory(&mutations, &name, &root.join(".awr/mutations").join(&name))?;
+    let mut r = Receipt {
+        plan,
+        preview_fingerprint: fingerprint,
+        phase: "prepared".into(),
+        project_revision: expected,
+        proposal_id: None,
+        outcome: None,
+    };
+    save(&dir, &r)?;
+    crate::fs_sync::sync_directory(&mutations)?;
+    finish(store, &root, &dir, &mut r, expected, false)
+}
+pub fn host_recover(
+    store: &mut Store,
+    root: &Path,
+    key: &str,
+    expected: Revision,
+) -> Result<HostSaveReport> {
+    let root = root.canonicalize()?;
+    let project = store.project_by_root(&root)?;
+    let name = name(project.id, key)?;
+    let _lock = named_lock(&root, &format!("{name}.lock"))?;
+    let mut r =
+        load(&root, project.id, key)?.ok_or_else(|| Error::NotFound("host save request".into()))?;
+    if r.phase != "prepared" {
+        return Ok(HostSaveReport {
+            value: summary(&r, true)?,
+            failure: None,
+        });
+    }
+    let dir = open_dir_exact(&root.join(".awr/mutations").join(&name))?;
+    finish(store, &root, &dir, &mut r, expected, true)
+}
+fn finish(
+    store: &mut Store,
+    root: &Path,
+    dir: &Dir,
+    r: &mut Receipt,
+    expected: Revision,
+    recovery: bool,
+) -> Result<HostSaveReport> {
+    let mut wrote = false;
+    let result = (|| -> Result<()> {
+        let actual = store.project(r.plan.project_id)?.project_revision;
+        if actual != expected {
+            return Err(Error::RevisionConflict { expected, actual });
+        }
+        match r.plan.backend.clone() {
+            Backend::NoChange => {
+                let current = prepare(store, root, r.plan.request.clone())?;
+                if !matches!(current.backend, Backend::NoChange) {
+                    return Err(Error::SourceConflict(
+                        "unchanged save no longer matches current source facts".into(),
+                    ));
+                }
+                r.phase = "no_change".into();
+                save(dir, r)?;
+            }
+            Backend::Document { input, preview } => {
+                let status = crate::document_status(store, root, &input.request_key)?;
+                let report = if status.value["found"] == true {
+                    if !recovery {
+                        return Err(Error::MutationConflict(
+                            "document request already exists; explicitly recover the host save"
+                                .into(),
+                        ));
+                    }
+                    crate::recover_document(store, root, &input.request_key, expected)?
+                } else {
+                    crate::change_document(
+                        store,
+                        root,
+                        input,
+                        true,
+                        preview["preview"]["fingerprint"].as_str(),
+                        Some(expected),
+                    )?
+                };
+                wrote = report.value["source_write_performed"] == true;
+                r.project_revision = store.project(r.plan.project_id)?.project_revision;
+                r.outcome = Some(report.value);
+                if let Some(e) = report.failure {
+                    save(dir, r)?;
+                    return Err(e);
+                }
+                r.phase = "completed".into();
+                save(dir, r)?;
+            }
+            Backend::Fields { patch, .. } => {
+                let project = r.plan.project_id;
+                let mut proposal = if let Some(p) =
+                    store.host_proposal(project, &r.plan.request.request_key)?
+                {
+                    if serde_json::to_value(p.bound_patch()?)? != serde_json::to_value(&patch)? {
+                        return Err(Error::SourceConflict(
+                            "saved host proposal differs from the reviewed patch".into(),
+                        ));
+                    }
+                    p
+                } else {
+                    let source = store.source(project, patch.target.meta.source_ref.source_id)?;
+                    verify_mutation_source(root, &source, &patch)?;
+                    crate::work_action::verify_work_dependencies(store, root, project, &patch)?;
+                    store
+                        .create_proposal(
+                            project,
+                            expected,
+                            MutationDraft {
+                                source_id: source.id,
+                                base_fingerprint: source.fingerprint,
+                                mutation_type: patch.mutation_type().into(),
+                                patch: patch.clone(),
+                                created_by_session: None,
+                            },
+                        )?
+                        .0
+                };
+                r.proposal_id = Some(proposal.id);
+                r.project_revision = store.project(project)?.project_revision;
+                save(dir, r)?;
+                loop {
+                    let action=match proposal.status {
+                        ProposalStatus::Draft=>ReviewProposalAction::Submit,
+                        ProposalStatus::Ready=>ReviewProposalAction::Approve,
+                        ProposalStatus::Approved=>if store.proposal_apply_attempt(project,proposal.id)?.is_some(){ReviewProposalAction::Recover}else{ReviewProposalAction::Apply},
+                        ProposalStatus::Applied=>break,
+                        _=>return Err(Error::SourceConflict("host proposal is terminal without application; preserve it and review a new request".into())),
+                    };
+                    let report = crate::review_proposal(
+                        store,
+                        root,
+                        &ReviewProposalRequest {
+                            proposal_id: proposal.id,
+                            expected_revision: r.project_revision,
+                            action,
+                            actor: format!(
+                                "{}:{}",
+                                r.plan.request.actor.host, r.plan.request.actor.subject
+                            ),
+                            reason: r.plan.request.reason.clone(),
+                        },
+                    )?;
+                    wrote |= report.source_write_performed == Some(true);
+                    r.project_revision = report.project_revision;
+                    r.outcome = Some(serde_json::to_value(&report)?);
+                    let failure = report.failure;
+                    proposal = report.proposal;
+                    save(dir, r)?;
+                    if let Some(e) = failure {
+                        return Err(e);
+                    }
+                }
+                r.phase = "completed".into();
+                save(dir, r)?;
+            }
+        }
+        Ok(())
+    })();
+    let mut value = summary(r, false)?;
+    value["source_write_performed"] = json!(wrote);
+    value["runtime_write_performed"] = json!(true);
+    let failure = result.err();
+    if let Some(e) = &failure {
+        value["ok"] = json!(false);
+        if value["status"] != "requires_review" {
+            value["status"] = json!("pending_recovery");
+            value["write_outcome"] = json!("pending_recovery");
+        }
+        value["error"] = json!(e.report())
+    }
+    Ok(HostSaveReport { value, failure })
+}

--- a/crates/awr-runtime/src/lib.rs
+++ b/crates/awr-runtime/src/lib.rs
@@ -8,8 +8,12 @@ mod branch_close;
 mod completion;
 mod doctor;
 mod document;
+mod host_save;
 pub use document::{
     DocumentReport, DocumentRequest, change_document, document_status, recover_document,
+};
+pub use host_save::{
+    HostChange, HostSaveReport, HostSaveRequest, host_preview, host_recover, host_save, host_status,
 };
 mod execution;
 mod fs_sync;

--- a/crates/awr-runtime/src/mutation.rs
+++ b/crates/awr-runtime/src/mutation.rs
@@ -112,6 +112,7 @@ pub fn create_proposal(
         source_config: target.source.config.clone(),
         intent: request.intent.clone(),
         changes: request.changes.clone(),
+        host_edit: None,
         work_action: None,
     };
     patch.validate()?;

--- a/crates/awr-runtime/src/work_action.rs
+++ b/crates/awr-runtime/src/work_action.rs
@@ -20,6 +20,21 @@ pub(crate) fn verify_work_dependencies(
     project: Id,
     patch: &MutationPatch,
 ) -> Result<()> {
+    if patch
+        .host_edit
+        .as_ref()
+        .is_some_and(|h| h.action == HostEditAction::ActivateDraft)
+    {
+        for source in store.sources(project)? {
+            let (_, _, actual) = awr_source::inspect_registered_source(root, &source)?;
+            if source.freshness != Freshness::Fresh || actual.fingerprint != source.fingerprint {
+                return Err(Error::SourceConflict(
+                    "draft activation requires current goal, rule, plan and dependency sources"
+                        .into(),
+                ));
+            }
+        }
+    }
     if !patch
         .work_action
         .as_ref()
@@ -56,6 +71,7 @@ pub(crate) fn verify_required_sources(
                 source_config: dependency.source.config.clone(),
                 intent: "Verify the current required dependency source".into(),
                 changes: serde_json::json!({"next_action":"verification only"}),
+                host_edit: None,
                 work_action: None,
             };
             verify_mutation_source(root, &dependency.source, &probe)?;
@@ -96,6 +112,7 @@ pub fn perform_work_action(
         source_config: target.source.config.clone(),
         intent: request.input.reason.clone(),
         changes,
+        host_edit: None,
         work_action: Some(binding),
     };
     verify_mutation_source(&root, &target.source, &patch)?;

--- a/crates/awr-source/src/lib.rs
+++ b/crates/awr-source/src/lib.rs
@@ -47,5 +47,5 @@ pub use yaml_create::{PreparedWorkCreation, prepare_work_creation};
 pub use yaml_ledger::YamlLedgerAdapter;
 pub use yaml_mutation::{
     PreparedYamlMutation, parse_mutation_projection, prepare_yaml_mutation,
-    read_yaml_mutation_record,
+    read_yaml_mutation_record, yaml_field_writable,
 };

--- a/crates/awr-source/src/yaml_edit.rs
+++ b/crates/awr-source/src/yaml_edit.rs
@@ -257,7 +257,14 @@ fn scalar_end(
                         if spaces <= indent {
                             break;
                         }
-                        end = line + content.trim_end().len();
+                        let comment = content.char_indices().find_map(|(i, c)| {
+                            (c == '#' && (i == 0 || content.as_bytes()[i - 1].is_ascii_whitespace()))
+                                .then_some(i)
+                        });
+                        end = line + content[..comment.unwrap_or(content.len())].trim_end().len();
+                        if comment.is_some() {
+                            break;
+                        }
                     }
                     line = next;
                 }
@@ -290,9 +297,18 @@ fn render(text: &str, node: &Node, value: &Value, newline: &str) -> Result<Strin
         };
         return Ok(format!("{prefix}{}", json(value)?));
     };
-    if *style == TScalarStyle::Plain && !node.range.is_empty() && original.trim() != old_value {
+    if *style == TScalarStyle::Plain
+        && !node.range.is_empty()
+        && original.trim() != old_value
+        && (original.contains('#')
+            || serde_yaml_ng::from_str::<Value>(original)
+                .ok()
+                .as_ref()
+                .and_then(Value::as_str)
+                != Some(old_value.as_str()))
+    {
         return Err(unsupported(
-            "multiline plain scalars require an explicit block or quoted style before editing",
+            "ambiguous multiline plain scalar boundaries require manual editing",
         ));
     }
     let Some(string) = value.as_str() else {

--- a/crates/awr-source/src/yaml_mutation.rs
+++ b/crates/awr-source/src/yaml_mutation.rs
@@ -54,7 +54,7 @@ pub fn read_yaml_mutation_record(
         Ok(record)
     }
 }
-fn allowed(kind: EntityKind, field: &str) -> bool {
+pub fn yaml_field_writable(kind: EntityKind, field: &str) -> bool {
     match kind {
         EntityKind::Goal => matches!(
             field,
@@ -150,10 +150,15 @@ pub fn prepare_yaml_mutation(
         ));
     }
     let changes = patch.changes.as_object().unwrap();
-    if let Some(field) = changes
-        .keys()
-        .find(|field| patch.work_action.is_none() && !allowed(patch.target.kind, field))
-    {
+    if let Some(field) = changes.keys().find(|field| {
+        patch.work_action.is_none()
+            && !yaml_field_writable(patch.target.kind, field)
+            && !(patch
+                .host_edit
+                .as_ref()
+                .is_some_and(|h| h.action == HostEditAction::ActivateDraft)
+                && field.as_str() == "status")
+    }) {
         return Err(unsupported(&format!(
             "field {field} is not supported by this writer; work state, ownership and verification changes require domain actions"
         )));

--- a/crates/awr-source/tests/yaml_mutation.rs
+++ b/crates/awr-source/tests/yaml_mutation.rs
@@ -42,6 +42,7 @@ impl Fixture {
         let target = self.store.mutation_target(self.project, kind, key)?;
         let patch = MutationPatch {
             version: 1,
+            host_edit: None,
             work_action: None,
             target: MutationTarget {
                 kind,
@@ -229,7 +230,7 @@ fn block_field_edits_keep_literal_or_folded_style_header_comment_and_neighbor_by
 }
 
 #[test]
-fn unrelated_multiline_plain_fields_are_preserved_and_ambiguous_target_edits_are_rejected() {
+fn multiline_plain_fields_are_preserved_or_edited_at_the_exact_span() {
     let text = "work_items:\n- id: W\n  status: ready\n  title: A plain title continued\n    on another line\n  next_action: Before\n";
     let f = Fixture::new(text);
     assert_eq!(
@@ -240,14 +241,26 @@ fn unrelated_multiline_plain_fields_are_preserved_and_ambiguous_target_edits_are
             .unwrap(),
         text.replace("Before", "After")
     );
-    assert!(matches!(
-        f.plan(EntityKind::WorkItem, "W", json!({"title":"Changed"})),
-        Err(Error::MutationUnsupported(_))
-    ));
+    assert_eq!(
+        f.plan(EntityKind::WorkItem, "W", json!({"title":"Changed"}))
+            .unwrap().after.text().unwrap(),
+        text.replace("A plain title continued\n    on another line", "Changed")
+    );
     assert_eq!(
         fs::read_to_string(f.root.join("ledger.yaml")).unwrap(),
         text
     );
+}
+
+#[test]
+fn wrapped_plain_edits_preserve_trailing_comments_and_newline_style() {
+    for newline in ["\n", "\r\n"] {
+        let text = "work_items:\n- id: W\n  status: ready\n  title: A plain title\n    continued here # keep this comment\n  next_action: Before\n".replace('\n', newline);
+        let f = Fixture::new(&text);
+        let expected = text.replace(&format!("A plain title{newline}    continued here"), "Changed");
+        assert_eq!(f.plan(EntityKind::WorkItem, "W", json!({"title":"Changed"})).unwrap().after.text().unwrap(), expected);
+        assert_eq!(fs::read_to_string(f.root.join("ledger.yaml")).unwrap(), text);
+    }
 }
 
 #[test]

--- a/crates/awr-store/src/mutation.rs
+++ b/crates/awr-store/src/mutation.rs
@@ -325,6 +325,14 @@ fn event_metadata(
 }
 
 impl Store {
+    /// Stable host request lookup; a read must never advance a proposal lifecycle.
+    pub fn host_proposal(&self, project: Id, key: &str) -> Result<Option<MutationProposal>> {
+        self.project(project)?;
+        self.conn.query_row(
+            &format!("SELECT {PROPOSAL_COLUMNS} FROM mutation_proposals WHERE project_id=?1 AND json_extract(patch_json,'$.host_edit.request_key')=?2"),
+            params![project.to_string(),key],proposal_row,
+        ).optional().map_err(db_error)
+    }
     /// Resolve one active source projection by exact ULID or external key.
     pub fn mutation_target(
         &self,
@@ -355,6 +363,10 @@ impl Store {
             expected,
             EventDraft::new("proposal.created", "Created source mutation proposal"),
             move |tx, _, event| {
+                if let Some(host)=&draft.patch.host_edit {
+                    let exists:bool=tx.query_row("SELECT EXISTS(SELECT 1 FROM mutation_proposals WHERE project_id=?1 AND json_extract(patch_json,'$.host_edit.request_key')=?2)",params![project.to_string(),host.request_key],|r|r.get(0)).map_err(db_error)?;
+                    if exists {return Err(Error::SourceConflict("host request already has a proposal; inspect its retained result".into()));}
+                }
                 let target = validate_binding(
                     tx,
                     project,

--- a/crates/awr-store/src/mutation_apply.rs
+++ b/crates/awr-store/src/mutation_apply.rs
@@ -161,6 +161,13 @@ impl Store {
             proposal.status=ProposalStatus::Applied; proposal.revision+=1;
             bind(event,tx,project,&proposal)?;
             event.payload=json!({"proposal_id":id,"source_id":proposal.source_id,"attempt_event_id":attempt_id,"write_plan_id":attempt.plan.id,"before_fingerprint":attempt.plan.before_fingerprint,"after_fingerprint":attempt.plan.after_fingerprint,"target_after_hash":attempt.plan.target_after_hash,"source_revision":target.source.revision,"target_revision":meta.revision,"actor":actor,"reason":reason});
+            if let Some(host)=&patch.host_edit {
+                event.payload["host_edit"]=json!(host);
+                if host.action==HostEditAction::ActivateDraft {
+                    event.event_type="work.draft_activated".into();
+                    event.summary="Explicitly activated source-declared draft".into();
+                }
+            }
             if let Some(binding)=patch.work_action {
                 event.event_type=binding.action.event_type().into();
                 event.summary=format!("Verified source work action {:?}",binding.action);

--- a/crates/awr-store/src/work_action.rs
+++ b/crates/awr-store/src/work_action.rs
@@ -14,6 +14,18 @@ pub(crate) fn validate_action(
     target: &serde_json::Value,
     session: Option<Id>,
 ) -> Result<()> {
+    if let Some(host) = &patch.host_edit {
+        host.validate()?;
+        if session.is_some() {
+            return Err(Error::InvalidInput(
+                "host edits record provenance without creating an Agent session".into(),
+            ));
+        }
+        if host.action == HostEditAction::ActivateDraft {
+            let work: WorkItem = serde_json::from_value(target.clone())?;
+            validate_draft_activation(conn, project, revision, &work)?;
+        }
+    }
     let Some(binding) = &patch.work_action else {
         return Ok(());
     };
@@ -69,6 +81,94 @@ pub(crate) fn validate_action(
     if let Some(completion) = &binding.completion {
         validate_completion_binding(conn, project, &work, session.branch_id, completion)?;
         check_blocker(&work)?;
+    }
+    Ok(())
+}
+
+fn validate_draft_activation(
+    conn: &Connection,
+    project: Id,
+    revision: Revision,
+    work: &WorkItem,
+) -> Result<()> {
+    if work.status != WorkStatus::Draft {
+        return Err(Error::InvalidTransition(
+            "only a draft can be explicitly activated".into(),
+        ));
+    }
+    validate_criteria(&work.acceptance)?;
+    if work.title.trim().is_empty()
+        || work.next_action.trim().is_empty()
+        || work.kind.as_deref() == Some("intake")
+    {
+        return Err(Error::RuleViolation(
+            "draft needs a title, delivery acceptance and a concrete next action".into(),
+        ));
+    }
+    let claimed:bool=conn.query_row("SELECT EXISTS(SELECT 1 FROM claims WHERE project_id=?1 AND work_item_id=?2 AND status='active' AND released_at IS NULL AND (expires_at IS NULL OR expires_at>?3))",params![project.to_string(),work.meta.id.to_string(),now_millis()?],|r|r.get(0)).map_err(db_error)?;
+    if claimed {
+        return Err(Error::ClaimConflict(
+            "release existing runtime occupancy before activating a draft".into(),
+        ));
+    }
+    check_dependencies(conn, project, revision, work, None, false)?;
+    let configs: Vec<serde_json::Value> = conn
+        .prepare("SELECT config_json FROM sources WHERE project_id=?1 AND active=1")
+        .map_err(db_error)?
+        .query_map([project.to_string()], |r| r.get::<_, String>(0))
+        .map_err(db_error)?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(db_error)?
+        .into_iter()
+        .map(|s| serde_json::from_str(&s).map_err(Error::from))
+        .collect::<Result<_>>()?;
+    let minimal = !configs.is_empty() && configs.iter().all(|c| c["context_profile"] == "minimal");
+    if !minimal {
+        let rules:bool=conn.query_row("SELECT EXISTS(SELECT 1 FROM sources WHERE project_id=?1 AND domain='rules' AND active=1 AND freshness='fresh')",[project.to_string()],|r|r.get(0)).map_err(db_error)?;
+        if !rules
+            || work
+                .milestone
+                .as_deref()
+                .is_none_or(|m| m.trim().is_empty())
+        {
+            return Err(Error::RuleViolation(
+                "standard projects retain their declared rule and milestone requirements".into(),
+            ));
+        }
+    }
+    if let Some(key) = &work.milestone {
+        let p: Projected<Plan> = crate::query::projection(conn, project, EntityKind::Plan, key)?;
+        if p.source.freshness != Freshness::Fresh {
+            return Err(Error::SourceStale("draft milestone is stale".into()));
+        }
+    }
+    let goal_keys=conn.prepare("SELECT e.to_key FROM edges e JOIN sources s ON s.id=e.source_id AND s.project_id=e.project_id WHERE e.project_id=?1 AND e.active=1 AND s.active=1 AND e.from_kind='work_item' AND e.from_key=?2 AND e.to_kind='goal' AND e.relation='supports'").map_err(db_error)?.query_map(params![project.to_string(),work.meta.external_key],|r|r.get::<_,String>(0)).map_err(db_error)?.collect::<rusqlite::Result<Vec<_>>>().map_err(db_error)?;
+    if goal_keys.is_empty() {
+        return Err(Error::RuleViolation(
+            "draft activation requires an explicit goal link".into(),
+        ));
+    }
+    for key in goal_keys {
+        let goal: Projected<Goal> =
+            crate::query::projection(conn, project, EntityKind::Goal, &key)?;
+        if goal.source.role != "primary"
+            || goal.source.freshness != Freshness::Fresh
+            || goal.item.title.trim().is_empty()
+            || !["active", "confirmed", "approved", "in_progress"]
+                .contains(&goal.item.status.to_ascii_lowercase().as_str())
+            || (goal.item.summary.trim().is_empty()
+                && validate_criteria(&goal.item.success_criteria).is_err())
+            || (goal
+                .source
+                .locator
+                .replace('\\', "/")
+                .contains(".awr/intake/")
+                && goal.item.title == "Establish a verified project baseline")
+        {
+            return Err(Error::RuleViolation(
+                "draft goal is missing, unconfirmed, finished or an intake placeholder".into(),
+            ));
+        }
     }
     Ok(())
 }

--- a/crates/awr-store/tests/mutation.rs
+++ b/crates/awr-store/tests/mutation.rs
@@ -176,6 +176,7 @@ fn proposal_draft(target: &Projected<Value>, changes: Value, session: Option<Id>
         mutation_type: "update_fields".into(),
         patch: MutationPatch {
             version: 1,
+            host_edit: None,
             work_action: None,
             target: MutationTarget {
                 kind: match target.item.get("raw_status") {

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -166,7 +166,7 @@ expected semantics and reparse through the source adapter. See the
 [YAML writer](../../adapters/yaml-ledger/README.md) for supported shapes.
 
 `mutation.markdown.document` supports registered heading, rule and decision documents.
-Markdown work ledgers remain read-only. Unsupported capabilities include human-save shortcuts, multi-file
+Markdown work ledgers remain read-only. Unsupported capabilities include multi-file
 writes and user-confirmed completion. Never route an unsupported operation through a
 generic status patch or a second writer.
 
@@ -440,6 +440,74 @@ foreign keys, and retains additional indexes and triggers. Builds that only supp
 schema 3 must reject this database; restore a matching database/program snapshot
 when rolling back. Newly created drafts need an explicit source declaration before
 execution; creation itself never supplies missing execution or completion facts.
+
+## One Save from a host
+
+`host save` provides one CLI invocation for a user's explicit edit. It reuses existing
+YAML proposals and document recovery journals; it does not create an Agent session,
+claim or model call. The trusted local host remains responsible for authenticating its
+user and showing the actual edit. The `actor` fields record caller-supplied provenance;
+they are not authentication, and every origin retains source registration, filesystem
+permissions, version checks and domain rules.
+
+```json
+{
+  "version": 1,
+  "request_key": "host/edit-task/1",
+  "actor": {"host": "desktop-app", "subject": "local-user", "origin": "human"},
+  "reason": "Save the user's explicit next-action edit",
+  "change": {
+    "operation": "fields",
+    "kind": "work_item",
+    "target": "WORK-EXAMPLE",
+    "source_fingerprint": "sha256:<source hash from the editor's original read>",
+    "fields": {"next_action": "Review the reading notes"}
+  }
+}
+```
+
+```text
+awr host save --input save.json --expected-revision <editor-revision> --json
+awr host status --key <same-request-key> --json
+awr host recover --key <same-request-key> --expected-revision <current-revision> --json
+```
+
+Request keys contain 1–512 UTF-8 bytes; the combined host and subject plus separator
+must fit 256 bytes. Reasons contain 1–4096 bytes. Field saves support the existing YAML
+goal, plan, work and evidence writer's fields. Work completion, ownership and evidence
+levels remain protected. The proposal and final event retain the exact request hash
+and actor; the saved host journal also binds their source preview and operation.
+
+For AI edits, set `origin` to `ai_accepted`, call `host preview --input save.json`, show
+the complete `preview.plan` change to the user, and pass its fingerprint to `host save
+--expected-preview <fingerprint> --expected-revision <preview-revision>`. The fingerprint
+binds the request, actor, exact patch, target, source and project versions. A changed
+patch, target or source requires a new preview. A provenance label alone cannot mark
+work completed or bypass a claim-dependent Agent action.
+
+For an Agent acting under authority already delegated by the user, record
+`origin: "delegated_agent"` and the actual Agent subject. This also requires the exact
+preview fingerprint. The host must enforce the scope of that delegation; the label
+does not grant it and does not assert that a human individually reviewed the patch.
+
+Use `change: {"operation":"document","change":<document change>}` for one registered
+Markdown edit or new draft through the same host flow. A supported unchanged save
+returns `no_change` without creating a proposal or business event. Existing proposal
+no-op errors remain unchanged. `host status` is read-only and reports retained outcomes
+separately from current source observations and the underlying proposal/document.
+An identical request replay returns the retained identity; changed content under the
+same key conflicts. A lost response requires lookup before retry. `pending_recovery`
+requires explicit recovery; `requires_review` means a terminal proposal stopped, and
+its outcome must be inspected before creating a new request. File effects and runtime
+effects remain separate; neither a transport error nor a stopped proposal proves the
+source was never written. Recovery retains external edits.
+
+After filling a work draft's goal, acceptance and next action, explicitly use
+`change: {"operation":"activate_draft","work":"<key>","source_fingerprint":"<hash>"}`.
+Activation requires a current, declared primary goal, valid structure, resolved
+dependencies and no blocker or existing claim. Standard projects retain rule/milestone
+requirements. It changes only `draft` to `planned`, with a protected
+`work.draft_activated` receipt; it never asserts completion or invents execution facts.
 
 One project keeps one source ledger. When replacing an existing host writer, switch
 only operations AWR actually supports, retain old runtime history as history, and


### PR DESCRIPTION
Hosts can save an authorized source edit in one call, with durable request identity, provenance and explicit recovery. AI and delegated edits bind the exact preview; draft activation rechecks declared goals, acceptance and dependencies without fabricating an Agent session. Wrapped YAML scalars preserve unrelated source bytes.

Validation: 84 targeted native CLI, source and store checks passed, including post-write receipt failure, third-party source changes, guarded fields and unchanged engineering completion behavior.
