### PR TITLE
Add reviewed ledger batches and reversible archival

### DIFF
--- a/crates/awr-cli/src/batch.rs
+++ b/crates/awr-cli/src/batch.rs
@@ -1,0 +1,94 @@
+use awr_core::*;
+use awr_runtime::{BatchReport, BatchRequest};
+use awr_store::Store;
+use clap::{Args, Subcommand};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Args)]
+pub struct ChangeArgs {
+    /// Versioned batch edit or new draft, including a stable request key.
+    #[arg(long)]
+    input: PathBuf,
+    #[arg(long)]
+    accept: bool,
+    #[arg(long)]
+    expected_preview: Option<String>,
+    #[arg(long)]
+    expected_revision: Option<Revision>,
+}
+#[derive(Debug, Subcommand)]
+pub enum BatchCommand {
+    /// Preview a source-bound change; accept exactly the returned preview to write it.
+    Change(ChangeArgs),
+    /// Read a retained request outcome without indexing or writing.
+    Status {
+        #[arg(long)]
+        key: String,
+    },
+    /// Explicitly recover one interrupted batch change at the current revision.
+    Recover {
+        #[arg(long)]
+        key: String,
+        #[arg(long)]
+        expected_revision: Revision,
+    },
+}
+fn output(report: BatchReport, json_output: bool) -> Result<()> {
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&report.value)?)
+    } else {
+        println!("Batch change: {}", report.value["status"])
+    }
+    match report.failure {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+pub fn run(root: &Path, command: &BatchCommand, json_output: bool) -> Result<()> {
+    let root = root.canonicalize()?;
+    let db = crate::source::runtime_dir(&root, false)?.join("state.db");
+    match command {
+        BatchCommand::Status { key } => output(
+            awr_runtime::batch_status(&Store::open_readonly(&db)?, &root, key)?,
+            json_output,
+        ),
+        BatchCommand::Recover {
+            key,
+            expected_revision,
+        } => output(
+            awr_runtime::recover_batch(
+                &mut Store::open_existing(&db)?,
+                &root,
+                key,
+                *expected_revision,
+            )?,
+            json_output,
+        ),
+        BatchCommand::Change(args) => {
+            let path = if args.input.is_absolute() {
+                args.input.clone()
+            } else {
+                root.join(&args.input)
+            };
+            let input: BatchRequest =
+                serde_json::from_slice(&awr_source::read_capped(&path, 64 * 1024 * 1024)?)
+                    .map_err(|_| {
+                        Error::InvalidInput(
+                            "batch JSON requires version, request_key and a supported change"
+                                .into(),
+                        )
+                    })?;
+            output(
+                awr_runtime::change_batch(
+                    &mut Store::open_existing(&db)?,
+                    &root,
+                    input,
+                    args.accept,
+                    args.expected_preview.as_deref(),
+                    args.expected_revision,
+                )?,
+                json_output,
+            )
+        }
+    }
+}

--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -258,6 +258,27 @@ fn catalog() -> Vec<Capability> {
                 "not_completion",
             ],
         ),
+        (
+            "mutation.batch.ledger",
+            true,
+            &["batch change", "batch status", "batch recover"],
+            &[
+                "single_source",
+                "all_operations_preflight",
+                "exact_preview_and_revision",
+                "draft_import_explicit_duplicates",
+            ],
+        ),
+        (
+            "mutation.work.archive",
+            true,
+            &["batch change"],
+            &[
+                "separate_from_lifecycle",
+                "dependency_and_claim_guards",
+                "identity_and_history_preserved",
+            ],
+        ),
         ("mutation.multi_file", false, &[], &["not_implemented"]),
         (
             "completion.engineering",

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -1,6 +1,7 @@
 use awr_core::{Error, Result};
 use clap::{CommandFactory, Parser, Subcommand};
 use std::path::PathBuf;
+mod batch;
 mod branch;
 mod capabilities;
 mod catalog;
@@ -43,6 +44,11 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Preview and apply a bounded batch of source edits.
+    Batch {
+        #[command(subcommand)]
+        command: batch::BatchCommand,
+    },
     /// Save explicit host edits with durable request identity and provenance.
     Host {
         #[command(subcommand)]
@@ -158,6 +164,7 @@ enum Command {
 fn run(cli: &Cli) -> Result<()> {
     match &cli.command {
         Some(Command::Host { command }) => host_save::run(&cli.project, command, cli.json),
+        Some(Command::Batch { command }) => batch::run(&cli.project, command, cli.json),
         Some(Command::Document { command }) => document::run(&cli.project, command, cli.json),
         Some(Command::Capabilities(args)) => capabilities::run(args, cli.json),
         Some(Command::Init(args)) => onboarding::run(&cli.project, args, cli.json),

--- a/crates/awr-cli/src/query.rs
+++ b/crates/awr-cli/src/query.rs
@@ -105,7 +105,7 @@ pub(crate) fn short(text: &str) -> String {
 
 fn brief(work: &Projected<WorkItem>) -> Value {
     json!({"id":work.item.meta.id,"external_key":work.item.meta.external_key,"title":work.item.title,
-        "ordinary_completion":work.item.ordinary_completion,"ordinary_work_policy":work.source.config["adapter_options"]["ordinary_work_policy"],
+        "archived":work.item.archived,"ordinary_completion":work.item.ordinary_completion,"ordinary_work_policy":work.source.config["adapter_options"]["ordinary_work_policy"],
         "status":work.item.status,"raw_status":work.item.raw_status,"summary":short(if work.item.summary.is_empty(){&work.item.title}else{&work.item.summary}),
         "priority":work.item.priority,"milestone":work.item.milestone,"owner":work.item.owner,"next_action":work.item.next_action,
         "blocker":work.item.blocker,"revision":work.item.meta.revision,"source_revision":work.item.meta.source_ref.source_revision,"freshness":work.source.freshness})

--- a/crates/awr-cli/tests/host_batch.rs
+++ b/crates/awr-cli/tests/host_batch.rs
@@ -1,0 +1,420 @@
+//! Native same-source batch, archive and interrupted-index fixtures.
+use awr_core::Id;
+use serde_json::{Value, json};
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+};
+struct Host {
+    root: PathBuf,
+    file: &'static str,
+}
+impl Host {
+    fn new(markdown: bool) -> Self {
+        let h = Self {
+            root: std::env::temp_dir().join(format!("awr 批量 {}", Id::new())),
+            file: if markdown { "work.md" } else { "work.yaml" },
+        };
+        fs::create_dir(&h.root).unwrap();
+        h.write(h.file,if markdown{"# Tasks\n\n| id | title | status | next_action |\n| --- | --- | --- | --- |\n| W | Read article | planned | Write note |\n| D | Draft task | draft | |\n\nKeep this paragraph.\n"}else{"# Keep this comment\nwork_items:\n- id: W\n  title: Read article\n  status: planned\n  next_action: Write note\n  custom: preserve\n- id: D\n  title: Draft task\n  status: draft\n"});
+        h.write("GOAL.md", "# Reading {#reading}\n\nRetain useful ideas.\n");
+        h.write("mapping.toml",&format!("[project]\nname='Batch fixture'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='{}'\nadapter='{}'\n[[sources]]\ndomain='goal'\nrole='supporting'\npath='GOAL.md'\nadapter='markdown-heading-v1'\n",h.file,if markdown{"markdown-ledger-v1"}else{"yaml-ledger-v1"}));
+        h.ok(&["init", "--manifest", "mapping.toml", "--accept"]);
+        h
+    }
+    fn write(&self, p: &str, s: &str) {
+        fs::write(self.root.join(p), s).unwrap()
+    }
+    fn text(&self, p: &str) -> String {
+        fs::read_to_string(self.root.join(p)).unwrap()
+    }
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_awr"))
+            .env_clear()
+            .args(["--project", self.root.to_str().unwrap(), "--json"])
+            .args(args)
+            .stdin(Stdio::null())
+            .output()
+            .unwrap()
+    }
+    fn ok(&self, args: &[&str]) -> Value {
+        let o = self.run(args);
+        assert!(
+            o.status.success(),
+            "{args:?}\n{}\n{}",
+            String::from_utf8_lossy(&o.stdout),
+            String::from_utf8_lossy(&o.stderr)
+        );
+        serde_json::from_slice(&o.stdout).unwrap()
+    }
+    fn error(&self, args: &[&str], code: &str) -> Output {
+        let o = self.run(args);
+        assert!(!o.status.success(), "{args:?}");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&o.stderr).unwrap()["code"],
+            code,
+            "{}",
+            String::from_utf8_lossy(&o.stderr)
+        );
+        o
+    }
+    fn revision(&self) -> String {
+        self.ok(&["session", "list"])["project_revision"].to_string()
+    }
+    fn request(&self, key: &str, operations: Value) {
+        let sources = self.ok(&["source", "list"]);
+        let source = sources["sources"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["domain"] == "ledger")
+            .unwrap();
+        self.write("batch.json",&json!({"version":1,"request_key":key,"actor":{"host":"fixture","subject":"editor","origin":"ai_accepted"},"reason":"Apply the reviewed reading plan edits","change":{"kind":"ledger","source_id":source["id"],"source_fingerprint":source["fingerprint"],"operations":operations}}).to_string())
+    }
+    fn preview(&self) -> Value {
+        self.ok(&["batch", "change", "--input", "batch.json"])
+    }
+    fn args(&self, p: &Value) -> Vec<String> {
+        vec![
+            "batch".into(),
+            "change".into(),
+            "--input".into(),
+            "batch.json".into(),
+            "--accept".into(),
+            "--expected-preview".into(),
+            p["preview"]["fingerprint"].as_str().unwrap().into(),
+            "--expected-revision".into(),
+            p["project_revision"].to_string(),
+        ]
+    }
+    fn accept(&self, p: &Value) -> Value {
+        self.ok(&self.args(p).iter().map(String::as_str).collect::<Vec<_>>())
+    }
+    fn sql(&self, s: &str) {
+        rusqlite::Connection::open(self.root.join(".awr/state.db"))
+            .unwrap()
+            .execute_batch(s)
+            .unwrap()
+    }
+}
+impl Drop for Host {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+#[test]
+fn all_operations_are_preflighted_before_writing_and_exact_preview_is_required() {
+    for md in [false, true] {
+        let h = Host::new(md);
+        let before = h.text(h.file);
+        let rev = h.revision();
+        h.request("invalid-second",json!([{"operation":"fields","target":"W","fields":{"title":"New title"}},{"operation":"fields","target":"D","fields":{"status":"completed"}}]));
+        h.error(
+            &["batch", "change", "--input", "batch.json"],
+            "MutationUnsupported",
+        );
+        assert_eq!(h.text(h.file), before);
+        assert_eq!(h.revision(), rev);
+        h.request("valid",json!([{"operation":"fields","target":"W","fields":{"title":"New title"}},{"operation":"fields","target":"D","fields":{"next_action":"Review draft"}}]));
+        let p = h.preview();
+        h.error(
+            &[
+                "batch",
+                "change",
+                "--input",
+                "batch.json",
+                "--accept",
+                "--expected-revision",
+                &h.revision(),
+            ],
+            "SourceConflict",
+        );
+        assert_eq!(h.text(h.file), before);
+        let r = h.accept(&p);
+        assert_eq!(r["status"], "completed");
+        assert_eq!(r["actor"]["origin"], "ai_accepted");
+        assert!(h.text(h.file).contains("New title"));
+        assert!(h.text(h.file).contains(if md {
+            "Keep this paragraph."
+        } else {
+            "custom: preserve"
+        }));
+        let rev = h.revision();
+        assert_eq!(h.accept(&p)["already_recorded"], true);
+        assert_eq!(h.revision(), rev);
+        assert_eq!(h.ok(&["session", "list"])["sessions"], json!([]));
+    }
+}
+#[test]
+fn imports_keep_explicit_ids_remain_drafts_and_never_overwrite_duplicates() {
+    for md in [false, true] {
+        let h = Host::new(md);
+        let ops = json!([{"operation":"import","external_key":"N","title":"New reading","fields":{"next_action":"Review scope","acceptance":["Note is available"]},"duplicate":"fail"}]);
+        h.request("import", ops.clone());
+        let r = h.accept(&h.preview());
+        let work = h.ok(&["work", "show", "N"]);
+        assert_eq!(work["work"]["status"], "draft");
+        assert_eq!(
+            h.ok(&["batch", "status", "--key", "import"])["applied_files"],
+            r["applied_files"]
+        );
+        h.request("duplicate", ops.clone());
+        let before = h.text(h.file);
+        h.error(
+            &["batch", "change", "--input", "batch.json"],
+            "SourceConflict",
+        );
+        assert_eq!(h.text(h.file), before);
+        let mut skip = ops.clone();
+        skip[0]["duplicate"] = json!("skip_exact");
+        h.request("skip", skip.clone());
+        let p = h.preview();
+        let rev = h.revision();
+        let r = h.accept(&p);
+        assert_eq!(r["status"], "no_change");
+        assert_eq!(r["outcomes"][0]["status"], "skipped_exact");
+        assert_eq!(h.revision(), rev);
+        assert_eq!(
+            h.ok(&["work", "show", "N"])["work"]["id"],
+            work["work"]["id"]
+        );
+        skip[0]["fields"]["next_action"] = json!("Conflicting scope");
+        h.request("conflict", skip);
+        h.error(
+            &["batch", "change", "--input", "batch.json"],
+            "SourceConflict",
+        );
+    }
+}
+#[test]
+fn archive_restore_preserves_identity_status_and_does_not_count_as_completion() {
+    for md in [false, true] {
+        let h = Host::new(md);
+        let w = h.ok(&["work", "show", "W"]);
+        h.request(
+            "archive",
+            json!([{"operation":"archive","target":"W","archived":true}]),
+        );
+        h.accept(&h.preview());
+        let archived = h.ok(&["work", "show", "W"]);
+        assert_eq!(archived["work"]["id"], w["work"]["id"]);
+        assert_eq!(archived["work"]["status"], w["work"]["status"]);
+        assert_eq!(archived["work"]["archived"], true);
+        let ready = h.ok(&["ready"]).to_string();
+        assert!(!ready.contains(w["work"]["id"].as_str().unwrap()));
+        let status = h.ok(&["status"]);
+        assert_eq!(status["organization"]["source_archived"], 1);
+        assert_eq!(status["organization"]["source_completed"], 0);
+        h.request(
+            "restore",
+            json!([{"operation":"archive","target":"W","archived":false}]),
+        );
+        h.accept(&h.preview());
+        let restored = h.ok(&["work", "show", "W"]);
+        assert_eq!(restored["work"]["id"], w["work"]["id"]);
+        assert_eq!(restored["work"]["archived"], false);
+        assert_eq!(restored["work"]["status"], "planned");
+    }
+}
+#[test]
+fn dependency_graph_is_checked_for_the_whole_batch() {
+    let h = Host::new(false);
+    h.request(
+        "dependency",
+        json!([{"operation":"fields","target":"D","fields":{"depends_on":["W"]}}]),
+    );
+    h.accept(&h.preview());
+    let before = h.text(h.file);
+    h.request(
+        "blocked",
+        json!([{"operation":"archive","target":"W","archived":true}]),
+    );
+    h.error(
+        &["batch", "change", "--input", "batch.json"],
+        "RuleViolation",
+    );
+    assert_eq!(h.text(h.file), before);
+    h.request("archive-scope",json!([{"operation":"archive","target":"W","archived":true},{"operation":"archive","target":"D","archived":true}]));
+    h.accept(&h.preview());
+    h.request(
+        "invalid-restore",
+        json!([{"operation":"archive","target":"D","archived":false}]),
+    );
+    h.error(
+        &["batch", "change", "--input", "batch.json"],
+        "RuleViolation",
+    );
+    h.request("restore-scope",json!([{"operation":"archive","target":"W","archived":false},{"operation":"archive","target":"D","archived":false}]));
+    h.accept(&h.preview());
+}
+#[test]
+fn real_index_failure_leaves_a_recoverable_receipt_and_blocks_other_source_writers() {
+    let h = Host::new(false);
+    h.request(
+        "interrupted",
+        json!([{"operation":"fields","target":"W","fields":{"next_action":"Review saved note"}}]),
+    );
+    let p = h.preview();
+    h.sql("CREATE TRIGGER fail_batch_index BEFORE UPDATE OF fingerprint ON sources WHEN NEW.fingerprint<>OLD.fingerprint BEGIN SELECT RAISE(ABORT,'fixture index failure'); END;");
+    let o = h.run(&h.args(&p).iter().map(String::as_str).collect::<Vec<_>>());
+    assert!(!o.status.success());
+    let r: Value = serde_json::from_slice(&o.stdout).unwrap();
+    assert_eq!(r["status"], "pending_recovery");
+    assert_eq!(r["source_write_performed"], true);
+    assert!(h.text(h.file).contains("Review saved note"));
+    h.sql("DROP TRIGGER fail_batch_index;");
+    h.ok(&["source", "reindex"]);
+    let work = h.ok(&["work", "show", "W"]);
+    h.write("host.json",&json!({"version":1,"request_key":"other-writer","actor":{"host":"fixture","subject":"user","origin":"human"},"reason":"Another edit","change":{"operation":"fields","kind":"work_item","target":"W","source_fingerprint":work["source_ref"]["source_fingerprint"],"fields":{"title":"Another title"}}}).to_string());
+    h.error(
+        &[
+            "host",
+            "save",
+            "--input",
+            "host.json",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "MutationConflict",
+    );
+    let recovered = h.ok(&[
+        "batch",
+        "recover",
+        "--key",
+        "interrupted",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    assert_eq!(recovered["status"], "completed");
+    assert_eq!(recovered["source_write_performed"], false);
+    let rev = h.revision();
+    h.ok(&[
+        "batch",
+        "recover",
+        "--key",
+        "interrupted",
+        "--expected-revision",
+        &rev,
+    ]);
+    assert_eq!(h.revision(), rev);
+}
+#[test]
+fn recovery_never_replaces_external_edits_and_foreign_project_receipts_are_rejected() {
+    let h = Host::new(false);
+    h.request(
+        "pending",
+        json!([{"operation":"fields","target":"W","fields":{"title":"Reviewed title"}}]),
+    );
+    let p = h.preview();
+    h.sql("CREATE TRIGGER fail_batch_index BEFORE UPDATE OF fingerprint ON sources WHEN NEW.fingerprint<>OLD.fingerprint BEGIN SELECT RAISE(ABORT,'fixture failure'); END;");
+    let o = h.run(&h.args(&p).iter().map(String::as_str).collect::<Vec<_>>());
+    let r: Value = serde_json::from_slice(&o.stdout).unwrap();
+    h.sql("DROP TRIGGER fail_batch_index;");
+    h.write(
+        h.file,
+        &format!("{}\n# External edit retained\n", h.text(h.file)),
+    );
+    let before = h.text(h.file);
+    h.error(
+        &[
+            "batch",
+            "recover",
+            "--key",
+            "pending",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "SourceConflict",
+    );
+    assert_eq!(h.text(h.file), before);
+    let path = h
+        .root
+        .join(r["recovery_directory"].as_str().unwrap())
+        .join("receipt.json");
+    let mut receipt: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    receipt["plan"]["project_id"] = json!(Id::new());
+    fs::write(&path, receipt.to_string()).unwrap();
+    h.error(&["batch", "status", "--key", "pending"], "SourceConflict");
+}
+#[test]
+fn project_scoped_request_keys_and_changed_actor_have_separate_outcomes() {
+    let a = Host::new(false);
+    let b = Host::new(false);
+    for h in [&a, &b] {
+        h.request(
+            "same-key",
+            json!([{"operation":"fields","target":"W","fields":{"title":"Reviewed reading"}}]),
+        );
+        h.accept(&h.preview());
+    }
+    assert_ne!(
+        a.ok(&["batch", "status", "--key", "same-key"])["project_id"],
+        b.ok(&["batch", "status", "--key", "same-key"])["project_id"]
+    );
+    let mut v: Value = serde_json::from_str(&a.text("batch.json")).unwrap();
+    v["actor"]["subject"] = json!("different-user");
+    a.write("batch.json", &v.to_string());
+    a.error(
+        &["batch", "change", "--input", "batch.json"],
+        "SourceConflict",
+    );
+}
+
+#[test]
+fn active_execution_prevents_archiving_until_its_claim_is_released() {
+    let h = Host::new(false);
+    let s = h.ok(&[
+        "session",
+        "start",
+        "--work",
+        "W",
+        "--agent",
+        "fixture",
+        "--provider",
+        "fixture",
+        "--model",
+        "fixture",
+        "--claim",
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    h.request(
+        "archive-active",
+        json!([{"operation":"archive","target":"W","archived":true}]),
+    );
+    let before = h.text(h.file);
+    h.error(
+        &["batch", "change", "--input", "batch.json"],
+        "ClaimConflict",
+    );
+    assert_eq!(h.text(h.file), before);
+    h.ok(&[
+        "session",
+        "end",
+        "--session",
+        s["session"]["id"].as_str().unwrap(),
+        "--expected-revision",
+        &h.revision(),
+    ]);
+    h.accept(&h.preview());
+    h.error(
+        &[
+            "session",
+            "start",
+            "--work",
+            "W",
+            "--agent",
+            "fixture",
+            "--provider",
+            "fixture",
+            "--model",
+            "fixture",
+            "--claim",
+            "--expected-revision",
+            &h.revision(),
+        ],
+        "DependencyBlocked",
+    );
+}

--- a/crates/awr-cli/tests/host_capabilities.rs
+++ b/crates/awr-cli/tests/host_capabilities.rs
@@ -165,3 +165,24 @@ fn discovery_does_not_open_or_migrate_an_existing_database() {
     assert_eq!(fs::read(config).unwrap(), b"future manifest");
     assert_eq!(fs::read_dir(host.0.join(".awr")).unwrap().count(), 2);
 }
+
+#[test]
+fn batch_and_archive_capabilities_are_negotiable() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_awr"))
+        .env_clear()
+        .args([
+            "--json",
+            "capabilities",
+            "--require",
+            "mutation.batch.ledger",
+            "--require",
+            "mutation.work.archive",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/awr-context/tests/hard_context.rs
+++ b/crates/awr-context/tests/hard_context.rs
@@ -9,6 +9,7 @@ fn fixture(path: &str, unknown: bool) -> Fixture {
     let mut f = Fixture::new();
     let work = WorkItem {
         ordinary_completion: None,
+        archived: false,
         meta: f.meta("W"),
         title: "Hard facts".into(),
         kind: None,

--- a/crates/awr-context/tests/recent_delta.rs
+++ b/crates/awr-context/tests/recent_delta.rs
@@ -7,6 +7,7 @@ use support::Fixture;
 fn work(f: &Fixture, key: &str) -> WorkItem {
     WorkItem {
         ordinary_completion: None,
+        archived: false,
         meta: f.meta(key),
         title: key.into(),
         kind: None,

--- a/crates/awr-context/tests/related_work.rs
+++ b/crates/awr-context/tests/related_work.rs
@@ -7,6 +7,7 @@ use support::Fixture;
 fn work(f: &Fixture, key: &str, status: WorkStatus) -> WorkItem {
     WorkItem {
         ordinary_completion: None,
+        archived: false,
         meta: f.meta(key),
         title: key.into(),
         kind: None,

--- a/crates/awr-core/src/model.rs
+++ b/crates/awr-core/src/model.rs
@@ -182,6 +182,8 @@ pub struct Rule {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkItem {
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub archived: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ordinary_completion: Option<crate::OrdinaryCompletion>,
     #[serde(flatten)]
@@ -203,6 +205,10 @@ pub struct WorkItem {
     pub acceptance: Vec<String>,
     pub tags: Vec<String>,
     pub paths: Vec<String>,
+}
+
+fn is_false(value: &bool) -> bool {
+    !value
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/awr-mcp/src/operations.rs
+++ b/crates/awr-mcp/src/operations.rs
@@ -39,7 +39,7 @@ fn short(text: &str) -> String {
 }
 fn brief(work: &Projected<WorkItem>) -> Value {
     json!({"id":work.item.meta.id,"external_key":work.item.meta.external_key,"title":work.item.title,
-        "ordinary_completion":work.item.ordinary_completion,"ordinary_work_policy":work.source.config["adapter_options"]["ordinary_work_policy"],
+        "archived":work.item.archived,"ordinary_completion":work.item.ordinary_completion,"ordinary_work_policy":work.source.config["adapter_options"]["ordinary_work_policy"],
         "status":work.item.status,"raw_status":work.item.raw_status,"summary":short(if work.item.summary.is_empty(){&work.item.title}else{&work.item.summary}),
         "priority":work.item.priority,"milestone":work.item.milestone,"owner":work.item.owner,"next_action":work.item.next_action,
         "blocker":work.item.blocker,"revision":work.item.meta.revision,"source_revision":work.item.meta.source_ref.source_revision,"freshness":work.source.freshness})

--- a/crates/awr-runtime/src/batch.rs
+++ b/crates/awr-runtime/src/batch.rs
@@ -1,0 +1,613 @@
+//! Reviewed source batches. A durable journal distinguishes source writes from indexing.
+use crate::mutation_apply::{
+    SourceReplacement, directory, named_lock, named_lock_for_owner, new_file, recovery_root,
+};
+use awr_core::*;
+use awr_source::*;
+use awr_store::Store;
+use cap_std::fs::Dir;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ffi::OsStr,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BatchRequest {
+    pub version: u32,
+    pub request_key: String,
+    pub actor: HostActor,
+    pub reason: String,
+    pub change: BatchChange,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum BatchChange {
+    Ledger {
+        source_id: Id,
+        source_fingerprint: String,
+        operations: Vec<LedgerBatchOperation>,
+    },
+}
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FilePlan {
+    path: PathBuf,
+    source: Source,
+    spec: SourceSpec,
+    before_fingerprint: String,
+    after_fingerprint: String,
+}
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Plan {
+    version: u32,
+    project_id: Id,
+    root: PathBuf,
+    project_revision: Revision,
+    manifest_fingerprint: String,
+    request: BatchRequest,
+    files: Vec<FilePlan>,
+    observations: Vec<Source>,
+    archive_targets: Vec<Id>,
+    outcomes: Vec<Value>,
+}
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Receipt {
+    plan: Plan,
+    fingerprint: String,
+    phase: String,
+    project_revision: Revision,
+    applied_files: Vec<usize>,
+}
+pub struct BatchReport {
+    pub value: Value,
+    pub failure: Option<Error>,
+}
+fn name(project: Id, key: &str) -> Result<String> {
+    if key.trim().is_empty() || key.len() > 512 || key.chars().any(char::is_control) {
+        return Err(Error::InvalidInput(
+            "batch requires a bounded stable request key".into(),
+        ));
+    }
+    Ok(format!(
+        "batch-{}",
+        fingerprint(&serde_json::to_vec(&(project, key))?).trim_start_matches("sha256:")
+    ))
+}
+fn read(path: &Path, cap: u64) -> Result<Vec<u8>> {
+    let f = open_file_exact(path)?;
+    if !f.metadata()?.is_file() || f.metadata()?.len() > cap {
+        return Err(Error::InvalidInput(
+            "invalid or oversized batch file".into(),
+        ));
+    }
+    let mut bytes = vec![];
+    f.take(cap + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > cap {
+        return Err(Error::InvalidInput("batch file exceeds bound".into()));
+    }
+    Ok(bytes)
+}
+fn manifest_hash(root: &Path) -> Result<String> {
+    Ok(fingerprint(&read(
+        &root.join(".awr/project.toml"),
+        64 * 1024,
+    )?))
+}
+fn load(root: &Path, project: Id, key: &str) -> Result<Option<Receipt>> {
+    let base = root.join(".awr/mutations").join(name(project, key)?);
+    match std::fs::symlink_metadata(&base) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+        Ok(m) if !m.is_dir() || m.file_type().is_symlink() => {
+            return Err(Error::RuleViolation(
+                "batch receipt directory must be real".into(),
+            ));
+        }
+        _ => (),
+    }
+    let r: Receipt = serde_json::from_slice(&read(&base.join("receipt.json"), 64 * 1024 * 1024)?)?;
+    if r.plan.version != 1
+        || r.plan.request.version != 1
+        || r.plan.project_id != project
+        || r.plan.root != root
+        || r.plan.request.request_key != key
+        || fingerprint(&serde_json::to_vec(&r.plan)?) != r.fingerprint
+        || !["prepared", "applied", "completed", "no_change"].contains(&r.phase.as_str())
+        || r.plan.files.is_empty()
+        || r.plan.files.len() > 100
+    {
+        return Err(Error::SourceConflict(
+            "batch receipt differs from its bound project, request or version".into(),
+        ));
+    }
+    Ok(Some(r))
+}
+fn save(dir: &Dir, r: &Receipt) -> Result<()> {
+    let temp = format!("receipt-{}.tmp", Id::new());
+    let mut f = new_file(dir, OsStr::new(&temp))?;
+    f.write_all(&serde_json::to_vec_pretty(r)?)?;
+    f.sync_all()?;
+    drop(f);
+    dir.rename(&temp, dir, "receipt.json")?;
+    crate::fs_sync::sync_directory(dir)
+}
+fn done(r: &Receipt) -> bool {
+    ["completed", "no_change"].contains(&r.phase.as_str())
+}
+fn report(r: &Receipt, replay: bool) -> Result<Value> {
+    Ok(
+        json!({"ok":done(r),"status":if r.phase=="no_change"{"no_change"}else if done(r){"completed"}else{"pending_recovery"},"phase":r.phase,"project_id":r.plan.project_id,"project_revision":r.project_revision,"request_key":r.plan.request.request_key,"actor":r.plan.request.actor,"reason":r.plan.request.reason,"preview_fingerprint":r.fingerprint,"outcomes":r.plan.outcomes,"applied_files":r.applied_files,"already_recorded":replay,"historical_outcome":replay,"source_write_performed":false,"runtime_write_performed":false,"write_outcome":if r.phase=="no_change"{"no_change"}else if done(r){"applied"}else{"pending_recovery"},"recovery_directory":format!(".awr/mutations/{}",name(r.plan.project_id,&r.plan.request.request_key)?)}),
+    )
+}
+fn observe(root: &Path, plan: &Plan) -> Result<Vec<String>> {
+    if manifest_hash(root)? != plan.manifest_fingerprint {
+        return Err(Error::SourceConflict(
+            "batch source registration changed".into(),
+        ));
+    }
+    for source in &plan.observations {
+        if inspect_registered_source(root, source)?.2.fingerprint != source.fingerprint {
+            return Err(Error::SourceConflict(
+                "a dependency source changed since batch review".into(),
+            ));
+        }
+    }
+    plan.files
+        .iter()
+        .map(|f| {
+            let (locator, spec, snapshot) = inspect_registered_source(root, &f.source)?;
+            if !matches!(locator, Locator::File(ref path) if path == &f.path)
+                || serde_json::to_value(spec)? != serde_json::to_value(&f.spec)?
+            {
+                return Err(Error::SourceConflict("batch source mapping changed".into()));
+            }
+            Ok(snapshot.fingerprint)
+        })
+        .collect()
+}
+fn lock_names(plan: &Plan) -> Vec<String> {
+    let mut names = BTreeSet::new();
+    for f in &plan.files {
+        names.insert(format!("{}.lock", f.source.id));
+        names.insert(format!(
+            "document-path-{}.lock",
+            fingerprint(f.path.to_string_lossy().as_bytes()).trim_start_matches("sha256:")
+        ));
+    }
+    names.into_iter().collect()
+}
+fn reserve(root: &Path, plan: &Plan, owner: &str) -> Result<()> {
+    let dir = recovery_root(root)?;
+    for lock in lock_names(plan) {
+        let file = lock.trim_end_matches(".lock").to_owned() + ".intent";
+        match new_file(&dir, OsStr::new(&file)) {
+            Ok(mut f) => {
+                f.write_all(owner.as_bytes())?;
+                f.sync_all()?;
+            }
+            Err(Error::Io(_)) if root.join(".awr/mutations").join(&file).exists() => {
+                if read(&root.join(".awr/mutations").join(&file), 512)? != owner.as_bytes() {
+                    return Err(Error::MutationConflict(
+                        "another batch owns the source intent".into(),
+                    ));
+                }
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    crate::fs_sync::sync_directory(&dir)
+}
+fn release(root: &Path, plan: &Plan, owner: &str) -> Result<()> {
+    let dir = recovery_root(root)?;
+    for lock in lock_names(plan) {
+        let file = lock.trim_end_matches(".lock").to_owned() + ".intent";
+        let path = root.join(".awr/mutations").join(&file);
+        match std::fs::symlink_metadata(&path) {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => (),
+            Err(e) => return Err(e.into()),
+            Ok(_) => {
+                if read(&path, 512)? != owner.as_bytes() {
+                    return Err(Error::MutationConflict(
+                        "batch cannot release another owner's intent".into(),
+                    ));
+                }
+                dir.remove_file(&file)?;
+            }
+        }
+    }
+    crate::fs_sync::sync_directory(&dir)
+}
+pub fn batch_status(store: &Store, root: &Path, key: &str) -> Result<BatchReport> {
+    let root = root.canonicalize()?;
+    let p = store.project_by_root(&root)?;
+    let value = if let Some(r) = load(&root, p.id, key)? {
+        let mut v = report(&r, true)?;
+        v["found"] = json!(true);
+        v["read_only"] = json!(true);
+        v["current_sources"] = match observe(&root, &r.plan) {
+            Ok(states) => json!(
+                states
+                    .iter()
+                    .zip(&r.plan.files)
+                    .map(|(s, f)| if s == &f.after_fingerprint {
+                        "after"
+                    } else if s == &f.before_fingerprint {
+                        "before"
+                    } else {
+                        "externally_changed"
+                    })
+                    .collect::<Vec<_>>()
+            ),
+            Err(_) => json!("unavailable_or_registration_changed"),
+        };
+        v
+    } else {
+        json!({"ok":true,"found":false,"read_only":true,"source_write_performed":false,"runtime_write_performed":false})
+    };
+    Ok(BatchReport {
+        value,
+        failure: None,
+    })
+}
+fn validate_archive(
+    store: &Store,
+    project: Id,
+    source: Id,
+    prepared: &PreparedLedgerBatch,
+) -> Result<()> {
+    for id in &prepared.archive_targets {
+        store.ensure_work_unoccupied(project, *id)?;
+    }
+    let mut works: BTreeMap<_, _> = store
+        .work_items(project)?
+        .into_iter()
+        .filter(|w| w.item.meta.source_ref.source_id != source)
+        .map(|w| (w.item.meta.external_key.clone(), w.item))
+        .collect();
+    works.extend(
+        prepared
+            .projection
+            .work_items
+            .iter()
+            .cloned()
+            .map(|w| (w.meta.external_key.clone(), w)),
+    );
+    let mut edges = store.work_dependency_links(project)?;
+    edges.retain(|e| e.source_ref.source_id != source);
+    edges.extend(
+        prepared
+            .projection
+            .edges
+            .iter()
+            .filter(|e| e.relation == "depends_on" && e.to_kind == EntityKind::WorkItem)
+            .cloned(),
+    );
+    for edge in edges {
+        if works.get(&edge.from_key).is_some_and(|w| !w.archived)
+            && works.get(&edge.to_key).is_some_and(|w| w.archived)
+        {
+            return Err(Error::RuleViolation(format!(
+                "{} still depends on archived {}; remove that dependency or explicitly archive its dependent in the same batch",
+                edge.from_key, edge.to_key
+            )));
+        }
+    }
+    Ok(())
+}
+pub fn change_batch(
+    store: &mut Store,
+    root: &Path,
+    request: BatchRequest,
+    accept: bool,
+    expected_preview: Option<&str>,
+    expected_revision: Option<Revision>,
+) -> Result<BatchReport> {
+    let root = root.canonicalize()?;
+    let project = store.project_by_root(&root)?;
+    let owner = name(project.id, &request.request_key)?;
+    ensure_public_data(&request)?;
+    request.actor.validate()?;
+    if request.version != 1 || request.reason.trim().is_empty() || request.reason.len() > 4096 {
+        return Err(Error::InvalidInput(
+            "batch requires version 1 and a bounded reason".into(),
+        ));
+    }
+    let _request_lock = if accept {
+        Some(named_lock(&root, &format!("{owner}.lock"))?)
+    } else {
+        None
+    };
+    if let Some(r) = load(&root, project.id, &request.request_key)? {
+        if r.plan.request != request {
+            return Err(Error::SourceConflict(
+                "batch key already belongs to different content or actor".into(),
+            ));
+        }
+        return Ok(BatchReport {
+            value: report(&r, true)?,
+            failure: (!done(&r))
+                .then(|| Error::MutationConflict("explicitly recover the pending batch".into())),
+        });
+    }
+    if !index_project(store, &root, &Manifest::load(&root)?, false)?.ok {
+        return Err(Error::SourceStale(
+            "refresh all registered sources before a batch".into(),
+        ));
+    }
+    let revision = store.project(project.id)?.project_revision;
+    if let Some(expected) = expected_revision
+        && expected != revision
+    {
+        return Err(Error::RevisionConflict {
+            expected,
+            actual: revision,
+        });
+    }
+    let (source, prepared) = match &request.change {
+        BatchChange::Ledger {
+            source_id,
+            source_fingerprint,
+            operations,
+        } => {
+            let source = store.source(project.id, *source_id)?;
+            if source.fingerprint != *source_fingerprint {
+                return Err(Error::SourceConflict(
+                    "batch ledger fingerprint changed".into(),
+                ));
+            }
+            if store.source_apply_pending(project.id, source.id)?.is_some() {
+                return Err(Error::MutationConflict(
+                    "finish pending source proposal before a batch".into(),
+                ));
+            }
+            let prepared =
+                prepare_ledger_batch(&root, &source, operations, store.projection_ids(&source)?)?;
+            validate_archive(store, project.id, source.id, &prepared)?;
+            (source, prepared)
+        }
+    };
+    let observations = store
+        .sources(project.id)?
+        .into_iter()
+        .filter(|s| s.domain == "ledger" && s.id != source.id)
+        .collect();
+    let plan = Plan {
+        version: 1,
+        project_id: project.id,
+        root: root.clone(),
+        project_revision: revision,
+        manifest_fingerprint: manifest_hash(&root)?,
+        request,
+        files: vec![FilePlan {
+            path: prepared.path,
+            source,
+            spec: prepared.spec,
+            before_fingerprint: prepared.before.fingerprint.clone(),
+            after_fingerprint: prepared.after.fingerprint.clone(),
+        }],
+        observations,
+        archive_targets: prepared.archive_targets,
+        outcomes: prepared.outcomes,
+    };
+    let preview = fingerprint(&serde_json::to_vec(&plan)?);
+    if !accept {
+        return Ok(BatchReport {
+            value: json!({"ok":true,"status":"preview","requires_accept":true,"project_revision":revision,"preview":{"fingerprint":preview,"plan":plan,"files":[{"before_text":prepared.before.text()?,"after_text":prepared.after.text()?}]},"source_write_performed":false,"runtime_write_performed":true}),
+            failure: None,
+        });
+    }
+    if expected_revision.is_none() || expected_preview != Some(preview.as_str()) {
+        return Err(Error::SourceConflict(
+            "batch acceptance requires the exact reviewed preview and revision".into(),
+        ));
+    }
+    let _locks = lock_names(&plan)
+        .iter()
+        .map(|n| named_lock_for_owner(&root, n, Some(&owner)))
+        .collect::<Result<Vec<_>>>()?;
+    let states = observe(&root, &plan)?;
+    if states
+        .iter()
+        .zip(&plan.files)
+        .any(|(s, f)| s != &f.before_fingerprint)
+    {
+        return Err(Error::SourceConflict(
+            "batch source changed after preflight".into(),
+        ));
+    }
+    let mutations = recovery_root(&root)?;
+    mutations.create_dir(&owner)?;
+    let dir = directory(
+        &mutations,
+        &owner,
+        &root.join(".awr/mutations").join(&owner),
+    )?;
+    for (name, bytes) in [
+        ("0.before", prepared.before.bytes.as_slice()),
+        ("0.after", prepared.after.bytes.as_slice()),
+    ] {
+        let mut f = new_file(&dir, OsStr::new(name))?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    let mut r = Receipt {
+        plan,
+        fingerprint: preview,
+        phase: "prepared".into(),
+        project_revision: revision,
+        applied_files: vec![],
+    };
+    save(&dir, &r)?;
+    crate::fs_sync::sync_directory(&mutations)?;
+    finish(store, &root, &dir, &mut r, revision)
+}
+pub fn recover_batch(
+    store: &mut Store,
+    root: &Path,
+    key: &str,
+    expected: Revision,
+) -> Result<BatchReport> {
+    let root = root.canonicalize()?;
+    let p = store.project_by_root(&root)?;
+    let owner = name(p.id, key)?;
+    let _request_lock = named_lock(&root, &format!("{owner}.lock"))?;
+    let mut r = load(&root, p.id, key)?.ok_or_else(|| Error::NotFound("batch receipt".into()))?;
+    let _locks = lock_names(&r.plan)
+        .iter()
+        .map(|n| named_lock_for_owner(&root, n, Some(&owner)))
+        .collect::<Result<Vec<_>>>()?;
+    if done(&r) {
+        release(&root, &r.plan, &owner)?;
+        return Ok(BatchReport {
+            value: report(&r, true)?,
+            failure: None,
+        });
+    }
+    let dir = open_dir_exact(&root.join(".awr/mutations").join(&owner))?;
+    finish(store, &root, &dir, &mut r, expected)
+}
+fn finish(
+    store: &mut Store,
+    root: &Path,
+    dir: &Dir,
+    r: &mut Receipt,
+    expected: Revision,
+) -> Result<BatchReport> {
+    let owner = name(r.plan.project_id, &r.plan.request.request_key)?;
+    let base = root.join(".awr/mutations").join(&owner);
+    let mut wrote = false;
+    let result = (|| -> Result<()> {
+        let actual = store.project(r.plan.project_id)?.project_revision;
+        if actual != expected {
+            return Err(Error::RevisionConflict { expected, actual });
+        }
+        for id in &r.plan.archive_targets {
+            store.ensure_work_unoccupied(r.plan.project_id, *id)?;
+        }
+        let states = observe(root, &r.plan)?;
+        let mut snapshots = vec![];
+        for (i, file) in r.plan.files.iter().enumerate() {
+            if store
+                .source_apply_pending(r.plan.project_id, file.source.id)?
+                .is_some()
+            {
+                return Err(Error::MutationConflict(
+                    "source proposal must be recovered first".into(),
+                ));
+            }
+            let before = read(
+                &base.join(format!("{i}.before")),
+                source_read_cap(&file.source.adapter)?,
+            )?;
+            let after = read(
+                &base.join(format!("{i}.after")),
+                source_read_cap(&file.source.adapter)?,
+            )?;
+            if fingerprint(&before) != file.before_fingerprint
+                || fingerprint(&after) != file.after_fingerprint
+            {
+                return Err(Error::SourceConflict(
+                    "batch snapshots differ from the reviewed plan".into(),
+                ));
+            }
+            if states[i] != file.before_fingerprint && states[i] != file.after_fingerprint {
+                return Err(Error::SourceConflict(
+                    "batch recovery preserves external source changes".into(),
+                ));
+            }
+            let permissions = open_file_exact(&file.path)?.metadata()?.permissions();
+            if permissions.readonly() {
+                return Err(Error::RuleViolation(
+                    "batch destination is read-only".into(),
+                ));
+            }
+            snapshots.push((after, permissions));
+        }
+        reserve(root, &r.plan, &owner)?;
+        for (i, (after, permissions)) in snapshots.into_iter().enumerate() {
+            let file = &r.plan.files[i];
+            let current = observe(root, &r.plan)?;
+            for (s, f) in current.iter().zip(&r.plan.files) {
+                if s != &f.before_fingerprint && s != &f.after_fingerprint {
+                    return Err(Error::SourceConflict(
+                        "source changed while batch was in progress".into(),
+                    ));
+                }
+            }
+            if current[i] == file.before_fingerprint
+                && file.before_fingerprint != file.after_fingerprint
+            {
+                let mut replacement = SourceReplacement::prepare(&file.path, &after, permissions)?;
+                if observe(root, &r.plan)? != current {
+                    return Err(Error::SourceConflict(
+                        "batch source changed immediately before writing".into(),
+                    ));
+                }
+                let actual = store.project(r.plan.project_id)?.project_revision;
+                if actual != expected {
+                    return Err(Error::RevisionConflict { expected, actual });
+                }
+                replacement.install()?;
+                replacement.sync_parent()?;
+                wrote = true;
+            }
+            if file.before_fingerprint != file.after_fingerprint && !r.applied_files.contains(&i) {
+                r.applied_files.push(i);
+            }
+            save(dir, r)?;
+        }
+        if r.plan
+            .files
+            .iter()
+            .all(|f| f.before_fingerprint == f.after_fingerprint)
+        {
+            r.phase = "no_change".into();
+        } else {
+            r.phase = "applied".into();
+            save(dir, r)?;
+            let indexed = index_project(store, root, &Manifest::load(root)?, false)?;
+            r.project_revision = indexed.project_revision;
+            if !indexed.ok {
+                return Err(Error::SourceStale(
+                    "batch files were written but indexing requires recovery".into(),
+                ));
+            }
+            if observe(root, &r.plan)?
+                .iter()
+                .zip(&r.plan.files)
+                .any(|(s, f)| s != &f.after_fingerprint)
+            {
+                return Err(Error::SourceConflict("indexed batch source changed".into()));
+            }
+            for f in &r.plan.files {
+                if store.source(r.plan.project_id, f.source.id)?.fingerprint != f.after_fingerprint
+                {
+                    return Err(Error::SourceConflict(
+                        "batch projection differs from reviewed content".into(),
+                    ));
+                }
+            }
+            r.phase = "completed".into();
+        }
+        save(dir, r)?;
+        release(root, &r.plan, &owner)
+    })();
+    let mut value = report(r, false)?;
+    value["source_write_performed"] = json!(wrote);
+    value["runtime_write_performed"] = json!(true);
+    let failure = result.err();
+    if let Some(e) = &failure {
+        value["ok"] = json!(false);
+        value["status"] = json!("pending_recovery");
+        value["write_outcome"] = json!("pending_recovery");
+        value["error"] = serde_json::to_value(e.report())?;
+    }
+    Ok(BatchReport { value, failure })
+}

--- a/crates/awr-runtime/src/lib.rs
+++ b/crates/awr-runtime/src/lib.rs
@@ -144,3 +144,6 @@ impl<'a> Runtime<'a> {
 }
 mod ordinary;
 pub use ordinary::*;
+
+mod batch;
+pub use batch::*;

--- a/crates/awr-runtime/src/mutation_apply.rs
+++ b/crates/awr-runtime/src/mutation_apply.rs
@@ -58,6 +58,13 @@ pub(crate) fn source_lock(root: &Path, source: Id) -> Result<SourceLock> {
     named_lock(root, &format!("{source}.lock"))
 }
 pub(crate) fn named_lock(root: &Path, name: &str) -> Result<SourceLock> {
+    named_lock_for_owner(root, name, None)
+}
+pub(crate) fn named_lock_for_owner(
+    root: &Path,
+    name: &str,
+    owner: Option<&str>,
+) -> Result<SourceLock> {
     if name.len() > 100
         || !name
             .bytes()
@@ -99,7 +106,22 @@ pub(crate) fn named_lock(root: &Path, name: &str) -> Result<SourceLock> {
             path.display()
         ))
     })?;
-    Ok(SourceLock(file))
+    let lock = SourceLock(file);
+    let intent = path.with_extension("intent");
+    match std::fs::symlink_metadata(&intent) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => (),
+        Err(e) => return Err(e.into()),
+        Ok(_) => {
+            let mut bytes = Vec::new();
+            open_file_exact(&intent)?
+                .take(513)
+                .read_to_end(&mut bytes)?;
+            if bytes.len() > 512 || owner.map(str::as_bytes) != Some(bytes.as_slice()) {
+                return Err(Error::MutationConflict("source has a pending batch; inspect its receipt and explicitly recover it before another write".into()));
+            }
+        }
+    }
+    Ok(lock)
 }
 pub(crate) fn new_file(directory: &Dir, name: &OsStr) -> Result<File> {
     let mut options = OpenOptions::new();

--- a/crates/awr-runtime/src/organization.rs
+++ b/crates/awr-runtime/src/organization.rs
@@ -62,6 +62,7 @@ pub struct OrganizationReport {
     pub business_checked_completed: usize,
     pub ordinary_work_policies: Vec<serde_json::Value>,
     pub source_cancelled: usize,
+    pub source_archived: usize,
     pub recheck: Vec<String>,
     pub next_action: String,
 }
@@ -141,6 +142,7 @@ impl OrganizationReport {
             business_checked_completed: 0,
             ordinary_work_policies: vec![],
             source_cancelled: 0,
+            source_archived: 0,
             recheck: vec![
                 "awr".into(),
                 "intake".into(),
@@ -402,6 +404,7 @@ pub fn inspect_organization(
     let noncancelled: BTreeSet<_> = works
         .iter()
         .filter(|w| w.item.status != WorkStatus::Cancelled)
+        .filter(|w| !w.item.archived)
         .map(|w| &w.item.meta.external_key)
         .collect();
     for (key, goal) in &goals {
@@ -427,6 +430,10 @@ pub fn inspect_organization(
     for projected in works {
         let work = &projected.item;
         let key = &work.meta.external_key;
+        if work.archived {
+            result.source_archived += 1;
+            continue;
+        }
         if work.status == WorkStatus::Cancelled {
             result.source_cancelled += 1;
             required_cancelled |= work.required;
@@ -596,9 +603,14 @@ pub fn inspect_organization(
         }
     }
     let concrete_work = works.iter().any(|w| {
-        w.item.kind.as_deref() != Some("intake") && w.item.status != WorkStatus::Cancelled
+        !w.item.archived
+            && w.item.kind.as_deref() != Some("intake")
+            && w.item.status != WorkStatus::Cancelled
     });
-    if !works.is_empty() && !concrete_work && result.source_cancelled != works.len() {
+    if !works.is_empty()
+        && !concrete_work
+        && result.source_cancelled + result.source_archived != works.len()
+    {
         result.gap("business_work_missing", "project", "Only intake work is present. Organizing a baseline does not establish the business delivery scope; add the actual delivery work before claiming project completion.", vec![], "work");
     }
     result.business_execution_ready = sources_ok && result.executable_work_total > 0;

--- a/crates/awr-source/src/indexer.rs
+++ b/crates/awr-source/src/indexer.rs
@@ -92,7 +92,7 @@ fn mapping_key(spec: &SourceSpec) -> String {
 }
 /// Configuration identity shared by indexing, source mutations and read-only diagnosis.
 pub fn source_configuration(spec: &SourceSpec, minimal_context: bool) -> serde_json::Value {
-    let mut config = json!({"mapping_key":mapping_key(spec),"adapter_options":spec.options,"adapter_version":if spec.adapter == "markdown-ledger-v1" {3}else{2}});
+    let mut config = json!({"mapping_key":mapping_key(spec),"adapter_options":spec.options,"adapter_version":if matches!(spec.adapter.as_str(), "markdown-ledger-v1" | "yaml-ledger-v1") {4}else{2}});
     if minimal_context {
         config["context_profile"] = json!("minimal");
     }

--- a/crates/awr-source/src/ledger_batch.rs
+++ b/crates/awr-source/src/ledger_batch.rs
@@ -1,0 +1,315 @@
+//! Complete same-source preflight. All transformations happen in memory.
+use crate::*;
+use awr_core::*;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
+pub enum LedgerBatchOperation {
+    Fields {
+        target: String,
+        fields: Map<String, Value>,
+    },
+    Import {
+        external_key: String,
+        title: String,
+        #[serde(default)]
+        fields: Map<String, Value>,
+        duplicate: ImportDuplicate,
+    },
+    Archive {
+        target: String,
+        archived: bool,
+    },
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportDuplicate {
+    Fail,
+    SkipExact,
+}
+pub struct PreparedLedgerBatch {
+    pub path: PathBuf,
+    pub spec: SourceSpec,
+    pub before: SourceSnapshot,
+    pub after: SourceSnapshot,
+    pub projection: ProjectionBatch,
+    pub outcomes: Vec<Value>,
+    pub archive_targets: Vec<Id>,
+}
+fn invalid(s: &str) -> Error {
+    Error::InvalidInput(s.into())
+}
+fn fields_valid(fields: &Map<String, Value>) -> Result<()> {
+    if fields
+        .keys()
+        .any(|k| !yaml_field_writable(EntityKind::WorkItem, k))
+    {
+        return Err(Error::MutationUnsupported(
+            "batch fields cannot write identity, lifecycle or verification fields".into(),
+        ));
+    }
+    Ok(())
+}
+fn parse(
+    source: &Source,
+    spec: &SourceSpec,
+    snapshot: &SourceSnapshot,
+    ids: &BTreeMap<(EntityKind, String), Id>,
+) -> Result<ProjectionBatch> {
+    source_adapter(&source.adapter)?.parse(
+        snapshot,
+        &ParseContext {
+            source,
+            existing_ids: ids.clone(),
+        },
+        spec,
+    )
+}
+fn raw(snapshot: &SourceSnapshot, spec: &SourceSpec, work: &WorkItem) -> Result<Value> {
+    if spec.adapter == "markdown-ledger-v1" {
+        let rows = crate::markdown_records::rows(snapshot.text()?, spec)?;
+        return rows
+            .into_iter()
+            .find(|r| r.values.get("id") == Some(&json!(work.meta.external_key)))
+            .map(|r| Value::Object(r.values))
+            .ok_or_else(|| {
+                Error::MutationUnsupported("batch writes require explicit Markdown IDs".into())
+            });
+    }
+    let doc: Value =
+        serde_yaml_ng::from_str(snapshot.text()?).map_err(|_| invalid("invalid YAML ledger"))?;
+    doc.pointer(
+        work.meta
+            .source_ref
+            .pointer
+            .as_deref()
+            .ok_or_else(|| invalid("exact record pointer required"))?,
+    )
+    .cloned()
+    .ok_or_else(|| invalid("missing ledger record"))
+}
+fn edit(
+    snapshot: &SourceSnapshot,
+    spec: &SourceSpec,
+    work: &WorkItem,
+    changes: &Map<String, Value>,
+) -> Result<String> {
+    if spec.adapter == "markdown-ledger-v1" {
+        return crate::markdown_mutation::edit_markdown_fields(
+            snapshot.text()?,
+            spec,
+            &work.meta.external_key,
+            changes,
+        );
+    }
+    let mapping = LedgerMapping::from_spec(spec)?;
+    let record = raw(snapshot, spec, work)?;
+    let mut fields = Map::new();
+    for (k, v) in changes {
+        let v = mapping.write_value(k, v, &record)?;
+        if record.get(mapping.source_field(k)) != Some(&v) {
+            fields.insert(mapping.source_field(k).to_owned(), v);
+        }
+    }
+    if fields.is_empty() {
+        return Ok(snapshot.text()?.into());
+    }
+    let pointer = work.meta.source_ref.pointer.as_deref().unwrap();
+    let mut expected: Value =
+        serde_yaml_ng::from_str(snapshot.text()?).map_err(|_| invalid("invalid YAML"))?;
+    expected
+        .pointer_mut(pointer)
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| invalid("record mapping required"))?
+        .extend(fields.clone());
+    let output = crate::yaml_edit::edit_fields(snapshot.text()?, pointer, &fields)?;
+    let actual: Value =
+        serde_yaml_ng::from_str(&output).map_err(|_| invalid("invalid edited YAML"))?;
+    if expected != actual {
+        return Err(Error::MutationUnsupported(
+            "batch edit changed unrelated source facts".into(),
+        ));
+    }
+    Ok(output)
+}
+pub fn prepare_ledger_batch(
+    root: &Path,
+    source: &Source,
+    operations: &[LedgerBatchOperation],
+    ids: BTreeMap<(EntityKind, String), Id>,
+) -> Result<PreparedLedgerBatch> {
+    if operations.is_empty() || operations.len() > 100 {
+        return Err(invalid("batch requires 1..100 operations"));
+    }
+    if source.domain != "ledger"
+        || !["yaml-ledger-v1", "markdown-ledger-v1"].contains(&source.adapter.as_str())
+    {
+        return Err(Error::MutationUnsupported(
+            "batch requires a writable registered ledger".into(),
+        ));
+    }
+    if source.freshness != Freshness::Fresh {
+        return Err(Error::SourceStale("refresh ledger before a batch".into()));
+    }
+    let (locator, spec, before) = inspect_registered_source(root, source)?;
+    let Locator::File(path) = locator else {
+        return Err(Error::MutationUnsupported(
+            "Git sources are read-only".into(),
+        ));
+    };
+    if path.starts_with(root.canonicalize()?.join(".awr")) {
+        return Err(Error::RuleViolation(
+            "runtime files cannot be ledgers".into(),
+        ));
+    }
+    if before.fingerprint != source.fingerprint {
+        return Err(Error::SourceConflict(
+            "ledger changed before batch preflight".into(),
+        ));
+    }
+    let mut after = before.clone();
+    let mut seen = BTreeSet::new();
+    let mut outcomes = vec![];
+    let mut archive_targets = vec![];
+    for op in operations {
+        let target = match op {
+            LedgerBatchOperation::Fields { target, .. }
+            | LedgerBatchOperation::Archive { target, .. } => target,
+            LedgerBatchOperation::Import { external_key, .. } => external_key,
+        };
+        if target.trim().is_empty()
+            || target.len() > 512
+            || target.chars().any(char::is_control)
+            || !seen.insert(target.clone())
+        {
+            return Err(invalid(
+                "batch requires unique nonempty stable keys; combine fields for the same target",
+            ));
+        }
+        let mut projection = parse(source, &spec, &after, &ids)?;
+        let existing = projection
+            .work_items
+            .iter()
+            .find(|w| w.meta.external_key == *target)
+            .cloned();
+        let mut skipped = false;
+        let output = match op {
+            LedgerBatchOperation::Fields { fields, .. } => {
+                fields_valid(fields)?;
+                edit(
+                    &after,
+                    &spec,
+                    &existing.ok_or_else(|| Error::NotFound(target.clone()))?,
+                    fields,
+                )?
+            }
+            LedgerBatchOperation::Archive { archived, .. } => {
+                let work = existing.ok_or_else(|| Error::NotFound(target.clone()))?;
+                if work.archived == *archived {
+                    after.text()?.into()
+                } else {
+                    archive_targets.push(work.meta.id);
+                    edit(
+                        &after,
+                        &spec,
+                        &work,
+                        &Map::from_iter([("archived".into(), json!(archived))]),
+                    )?
+                }
+            }
+            LedgerBatchOperation::Import {
+                external_key,
+                title,
+                fields,
+                duplicate,
+            } => {
+                fields_valid(fields)?;
+                if title.trim().is_empty() || fields.contains_key("title") {
+                    return Err(invalid("import requires a nonempty title declared once"));
+                }
+                if let Some(work) = existing {
+                    if *duplicate != ImportDuplicate::SkipExact
+                        || work.status != WorkStatus::Draft
+                        || work.archived
+                        || work.title != *title
+                    {
+                        return Err(Error::SourceConflict(format!(
+                            "import key {target} already exists"
+                        )));
+                    }
+                    let original = raw(&after, &spec, &work)?;
+                    let record = if spec.adapter == "yaml-ledger-v1" {
+                        LedgerMapping::from_spec(&spec)?.record(&original)?
+                    } else {
+                        original
+                    };
+                    if fields.iter().any(|(k, v)| record.get(k) != Some(v)) {
+                        return Err(Error::SourceConflict(
+                            "skip_exact import fields differ from existing draft".into(),
+                        ));
+                    }
+                    skipped = true;
+                    after.text()?.into()
+                } else {
+                    let output = if spec.adapter == "markdown-ledger-v1" {
+                        crate::markdown_mutation::append_markdown_work(
+                            after.text()?,
+                            &spec,
+                            external_key,
+                            title,
+                        )?
+                    } else {
+                        let mapping = LedgerMapping::from_spec(&spec)?;
+                        let base = vec![
+                            (mapping.source_field("id").into(), json!(external_key)),
+                            (mapping.source_field("title").into(), json!(title)),
+                            (
+                                mapping.source_field("status").into(),
+                                mapping.write_value("status", &json!("draft"), &json!({}))?,
+                            ),
+                        ];
+                        crate::yaml_edit::append_work(after.text()?, external_key, &base)?
+                    };
+                    let snapshot = SourceSnapshot {
+                        locator: after.locator.clone(),
+                        fingerprint: fingerprint(output.as_bytes()),
+                        bytes: output.into_bytes(),
+                    };
+                    projection = parse(source, &spec, &snapshot, &ids)?;
+                    let work = projection
+                        .work_items
+                        .iter()
+                        .find(|w| w.meta.external_key == *target && w.status == WorkStatus::Draft)
+                        .ok_or_else(|| {
+                            Error::MutationUnsupported("import must preserve draft status".into())
+                        })?;
+                    edit(&snapshot, &spec, work, fields)?
+                }
+            }
+        };
+        crate::limits::check_source_size(output.as_bytes(), source_read_cap(&source.adapter)?)?;
+        let changed = output.as_bytes() != after.bytes;
+        after = SourceSnapshot {
+            locator: before.locator.clone(),
+            fingerprint: fingerprint(output.as_bytes()),
+            bytes: output.into_bytes(),
+        };
+        outcomes.push(json!({"external_key":target,"status":if skipped{"skipped_exact"}else if changed{"changed"}else{"no_change"}}));
+    }
+    let projection = parse(source, &spec, &after, &ids)?;
+    Ok(PreparedLedgerBatch {
+        path,
+        spec,
+        before,
+        after,
+        projection,
+        outcomes,
+        archive_targets,
+    })
+}

--- a/crates/awr-source/src/lib.rs
+++ b/crates/awr-source/src/lib.rs
@@ -53,3 +53,6 @@ mod markdown_records;
 
 mod markdown_mutation;
 pub use markdown_mutation::*;
+
+mod ledger_batch;
+pub use ledger_batch::*;

--- a/crates/awr-source/src/markdown_records.rs
+++ b/crates/awr-source/src/markdown_records.rs
@@ -36,6 +36,7 @@ pub(crate) fn cell_value(key: &str, s: &str) -> Value {
             | "evidence"
             | "verification"
             | "ordinary_completion"
+            | "archived"
             | "required"
             | "required_for_v1"
             | "score"

--- a/crates/awr-source/src/yaml_ledger.rs
+++ b/crates/awr-source/src/yaml_ledger.rs
@@ -253,6 +253,7 @@ impl SourceAdapter for YamlLedgerAdapter {
                 ),
             };
             let work = WorkItem {
+                archived: boolean(&value["archived"], false, &pointer)?,
                 ordinary_completion: value
                     .get("ordinary_completion")
                     .filter(|v| !v.is_null())

--- a/crates/awr-store/src/mutation_apply.rs
+++ b/crates/awr-store/src/mutation_apply.rs
@@ -87,6 +87,14 @@ fn open_attempt(
     Ok((proposal, attempt))
 }
 impl Store {
+    pub fn source_apply_pending(
+        &self,
+        project: Id,
+        source: Id,
+    ) -> Result<Option<MutationApplyAttempt>> {
+        self.source(project, source)?;
+        pending_for_source(&self.conn, project, source)
+    }
     pub fn proposal_apply_attempt(
         &self,
         project: Id,

--- a/crates/awr-store/src/work.rs
+++ b/crates/awr-store/src/work.rs
@@ -181,6 +181,13 @@ pub(crate) fn readiness(
             format!("source status is {}", work.item.raw_status),
         );
     }
+    if work.item.archived {
+        add(
+            "work_archived",
+            key,
+            "Restore this source record before selecting it for execution".into(),
+        );
+    }
     if let Some(blocker) = work.item.blocker.as_ref().filter(|s| !s.trim().is_empty()) {
         add("active_blocker", key, blocker.clone());
     }
@@ -220,7 +227,7 @@ pub(crate) fn readiness(
         );
     }
     for dependency in &dependencies.dependencies {
-        if dependency.item.status != WorkStatus::Completed {
+        if dependency.item.archived || dependency.item.status != WorkStatus::Completed {
             add(
                 if dependency.item.status == WorkStatus::Unknown {
                     "unknown_status"
@@ -257,6 +264,15 @@ pub(crate) fn readiness(
 }
 
 impl Store {
+    /// Source-declared work dependency associations, including source references for diagnosis.
+    pub fn work_dependency_links(&self, project: Id) -> Result<Vec<Edge>> {
+        self.project(project)?;
+        self.conn.prepare("SELECT e.id,e.from_key,e.to_key,e.required,e.revision,e.source_ref_json FROM edges e JOIN sources s ON e.source_id=s.id AND e.project_id=s.project_id WHERE e.project_id=?1 AND e.active=1 AND s.active=1 AND e.from_kind='work_item' AND e.to_kind='work_item' AND e.relation='depends_on' ORDER BY e.from_key,e.to_key,e.id").map_err(db_error)?
+            .query_map([project.to_string()], |row| {
+                let source_ref = serde_json::from_str(&row.get::<_, String>(5)?).map_err(|e| rusqlite::Error::FromSqlConversionFailure(5,rusqlite::types::Type::Text,Box::new(e)))?;
+                Ok(Edge { id:id_at(row,0)?, project_id:project, from_kind:EntityKind::WorkItem, from_key:row.get(1)?, relation:"depends_on".into(), to_kind:EntityKind::WorkItem, to_key:row.get(2)?, required:row.get(3)?, revision:revision_at(row,4)?, source_ref })
+            }).map_err(db_error)?.collect::<rusqlite::Result<Vec<_>>>().map_err(db_error)
+    }
     /// Source-declared work-to-goal associations, including source references for diagnosis.
     pub fn work_goal_links(&self, project: Id) -> Result<Vec<Edge>> {
         self.project(project)?;
@@ -265,6 +281,17 @@ impl Store {
                 let source_ref = serde_json::from_str(&row.get::<_, String>(5)?).map_err(|e| rusqlite::Error::FromSqlConversionFailure(5,rusqlite::types::Type::Text,Box::new(e)))?;
                 Ok(Edge { id:id_at(row,0)?, project_id:project, from_kind:EntityKind::WorkItem, from_key:row.get(1)?, relation:"supports".into(), to_kind:EntityKind::Goal, to_key:row.get(2)?, required:row.get(3)?, revision:revision_at(row,4)?, source_ref })
             }).map_err(db_error)?.collect::<rusqlite::Result<Vec<_>>>().map_err(db_error)
+    }
+    /// Source state is shared across branches: archive changes require no active executor.
+    pub fn ensure_work_unoccupied(&self, project: Id, work: Id) -> Result<()> {
+        self.project(project)?;
+        let claimed: bool = self.conn.query_row("SELECT EXISTS(SELECT 1 FROM claims WHERE project_id=?1 AND work_item_id=?2 AND status='active' AND released_at IS NULL AND (expires_at IS NULL OR expires_at>?3))", rusqlite::params![project.to_string(), work.to_string(), now_millis()?], |r|r.get(0)).map_err(db_error)?;
+        if claimed {
+            return Err(Error::ClaimConflict(
+                "release the active execution before archiving or restoring work".into(),
+            ));
+        }
+        Ok(())
     }
     pub fn work_item(&self, project: Id, key: &str) -> Result<Projected<WorkItem>> {
         projection(&self.conn, project, EntityKind::WorkItem, key)
@@ -307,6 +334,9 @@ impl Store {
         let mut ready = Vec::new();
         let mut blocked = Vec::new();
         for work in works {
+            if work.item.archived {
+                continue;
+            }
             if matches!(
                 work.item.status,
                 WorkStatus::Completed | WorkStatus::Cancelled

--- a/crates/awr-store/src/work_action.rs
+++ b/crates/awr-store/src/work_action.rs
@@ -14,6 +14,17 @@ pub(crate) fn validate_action(
     target: &serde_json::Value,
     session: Option<Id>,
 ) -> Result<()> {
+    if (patch.work_action.is_some()
+        || patch
+            .host_edit
+            .as_ref()
+            .is_some_and(|h| h.action != HostEditAction::Fields))
+        && target.get("archived").and_then(serde_json::Value::as_bool) == Some(true)
+    {
+        return Err(Error::RuleViolation(
+            "restore archived work before performing lifecycle actions".into(),
+        ));
+    }
     if let Some(host) = &patch.host_edit {
         host.validate()?;
         if session.is_some() {

--- a/crates/awr-store/tests/events.rs
+++ b/crates/awr-store/tests/events.rs
@@ -6,6 +6,7 @@ use support::Fixture;
 fn work(f: &Fixture, key: &str) -> WorkItem {
     WorkItem {
         ordinary_completion: None,
+        archived: false,
         meta: f.meta(key),
         title: key.into(),
         kind: None,

--- a/crates/awr-store/tests/evidence.rs
+++ b/crates/awr-store/tests/evidence.rs
@@ -5,6 +5,7 @@ use support::Fixture;
 fn work(f: &Fixture, key: &str) -> WorkItem {
     WorkItem {
         ordinary_completion: None,
+        archived: false,
         meta: f.meta(key),
         title: key.into(),
         kind: None,

--- a/crates/awr-store/tests/mutation.rs
+++ b/crates/awr-store/tests/mutation.rs
@@ -48,6 +48,7 @@ fn meta(
 fn work(meta: ProjectionMeta, next_action: &str) -> WorkItem {
     WorkItem {
         ordinary_completion: None,
+        archived: false,
         meta,
         title: "Work".into(),
         kind: Some("feature".into()),

--- a/crates/awr-store/tests/readiness.rs
+++ b/crates/awr-store/tests/readiness.rs
@@ -7,6 +7,7 @@ use support::Fixture;
 fn work(f: &Fixture, key: &str, status: &str) -> WorkItem {
     WorkItem {
         ordinary_completion: None,
+        archived: false,
         meta: f.meta(key),
         title: key.into(),
         kind: None,

--- a/crates/awr-store/tests/reconcile.rs
+++ b/crates/awr-store/tests/reconcile.rs
@@ -11,6 +11,7 @@ use support::Fixture;
 fn add_work(fixture: &mut Fixture, key: &str) -> Id {
     let item = WorkItem {
         ordinary_completion: None,
+        archived: false,
         meta: fixture.meta(key),
         title: key.into(),
         kind: Some("feature".into()),

--- a/crates/awr-store/tests/search.rs
+++ b/crates/awr-store/tests/search.rs
@@ -6,6 +6,7 @@ use support::Fixture;
 fn work(f: &Fixture, key: &str, title: &str, summary: &str) -> WorkItem {
     WorkItem {
         ordinary_completion: None,
+        archived: false,
         meta: f.meta(key),
         title: title.into(),
         kind: None,

--- a/crates/awr-store/tests/sessions.rs
+++ b/crates/awr-store/tests/sessions.rs
@@ -6,6 +6,7 @@ use support::Fixture;
 fn work(f: &Fixture, status: &str) -> WorkItem {
     WorkItem {
         ordinary_completion: None,
+        archived: false,
         meta: f.meta("W"),
         title: "Implement runtime".into(),
         kind: None,

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -600,3 +600,22 @@ engineering completion uses the existing acceptance/evidence contract. The singl
 journal and source reservation rules also cover Markdown, including lost receipts and
 external edits during recovery. Internal snapshot filenames are opaque implementation
 details; the registered adapter determines their format.
+
+
+## Same-source batches and archival
+
+`batch change --input request.json` previews up to 100 operations against one registered YAML or finite Markdown ledger. Acceptance requires `--accept --expected-preview <fingerprint> --expected-revision <revision>`. The version 1 envelope contains `request_key`, `actor` (the same provenance fields as host save), `reason`, and `change`:
+
+```json
+{"kind":"ledger","source_id":"<source ID>","source_fingerprint":"sha256:<current hash>","operations":[
+  {"operation":"fields","target":"READ-1","fields":{"next_action":"Review the note"}},
+  {"operation":"import","external_key":"READ-2","title":"Read the follow-up","fields":{"acceptance":["Useful notes"]},"duplicate":"fail"},
+  {"operation":"archive","target":"OLD-1","archived":true}
+]}
+```
+
+Use each stable key once per batch; combine fields in one operation. All operations and the final dependency graph are checked in memory before any source write. Import requires an explicit stable external key and produces a draft. `duplicate: "skip_exact"` only skips an existing unarchived draft with the same title and requested field values; unrelated existing fields remain intact. Conflicts never overwrite an existing entry. Status, verification, identity and completion metadata remain domain guarded.
+
+Archive is an independent `archived` boolean. It retains the original lifecycle status, ID, source record and runtime history. Archived work stays in explicit catalogs and `work show`, is absent from ready selection and current-scope completion counts, and cannot execute lifecycle actions until restored. `source_archived` is reported separately. Archive/restore requires no active executor across any branch. Remove incoming dependencies explicitly or archive the associated dependent scope in the same batch; restoring dependents requires restoring their dependencies too. Cancelled work remains separately counted; moving work out of current scope proves no completion.
+
+`batch status --key <key>` reads the durable outcome without writing. `batch recover --key <key> --expected-revision <revision>` explicitly resumes interrupted writes/indexing. Recovery binds the project, full manifest, reviewed bytes and dependency sources. A pending intent prevents another AWR writer from changing the same source; external edits are preserved and reported as conflicts. A duplicate request returns its historical receipt without new writes. No-change batches write no business events. The actor is provenance supplied by the host, not authentication. Raw journals are local runtime state.

--- a/tests/concurrency/isolation.rs
+++ b/tests/concurrency/isolation.rs
@@ -19,6 +19,7 @@ fn fixture() -> Fixture {
     fs::write(f.root.join("fixture-owner"), "awr-isolation-test").unwrap();
     let work = |key: &str| WorkItem {
         ordinary_completion: None,
+        archived: false,
         meta: f.meta(key),
         title: format!("Review {key} report"),
         kind: None,


### PR DESCRIPTION
Hosts can now preview and apply a complete same-source batch of field edits, draft imports and archive/restore actions. Invalid operations prevent all writes; duplicate imports have explicit handling, while archival preserves identity and history and checks dependencies and active claims.

A durable request journal provides idempotent status and explicit recovery after interrupted writes or indexing. Pending source intents block conflicting AWR writers, and recovery preserves external edits. YAML and finite Markdown writers retain unrelated bytes.

Validation: 8 dedicated native batch checks, related source/store and CLI regressions, and matching CLI/MCP read contracts. Public-tree and formatting checks pass. These are local/native integration checks, not full application business acceptance.
