### PR TITLE
Release AWR 0.3.2 with source-first workflows and runtime recovery

### DIFF
--- a/.github/workflows/distributions.yml
+++ b/.github/workflows/distributions.yml
@@ -13,7 +13,7 @@ on:
         description: Exact version expected in Cargo.toml
         type: string
         required: true
-        default: '0.3.1'
+        default: '0.3.2'
       registry:
         description: Registry publication targets
         type: choice

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "awr-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "awr-context",
  "awr-core",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "awr-context"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "awr-core",
  "awr-source",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "awr-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64",
  "globset",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "awr-mcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "awr-context",
  "awr-core",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "awr-runtime"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "awr-context",
  "awr-core",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "awr-source"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "awr-core",
  "awr-store",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "awr-store"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "awr-core",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 default-members = ["crates/awr-cli"]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.93"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -54,17 +54,17 @@ On this Apple M3 Max / macOS run, context compilation took **108 ms at p95**
 
 ## Get started
 
-Install **0.3.1** through either registry; both supply `awr` and `awr-mcp`:
+Install **0.3.2** through either registry; both supply `awr` and `awr-mcp`:
 
 ```sh
-npm install -g @originoneai/agent-work-runtime@0.3.1
+npm install -g @originoneai/agent-work-runtime@0.3.2
 # or, in a Python virtual environment
-python -m pip install agent-work-runtime==0.3.1
+python -m pip install agent-work-runtime==0.3.2
 ```
 
 Prebuilt targets: macOS 15+ arm64 and Intel x64, Linux x64/glibc 2.39+, Windows x64.
 Launchers require Node 22.14+ or Python 3.9+. See [distribution details](docs/release/DISTRIBUTIONS.md).
-See the [0.3.1 release notes](docs/release/0.3.1.md) for host capabilities and schema upgrade guidance.
+See the [0.3.2 release notes](docs/release/0.3.2.md) for host capabilities and schema upgrade guidance.
 
 For an optional source build, use [Rust](https://www.rust-lang.org/tools/install)
 (the repository pins its toolchain):

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,16 +39,16 @@
 
 ## 怎么用
 
-任选 npm 或 pip 安装 **0.3.1 正式版**，均提供 `awr` 和 `awr-mcp`：
+任选 npm 或 pip 安装 **0.3.2 正式版**，均提供 `awr` 和 `awr-mcp`：
 
 ```sh
-npm install -g @originoneai/agent-work-runtime@0.3.1
+npm install -g @originoneai/agent-work-runtime@0.3.2
 # 或在 Python 虚拟环境内
-python -m pip install agent-work-runtime==0.3.1
+python -m pip install agent-work-runtime==0.3.2
 ```
 
 预编译包支持 macOS 15+ Apple Silicon arm64 和 Intel x64、Linux x64/glibc 2.39+、Windows x64；启动器需要 Node 22.14+ 或 Python 3.9+。详见[安装边界](docs/release/DISTRIBUTIONS.md)。
-宿主能力和数据库升级说明见 [0.3.1 发布说明](docs/release/0.3.1.md)。
+宿主能力和数据库升级说明见 [0.3.2 发布说明](docs/release/0.3.2.md)。
 
 也可安装 [Rust](https://www.rust-lang.org/tools/install)，选择源码构建：
 

--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -27,6 +27,28 @@ struct Capability {
 fn catalog() -> Vec<Capability> {
     [
         (
+            "runtime.matched_snapshot",
+            true,
+            &[
+                "runtime binding",
+                "runtime backup",
+                "runtime check",
+                "runtime restore-preview",
+                "runtime restore",
+                "runtime restore-status",
+                "runtime restore-recover",
+            ][..],
+            &[
+                "same_root",
+                "same_executable_bytes",
+                "matching_sources_and_known_runtime_files",
+                "database_only_restore",
+                "explicit_offline",
+                "new_files_preserved",
+                "external_host_state_excluded",
+            ][..],
+        ),
+        (
             "query.summary",
             true,
             &["status --view summary"][..],

--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -37,6 +37,22 @@ fn catalog() -> Vec<Capability> {
             ][..],
         ),
         (
+            "organization.mapped_metadata",
+            true,
+            &[
+                "organization preview",
+                "organization change",
+                "organization status",
+                "organization recover",
+            ][..],
+            &[
+                "primary_yaml",
+                "explicit_mapping",
+                "no_entity_or_acceptance_changes",
+                "exact_preview",
+            ][..],
+        ),
+        (
             "source.read",
             true,
             &["source list", "source show"][..],

--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -65,6 +65,33 @@ fn catalog() -> Vec<Capability> {
             &["requires_expected_preview", "individual_files_only"],
         ),
         (
+            "intake.semantic_preflight",
+            true,
+            &["init", "source configure"],
+            &[
+                "captured_bytes",
+                "no_project_writes",
+                "execution_readiness_separate",
+                "bounded_temporary_snapshot",
+            ],
+        ),
+        (
+            "source.relocate",
+            true,
+            &[
+                "source relocate",
+                "source relocate-status",
+                "source relocate-recover",
+            ],
+            &[
+                "single_relative_file",
+                "unchanged_contents",
+                "stable_object_keys",
+                "explicit_preview",
+                "recoverable_not_filesystem_atomic",
+            ],
+        ),
+        (
             "source.configure",
             true,
             &["source configure", "source configure-status"],

--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -102,6 +102,24 @@ fn catalog() -> Vec<Capability> {
             ],
         ),
         (
+            "query.coherent_snapshot",
+            true,
+            &[
+                "status",
+                "ready",
+                "work show",
+                "object list",
+                "search",
+                "context compile",
+            ],
+            &[
+                "source_transition_wait_bounded",
+                "query_revision_is_a_snapshot",
+                "source_fingerprint_excludes_runtime_events",
+                "cached_mode_does_not_verify_current_sources",
+            ],
+        ),
+        (
             "work.read",
             true,
             &["work show", "ready", "status"],

--- a/crates/awr-cli/src/capabilities.rs
+++ b/crates/awr-cli/src/capabilities.rs
@@ -27,6 +27,16 @@ struct Capability {
 fn catalog() -> Vec<Capability> {
     [
         (
+            "query.summary",
+            true,
+            &["status --view summary"][..],
+            &[
+                "explicit_scope",
+                "source_counts_are_not_acceptance",
+                "details_on_demand",
+            ][..],
+        ),
+        (
             "source.read",
             true,
             &["source list", "source show"][..],

--- a/crates/awr-cli/src/catalog.rs
+++ b/crates/awr-cli/src/catalog.rs
@@ -15,6 +15,9 @@ pub struct ListArgs {
     cursor: Option<String>,
     #[arg(long, default_value_t = 20)]
     limit: usize,
+    /// Read last recorded facts without refreshing authoritative files.
+    #[arg(long)]
+    cached: bool,
 }
 
 pub fn list(root: &Path, args: &ListArgs, json_output: bool) -> Result<()> {
@@ -29,7 +32,7 @@ pub fn list(root: &Path, args: &ListArgs, json_output: bool) -> Result<()> {
     if !(1..=200).contains(&args.limit) {
         return Err(Error::InvalidInput("catalog limit must be 1..200".into()));
     }
-    let query = crate::query::QueryProject::open(root)?;
+    let query = crate::query::QueryProject::open_read(root, args.cached)?;
     let page = query.store.catalog_page(
         query.project.id,
         query.project.project_revision,

--- a/crates/awr-cli/src/intake_plan.rs
+++ b/crates/awr-cli/src/intake_plan.rs
@@ -119,12 +119,45 @@ pub fn preview(
     }
     let mut snapshots = Vec::new();
     let mut issues = Vec::new();
+    let mut captured = awr_source::PreviewSources::new();
     for spec in &manifest.sources {
+        let key = awr_source::source_configuration(spec, false)["mapping_key"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+        let captured_files = captured.entry(key).or_default();
         if let Some(body) = spec
             .path
             .as_ref()
             .and_then(|p| generated.get(&p.to_string_lossy().into_owned()))
         {
+            let path = spec.path.as_ref().unwrap();
+            if path.is_absolute()
+                || path.components().any(|c| {
+                    !matches!(
+                        c,
+                        std::path::Component::Normal(_) | std::path::Component::CurDir
+                    )
+                })
+            {
+                return Err(Error::RuleViolation(
+                    "proposed intake source must stay within the project".into(),
+                ));
+            }
+            if spec.adapter == "markdown-directory-v1" {
+                return Err(Error::Unsupported(
+                    "proposed directory sources require explicit members".into(),
+                ));
+            }
+            let locator = awr_source::Locator::File(root.join(path));
+            captured_files.push((
+                locator.clone(),
+                awr_source::SourceSnapshot {
+                    locator: locator.identity()?,
+                    fingerprint: fingerprint(body.as_bytes()),
+                    bytes: body.as_bytes().to_vec(),
+                },
+            ));
             snapshots.push(json!({"domain":spec.domain,"path":spec.path,"proposed":true,"fingerprint":fingerprint(body.as_bytes())}));
             continue;
         }
@@ -133,8 +166,13 @@ pub fn preview(
             Ok(locators) => {
                 for locator in locators {
                     match locator.read(root, source_read_cap(&spec.adapter)?) {
-                        Ok(snapshot) => snapshots.push(json!({"domain":spec.domain,"locator":snapshot.locator,"fingerprint":snapshot.fingerprint})),
-                        Err(error) => issues.push(json!({"domain":spec.domain,"source":spec,"error":error.report()})),
+                        Ok(snapshot) => {
+                            snapshots.push(json!({"domain":spec.domain,"locator":snapshot.locator,"fingerprint":snapshot.fingerprint}));
+                            captured_files.push((locator, snapshot));
+                        }
+                        Err(error) => issues.push(
+                            json!({"domain":spec.domain,"source":spec,"error":error.report()}),
+                        ),
                     }
                 }
             }
@@ -159,10 +197,30 @@ pub fn preview(
         runtime_effects
             .push(json!({"path_pattern":".awr/intake-*/","action":"temporary_intake_staging"}));
     }
+    let mut semantic = match semantic_preview(root, manifest, &captured) {
+        Ok(value) => value,
+        Err(error) => json!({"can_apply":false,"can_execute":false,"issues":[{
+            "domain":"project","source":null,"error":error.report()}]}),
+    };
+    for issue in semantic["issues"].as_array().into_iter().flatten() {
+        // Preserve the original source issue contract and avoid duplicate read errors.
+        if !issues.iter().any(|old| {
+            old["source"] == issue["source"]
+                && old["locator"] == issue["locator"]
+                && old["error"]["code"] == issue["error"]["code"]
+        }) {
+            issues.push(issue.clone());
+        }
+    }
+    if !issues.is_empty() {
+        semantic["can_apply"] = json!(false);
+        semantic["can_execute"] = json!(false);
+    }
     let mut plan = json!({
         "version":1, "operation":if configure {"source.configure"} else {"init"},
         "project_root":root, "authority_mapping":manifest, "writes":writes,
         "source_snapshots":snapshots, "source_issues":issues,
+        "can_apply":semantic["can_apply"], "semantic":semantic,
         "runtime_effects":runtime_effects,
         "source_write_performed":false, "runtime_write_performed":false,
         "atomicity":"individual_files_only; partial_initialization_can_remain_on_failure"
@@ -170,6 +228,72 @@ pub fn preview(
     let digest = fingerprint(&serde_json::to_vec(&plan)?);
     plan["fingerprint"] = json!(digest);
     Ok(plan)
+}
+
+fn semantic_preview(
+    root: &Path,
+    manifest: &Manifest,
+    captured: &awr_source::PreviewSources,
+) -> Result<Value> {
+    let database = root.join(".awr/state.db");
+    let (mut store, basis) = if database.exists() {
+        super::source::runtime_dir(root, false)?;
+        awr_source::open_file_exact(&database)?;
+        let store = awr_store::Store::preview_snapshot(&database, 256 * 1024 * 1024)?;
+        let project = store.project_by_root(root)?;
+        // Runtime-only observations need not invalidate a source configuration preview.
+        let sources = store.sources(project.id)?.into_iter().map(|s|
+            json!({"id":s.id,"revision":s.revision,"locator":s.locator,"fingerprint":s.fingerprint,"config":s.config})).collect::<Vec<_>>();
+        (store, json!({"project_id":project.id,"sources":sources}))
+    } else {
+        (awr_store::Store::memory()?, Value::Null)
+    };
+    let report = awr_source::preview_index_project(&mut store, root, manifest, captured)?;
+    let issues = report
+        .issues
+        .iter()
+        .map(|issue| {
+            let spec = manifest.sources.iter().find(|s| {
+                awr_source::source_configuration(s, false)["mapping_key"] == issue.mapping
+            });
+            json!({"domain":spec.map(|s|s.domain.as_str()).unwrap_or("project"),"source":spec,"locator":issue.locator,
+            "error":{"code":issue.code,"message":issue.message,"details":issue.details}})
+        })
+        .collect::<Vec<_>>();
+    let project = store.project(report.project_id)?;
+    let readiness = store.ready_work(project.id, None, awr_core::now_millis()?)?;
+    let organization = awr_runtime::inspect_organization(
+        &store,
+        &project,
+        None,
+        None,
+        report.ok,
+        &store.work_items(project.id)?,
+        &readiness,
+    )?;
+    // Generated IDs, timestamps and speculative revision numbers never enter the preview hash.
+    let organization = serde_json::to_value(organization)?;
+    let gaps = organization["gaps"].as_array().into_iter().flatten().map(|g|
+        json!({"code":g["code"],"target":g["target"],"detail":g["detail"],"action":g["action"]})).collect::<Vec<_>>();
+    let work = organization["executable_work"].clone();
+    Ok(
+        json!({"version":1,"can_apply":report.ok,"can_execute":organization["business_execution_ready"],
+        "source_basis":basis,"issues":issues,"organization_state":organization["state"],
+        "gap_total":organization["gap_total"],"gaps":gaps,"truncated":organization["truncated"],
+        "executable_work":work,"executable_work_total":organization["executable_work_total"],
+        "source_write_performed":false,"runtime_write_performed":false,"storage":"private_memory"}),
+    )
+}
+
+pub fn require_applicable(plan: &Value) -> Result<()> {
+    if plan["can_apply"] == true {
+        Ok(())
+    } else {
+        Err(Error::IntakePreflightRejected {
+            issues: plan["source_issues"].clone(),
+            intake_staged: false,
+        })
+    }
 }
 
 pub fn check_expected(plan: &Value, expected: Option<&str>) -> Result<()> {

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod organization;
+mod runtime_snapshot;
 use awr_core::{Error, Result};
 use clap::{CommandFactory, Parser, Subcommand};
 use std::path::PathBuf;
@@ -46,6 +47,11 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Inspect, back up and explicitly restore a matching local runtime.
+    Runtime {
+        #[command(subcommand)]
+        command: runtime_snapshot::RuntimeCommand,
+    },
     /// Maintain explicitly mapped project phase, scope and focus.
     Organization {
         #[command(subcommand)]
@@ -187,6 +193,9 @@ enum Command {
 fn run(cli: &Cli) -> Result<()> {
     match &cli.command {
         Some(Command::Host { command }) => host_save::run(&cli.project, command, cli.json),
+        Some(Command::Runtime { command }) => {
+            runtime_snapshot::run(&cli.project, command, cli.json)
+        }
         Some(Command::Organization { command }) => {
             organization::run(&cli.project, command, cli.json)
         }

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod organization;
 use awr_core::{Error, Result};
 use clap::{CommandFactory, Parser, Subcommand};
 use std::path::PathBuf;
@@ -45,6 +46,11 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Maintain explicitly mapped project phase, scope and focus.
+    Organization {
+        #[command(subcommand)]
+        command: organization::OrganizationCommand,
+    },
     /// Preview and apply a bounded batch of source edits.
     Batch {
         #[command(subcommand)]
@@ -181,6 +187,9 @@ enum Command {
 fn run(cli: &Cli) -> Result<()> {
     match &cli.command {
         Some(Command::Host { command }) => host_save::run(&cli.project, command, cli.json),
+        Some(Command::Organization { command }) => {
+            organization::run(&cli.project, command, cli.json)
+        }
         Some(Command::Batch { command }) => batch::run(&cli.project, command, cli.json),
         Some(Command::Document { command }) => document::run(&cli.project, command, cli.json),
         Some(Command::Capabilities(args)) => capabilities::run(args, cli.json),

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -24,6 +24,7 @@ mod search;
 mod session;
 mod source;
 mod source_changes;
+mod source_relocation;
 mod work_action;
 mod work_create;
 

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -91,6 +91,16 @@ enum Command {
     },
     /// Refresh source projections and summarize current project work.
     Status {
+        /// Select the compatible full view or the versioned compact summary.
+        #[arg(long, default_value="full", value_parser=["full","summary"])]
+        view: String,
+        /// Exact work keys in the summary scope; repeat to select several.
+        #[arg(long, requires = "view")]
+        work: Vec<String>,
+        #[arg(long)]
+        goal: Option<String>,
+        #[arg(long)]
+        milestone: Option<String>,
         #[arg(long)]
         branch: Option<String>,
         /// Use the last recorded snapshot without refreshing business sources.
@@ -184,13 +194,30 @@ fn run(cli: &Cli) -> Result<()> {
             branch,
             source_sha,
             cached,
-        }) => query::status(
-            &cli.project,
-            branch.as_deref(),
-            source_sha.as_deref(),
-            cli.json,
-            *cached,
-        ),
+            view,
+            work,
+            goal,
+            milestone,
+        }) => {
+            let scope = awr_runtime::StatusScope {
+                work: work.clone(),
+                goal: goal.clone(),
+                milestone: milestone.clone(),
+            };
+            if view == "full" && !scope.is_empty() {
+                return Err(awr_core::Error::InvalidInput(
+                    "scope selectors require --view summary".into(),
+                ));
+            }
+            query::status_with_scope(
+                &cli.project,
+                branch.as_deref(),
+                source_sha.as_deref(),
+                cli.json,
+                *cached,
+                (view == "summary").then_some(&scope),
+            )
+        }
         Some(Command::Ready {
             limit,
             branch,

--- a/crates/awr-cli/src/main.rs
+++ b/crates/awr-cli/src/main.rs
@@ -93,6 +93,9 @@ enum Command {
     Status {
         #[arg(long)]
         branch: Option<String>,
+        /// Use the last recorded snapshot without refreshing business sources.
+        #[arg(long)]
+        cached: bool,
         /// Verify completion reports against this explicit full source SHA.
         #[arg(long)]
         source_sha: Option<String>,
@@ -103,6 +106,9 @@ enum Command {
         limit: usize,
         #[arg(long)]
         branch: Option<String>,
+        /// Use the last recorded snapshot without refreshing business sources.
+        #[arg(long)]
+        cached: bool,
     },
     /// Read one work item without expanding the full ledger or event history.
     Work {
@@ -174,15 +180,22 @@ fn run(cli: &Cli) -> Result<()> {
         Some(Command::Execution { command }) => execution::run(&cli.project, command, cli.json),
         Some(Command::Recovery { command }) => recovery::run(&cli.project, command, cli.json),
         Some(Command::Source { command }) => source::run(&cli.project, command, cli.json),
-        Some(Command::Status { branch, source_sha }) => query::status(
+        Some(Command::Status {
+            branch,
+            source_sha,
+            cached,
+        }) => query::status(
             &cli.project,
             branch.as_deref(),
             source_sha.as_deref(),
             cli.json,
+            *cached,
         ),
-        Some(Command::Ready { limit, branch }) => {
-            query::ready(&cli.project, *limit, branch.as_deref(), cli.json)
-        }
+        Some(Command::Ready {
+            limit,
+            branch,
+            cached,
+        }) => query::ready(&cli.project, *limit, branch.as_deref(), cli.json, *cached),
         Some(Command::Work { command }) => query::work(&cli.project, command, cli.json),
         Some(Command::Session { command }) => session::run(&cli.project, command, cli.json),
         Some(Command::Evidence { command }) => records::evidence(&cli.project, command, cli.json),

--- a/crates/awr-cli/src/onboarding.rs
+++ b/crates/awr-cli/src/onboarding.rs
@@ -493,6 +493,7 @@ pub fn run(root: &Path, args: &InitArgs, json_output: bool) -> Result<()> {
     if !candidate.ambiguous_domains.is_empty() {
         return Err(Error::SourceConflict("multiple authority candidates; supply an explicit manifest or resolve the reviewed draft mapping".into()));
     }
+    crate::intake_plan::require_applicable(&preview)?;
     candidate.authority_mapping.validate()?;
     let mut primary = BTreeSet::new();
     for spec in &candidate.authority_mapping.sources {
@@ -559,4 +560,11 @@ pub fn run(root: &Path, args: &InitArgs, json_output: bool) -> Result<()> {
         json_output,
         None,
     )
+    .map_err(|error| match error {
+        Error::IntakePreflightRejected { issues, .. } => Error::IntakePreflightRejected {
+            issues,
+            intake_staged: true,
+        },
+        other => other,
+    })
 }

--- a/crates/awr-cli/src/onboarding.rs
+++ b/crates/awr-cli/src/onboarding.rs
@@ -52,9 +52,13 @@ pub enum IntakeCommand {
 
 pub fn inspect(root: &Path, command: &IntakeCommand, json_output: bool) -> Result<()> {
     match command {
-        IntakeCommand::Inspect { branch, source_sha } => {
-            crate::query::status(root, branch.as_deref(), source_sha.as_deref(), json_output)
-        }
+        IntakeCommand::Inspect { branch, source_sha } => crate::query::status(
+            root,
+            branch.as_deref(),
+            source_sha.as_deref(),
+            json_output,
+            false,
+        ),
     }
 }
 

--- a/crates/awr-cli/src/organization.rs
+++ b/crates/awr-cli/src/organization.rs
@@ -1,0 +1,108 @@
+use awr_core::*;
+use awr_runtime::OrganizationChange;
+use awr_store::Store;
+use clap::Subcommand;
+use std::path::{Path, PathBuf};
+#[derive(Debug, Subcommand)]
+pub enum OrganizationCommand {
+    /// Read source annotations through an explicit JSON mapping file.
+    Show {
+        #[arg(long)]
+        source: Id,
+        #[arg(long)]
+        mapping: PathBuf,
+    },
+    /// Preview exact changes to explicitly mapped project metadata.
+    Preview {
+        #[arg(long)]
+        input: PathBuf,
+    },
+    /// Apply the reviewed metadata edit without changing entity lifecycle or contracts.
+    Change {
+        #[arg(long)]
+        input: PathBuf,
+        #[arg(long)]
+        expected_preview: String,
+        #[arg(long)]
+        expected_revision: Revision,
+    },
+    /// Read a retained request's outcome without applying it again.
+    Status {
+        #[arg(long)]
+        key: String,
+    },
+    /// Recover an interrupted request only from its matching before/after bytes.
+    Recover {
+        #[arg(long)]
+        key: String,
+        #[arg(long)]
+        expected_revision: Revision,
+    },
+}
+fn input(root: &Path, path: &Path) -> Result<OrganizationChange> {
+    let path = if path.is_absolute() {
+        path.to_owned()
+    } else {
+        root.join(path)
+    };
+    serde_json::from_slice(&awr_source::read_capped(&path,awr_source::YAML_READ_CAP)?).map_err(|_|Error::InvalidInput("organization JSON requires version, request_key, actor, reason, source_id, source_fingerprint, mapping and values".into()))
+}
+pub fn run(root: &Path, command: &OrganizationCommand, json_output: bool) -> Result<()> {
+    let root = root.canonicalize()?;
+    let database = crate::source::runtime_dir(&root, false)?.join("state.db");
+    let value = match command {
+        OrganizationCommand::Show { source, mapping } => {
+            let path = if mapping.is_absolute() {
+                mapping.to_owned()
+            } else {
+                root.join(mapping)
+            };
+            let mapping = serde_json::from_slice(&awr_source::read_capped(&path, 65536)?)?;
+            awr_runtime::read_organization(
+                &Store::read_snapshot(&database, 256 * 1024 * 1024)?,
+                &root,
+                *source,
+                &mapping,
+            )?
+        }
+        OrganizationCommand::Preview { input: path } => awr_runtime::organization_preview(
+            &Store::read_snapshot(&database, 256 * 1024 * 1024)?,
+            &root,
+            input(&root, path)?,
+        )?,
+        OrganizationCommand::Status { key } => awr_runtime::organization_status(
+            &Store::read_snapshot(&database, 256 * 1024 * 1024)?,
+            &root,
+            key,
+        )?,
+        OrganizationCommand::Change {
+            input: path,
+            expected_preview,
+            expected_revision,
+        } => awr_runtime::change_organization(
+            &mut Store::open_existing(&database)?,
+            &root,
+            input(&root, path)?,
+            *expected_revision,
+            expected_preview,
+        )?,
+        OrganizationCommand::Recover {
+            key,
+            expected_revision,
+        } => awr_runtime::recover_organization(
+            &mut Store::open_existing(&database)?,
+            &root,
+            key,
+            *expected_revision,
+        )?,
+    };
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        println!(
+            "Organization: {}",
+            value["phase"].as_str().unwrap_or("preview")
+        );
+    }
+    Ok(())
+}

--- a/crates/awr-cli/src/query.rs
+++ b/crates/awr-cli/src/query.rs
@@ -41,6 +41,9 @@ pub enum WorkCommand {
         /// Explicit full source SHA for evidence currency (does not assume HEAD is clean).
         #[arg(long)]
         source_sha: Option<String>,
+        /// Read last recorded facts without refreshing files; currentness is not verified.
+        #[arg(long)]
+        cached: bool,
     },
 }
 
@@ -48,6 +51,8 @@ pub(crate) struct QueryProject {
     pub store: Store,
     pub project: Project,
     pub refresh: IndexReport,
+    snapshot: Option<Value>,
+    cached: bool,
 }
 impl QueryProject {
     /// Refresh the rebuildable projection cache only; authoritative files are never modified.
@@ -68,12 +73,43 @@ impl QueryProject {
             store,
             project,
             refresh,
+            snapshot: None,
+            cached: false,
+        })
+    }
+    pub(crate) fn open_read(root: &Path, cached: bool) -> Result<Self> {
+        let root = root.canonicalize()?;
+        let database = super::source::runtime_dir(&root, false)?.join("state.db");
+        if !database.is_file() {
+            return Err(Error::NotFound("AWR database; initialize first".into()));
+        }
+        let snapshot = if cached {
+            awr_source::recorded_snapshot(&root)?
+        } else {
+            let mut origin = Store::open(&database)?;
+            awr_source::refresh_snapshot(&mut origin, &root)?
+        };
+        let project = snapshot.store.project(snapshot.refresh.project_id)?;
+        let metadata = json!({"version":1,"storage":"private_memory","coherent":true,
+            "project_revision":project.project_revision,"source_state_fingerprint":snapshot.source_state_fingerprint,
+            "source_refresh_revision":if cached {None}else{Some(snapshot.refresh.change_window.through_revision)},
+            "source_currentness_verified":!cached && snapshot.refresh.ok});
+        Ok(Self {
+            store: snapshot.store,
+            project,
+            refresh: snapshot.refresh,
+            snapshot: Some(metadata),
+            cached,
         })
     }
     pub(crate) fn metadata(&self) -> Value {
-        json!({"ok":self.refresh.ok,"project_revision":self.project.project_revision,
-            "freshness_basis":"source_refresh","source_refresh_performed":true,"read_only":false,"source_issues":self.refresh.issues,
-            "source_warnings":self.refresh.sources.iter().map(|s|s.warnings.len()).sum::<usize>()})
+        let mut value = json!({"ok":self.refresh.ok,"project_revision":self.project.project_revision,
+            "freshness_basis":if self.cached {"last_recorded_source_state"} else {"source_refresh"},"source_refresh_performed":!self.cached,"read_only":self.cached,"source_issues":self.refresh.issues,
+            "source_warnings":self.refresh.sources.iter().map(|s|s.warnings.len()).sum::<usize>()});
+        if let Some(snapshot) = &self.snapshot {
+            value["snapshot"] = snapshot.clone();
+        }
+        value
     }
     pub(crate) fn finish(&self) -> Result<()> {
         if self.refresh.ok {
@@ -134,6 +170,7 @@ pub fn status(
     reference: Option<&str>,
     source_sha: Option<&str>,
     json_output: bool,
+    cached: bool,
 ) -> Result<()> {
     if source_sha.is_some_and(|s| !is_source_sha(s)) {
         return Err(Error::InvalidInput(
@@ -141,7 +178,7 @@ pub fn status(
         ));
     }
     let root = root.canonicalize()?;
-    let query = match QueryProject::open(&root) {
+    let query = match QueryProject::open_read(&root, cached) {
         Ok(query) => query,
         Err(error) => {
             let initialized =
@@ -263,11 +300,17 @@ pub fn status(
     query.finish()
 }
 
-pub fn ready(root: &Path, limit: usize, reference: Option<&str>, json_output: bool) -> Result<()> {
+pub fn ready(
+    root: &Path,
+    limit: usize,
+    reference: Option<&str>,
+    json_output: bool,
+    cached: bool,
+) -> Result<()> {
     if limit == 0 || limit > 100 {
         return Err(Error::InvalidInput("ready limit must be 1..100".into()));
     }
-    let query = QueryProject::open(root)?;
+    let query = QueryProject::open_read(root, cached)?;
     let branch_id = branch(&query.store, &query.project, reference)?;
     let report = query
         .store
@@ -374,13 +417,14 @@ pub fn work(root: &Path, command: &WorkCommand, json_output: bool) -> Result<()>
             id,
             source_sha,
             branch: reference,
+            cached,
         } => {
             if source_sha.as_ref().is_some_and(|s| !is_source_sha(s)) {
                 return Err(Error::InvalidInput(
                     "--source-sha requires a full source SHA".into(),
                 ));
             }
-            let query = QueryProject::open(root)?;
+            let query = QueryProject::open_read(root, *cached)?;
             let branch_id = branch(&query.store, &query.project, reference.as_deref())?;
             let work =
                 query

--- a/crates/awr-cli/src/query.rs
+++ b/crates/awr-cli/src/query.rs
@@ -172,6 +172,16 @@ pub fn status(
     json_output: bool,
     cached: bool,
 ) -> Result<()> {
+    status_with_scope(root, reference, source_sha, json_output, cached, None)
+}
+pub fn status_with_scope(
+    root: &Path,
+    reference: Option<&str>,
+    source_sha: Option<&str>,
+    json_output: bool,
+    cached: bool,
+    scope: Option<&awr_runtime::StatusScope>,
+) -> Result<()> {
     if source_sha.is_some_and(|s| !is_source_sha(s)) {
         return Err(Error::InvalidInput(
             "--source-sha requires a full source SHA".into(),
@@ -212,6 +222,34 @@ pub fn status(
         &works,
         &report,
     )?;
+    if let Some(scope) = scope {
+        let mut value = awr_runtime::summarize_status(
+            &query.store,
+            &query.project,
+            scope,
+            &works,
+            &report,
+            &organization,
+        )?;
+        for (key, item) in query.metadata().as_object().expect("query metadata") {
+            value[key] = item.clone();
+        }
+        query.check_revision()?;
+        if json_output {
+            println!("{}", serde_json::to_string(&value)?);
+        } else {
+            println!(
+                "Project: {} | {} selected | {} active | {} ready | {} blocked\nNext: {}\nDetails: awr status; awr work show KEY",
+                query.project.name,
+                value["total"],
+                value["current_total"],
+                value["ready_count"],
+                value["blocked_count"],
+                value["next_action"]
+            );
+        }
+        return query.finish();
+    }
     let mut counts = BTreeMap::<String, usize>::new();
     for work in &works {
         *counts

--- a/crates/awr-cli/src/runtime_snapshot.rs
+++ b/crates/awr-cli/src/runtime_snapshot.rs
@@ -1,0 +1,1007 @@
+//! Matched, same-root runtime snapshots. Source files are never restore targets.
+use awr_core::{Error, Freshness, Id, Result, Revision, Source};
+use awr_source::{Manifest, fingerprint};
+use awr_store::{RuntimeLease, Store};
+use clap::Subcommand;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs::{self, File, OpenOptions},
+    io::{Read, Write},
+    path::{Component, Path, PathBuf},
+};
+
+const FILE_CAP: u64 = 256 * 1024 * 1024;
+const TOTAL_CAP: u64 = 1024 * 1024 * 1024;
+const FILE_COUNT: usize = 10000;
+const CLI_PAYLOAD: &str = if cfg!(windows) {
+    "program/awr.exe"
+} else {
+    "program/awr"
+};
+const MCP_PAYLOAD: &str = if cfg!(windows) {
+    "program/awr-mcp.exe"
+} else {
+    "program/awr-mcp"
+};
+const DATABASE_FILES: [&str; 4] = [
+    "state.db",
+    "state.db-wal",
+    "state.db-shm",
+    "state.db-journal",
+];
+
+#[derive(Debug, Subcommand)]
+pub enum RuntimeCommand {
+    /// Inspect the executing program, schema, configuration and current source/history binding.
+    Binding,
+    /// Capture a coherent database, registered sources, runtime files and executable copies.
+    Backup {
+        #[arg(long)]
+        output: PathBuf,
+        /// Optional matching MCP executable to retain alongside the CLI.
+        #[arg(long)]
+        companion: Option<PathBuf>,
+        /// Optional caller assertion; executable bytes remain the verified program identity.
+        #[arg(long)]
+        source_sha: Option<String>,
+    },
+    /// Verify a sealed backup without opening or changing the target project database.
+    Check {
+        #[arg(long)]
+        backup: PathBuf,
+    },
+    /// Preview a same-root history restore; sources and known runtime files must still match.
+    RestorePreview {
+        #[arg(long)]
+        backup: PathBuf,
+    },
+    /// Restore only the database after an exact preview and explicit offline acknowledgement.
+    Restore {
+        #[arg(long)]
+        backup: PathBuf,
+        #[arg(long)]
+        expected_preview: String,
+        /// Assert all clients, including older versions without runtime leases, are stopped.
+        #[arg(long, required = true)]
+        offline: bool,
+    },
+    /// Inspect an interrupted restore without opening SQLite. Omit ID for the pending restore.
+    RestoreStatus {
+        #[arg(long)]
+        id: Option<Id>,
+    },
+    /// Resume the pending restore only while its saved inputs and database bytes still match.
+    RestoreRecover {
+        #[arg(long, required = true)]
+        offline: bool,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Blob {
+    path: String,
+    sha256: String,
+    bytes: u64,
+}
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Program {
+    original_path: PathBuf,
+    version: String,
+    binary: Blob,
+}
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SourceCopy {
+    source: Source,
+    content: Blob,
+}
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Snapshot {
+    version: u32,
+    id: Id,
+    created_at: i64,
+    project_root: PathBuf,
+    project_id: Id,
+    project_revision: Revision,
+    schema_version: i64,
+    program: Program,
+    companion: Option<Program>,
+    caller_source_sha: Option<String>,
+    source_state_fingerprint: String,
+    sources: Vec<SourceCopy>,
+    runtime_files: BTreeMap<String, Blob>,
+    database: Blob,
+    fingerprint: String,
+}
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RestoreJournal {
+    version: u32,
+    id: Id,
+    phase: String,
+    created_at: i64,
+    project_root: PathBuf,
+    project_id: Id,
+    backup: PathBuf,
+    backup_fingerprint: String,
+    preview: Value,
+    before_database: BTreeMap<String, Option<Blob>>,
+    rollback: BTreeMap<String, Blob>,
+    restored_revision: Revision,
+}
+
+fn conflict(message: impl Into<String>) -> Error {
+    Error::SourceConflict(message.into())
+}
+fn relative(path: &str) -> Result<&Path> {
+    let p = Path::new(path);
+    if path.is_empty() || p.components().any(|p| !matches!(p, Component::Normal(_))) {
+        return Err(Error::RuleViolation(
+            "snapshot paths must be relative without traversal".into(),
+        ));
+    }
+    Ok(p)
+}
+fn exact_read(path: &Path, cap: u64) -> Result<Vec<u8>> {
+    let file = awr_source::open_file_exact(path)?;
+    let m = file.metadata()?;
+    if !m.is_file() || m.len() > cap {
+        return Err(Error::InvalidInput(
+            "snapshot needs a bounded regular file".into(),
+        ));
+    }
+    let mut bytes = Vec::new();
+    file.take(cap + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > cap {
+        return Err(Error::InvalidInput(
+            "snapshot file grew past its read cap".into(),
+        ));
+    }
+    Ok(bytes)
+}
+fn describe(path: String, bytes: &[u8]) -> Blob {
+    Blob {
+        path,
+        sha256: fingerprint(bytes),
+        bytes: bytes.len() as u64,
+    }
+}
+fn exists(path: &Path) -> Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e.into()),
+    }
+}
+fn private_dir(path: &Path) -> Result<()> {
+    if exists(path)? {
+        awr_source::open_dir_exact(path)?;
+        return Ok(());
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| Error::InvalidInput("directory needs parent".into()))?;
+    awr_source::open_dir_exact(parent)?;
+    let mut b = fs::DirBuilder::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        b.mode(0o700);
+    }
+    b.create(path)?;
+    sync_dir(parent)
+}
+fn sync_dir(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        File::open(path)?.sync_all()?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+fn write_new(path: &Path, bytes: &[u8], executable: bool) -> Result<()> {
+    awr_source::open_dir_exact(
+        path.parent()
+            .ok_or_else(|| Error::InvalidInput("file needs parent".into()))?,
+    )?;
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(if executable { 0o700 } else { 0o600 });
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = executable;
+    }
+    let mut f = options.open(path)?;
+    f.write_all(bytes)?;
+    f.sync_all()?;
+    sync_dir(path.parent().unwrap())
+}
+fn write_payload(root: &Path, path: &str, bytes: &[u8], executable: bool) -> Result<Blob> {
+    let target = root.join(relative(path)?);
+    let mut parent = root.to_path_buf();
+    for p in relative(path)?.parent().unwrap().components() {
+        parent.push(p.as_os_str());
+        private_dir(&parent)?;
+    }
+    write_new(&target, bytes, executable)?;
+    Ok(describe(path.into(), bytes))
+}
+fn blob_bytes(root: &Path, blob: &Blob) -> Result<Vec<u8>> {
+    let bytes = exact_read(&root.join(relative(&blob.path)?), FILE_CAP)?;
+    if describe(blob.path.clone(), &bytes) != *blob {
+        return Err(conflict(format!("backup payload differs: {}", blob.path)));
+    }
+    Ok(bytes)
+}
+fn seal<T: Serialize>(value: &T) -> Result<String> {
+    // Canonical object ordering permits independent manifest verification by hosts.
+    Ok(fingerprint(&serde_json::to_vec(&serde_json::to_value(
+        value,
+    )?)?))
+}
+fn snapshot_fingerprint(s: &Snapshot) -> Result<String> {
+    let mut copy = s.clone();
+    copy.fingerprint.clear();
+    seal(&copy)
+}
+fn program() -> Result<(Program, Vec<u8>)> {
+    let path = std::env::current_exe()?.canonicalize()?;
+    let bytes = exact_read(&path, FILE_CAP)?;
+    Ok((
+        Program {
+            original_path: path,
+            version: env!("CARGO_PKG_VERSION").into(),
+            binary: describe(CLI_PAYLOAD.into(), &bytes),
+        },
+        bytes,
+    ))
+}
+fn excluded_runtime(path: &str, restore_id: Option<Id>) -> bool {
+    DATABASE_FILES.contains(&path)
+        || path == "state.db-restore.pending"
+        || path.ends_with(".lock")
+        || restore_id.is_some_and(|id| path.starts_with(&format!("restores/{id}/")))
+}
+fn inventory(runtime: &Path, restore_id: Option<Id>) -> Result<BTreeMap<String, Blob>> {
+    let mut files = BTreeMap::new();
+    let mut total = 0;
+    fn walk(
+        root: &Path,
+        dir: &Path,
+        id: Option<Id>,
+        files: &mut BTreeMap<String, Blob>,
+        total: &mut u64,
+    ) -> Result<()> {
+        awr_source::open_dir_exact(dir)?;
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(root)
+                .map_err(|_| conflict("runtime inventory escaped root"))?
+                .to_str()
+                .ok_or_else(|| Error::InvalidInput("runtime names must be UTF-8".into()))?
+                .replace('\\', "/");
+            if excluded_runtime(&relative, id) {
+                continue;
+            }
+            let meta = fs::symlink_metadata(&path)?;
+            if meta.file_type().is_symlink() {
+                return Err(conflict("runtime snapshots refuse symlinked entries"));
+            }
+            if meta.is_dir() {
+                walk(root, &path, id, files, total)?;
+            } else {
+                let bytes = exact_read(&path, FILE_CAP)?;
+                *total += bytes.len() as u64;
+                if *total > TOTAL_CAP || files.len() >= FILE_COUNT {
+                    return Err(Error::InvalidInput(
+                        "runtime snapshot exceeds total size/file cap".into(),
+                    ));
+                }
+                files.insert(
+                    relative.clone(),
+                    describe(format!("runtime/{relative}"), &bytes),
+                );
+            }
+        }
+        Ok(())
+    }
+    walk(runtime, runtime, restore_id, &mut files, &mut total)?;
+    Ok(files)
+}
+fn require_clear(runtime: &Path) -> Result<()> {
+    if exists(&awr_store::restore_pending_path(&runtime.join("state.db")))? {
+        return Err(conflict(
+            "runtime restore is pending; inspect restore-status and recover",
+        ));
+    }
+    Ok(())
+}
+fn sources(store: &Store, root: &Path) -> Result<(String, Vec<(Source, Vec<u8>)>)> {
+    let project = store.project_by_root(root)?;
+    let state = awr_source::source_state_fingerprint(store, project.id)?;
+    let mut check = store.memory_snapshot(FILE_CAP)?;
+    let report = awr_source::index_project(&mut check, root, &Manifest::load(root)?, false)?;
+    if !report.ok || awr_source::source_state_fingerprint(&check, project.id)? != state {
+        return Err(Error::SourceStale("configuration or source inventory differs from recorded state; refresh explicitly before taking a matching snapshot".into()));
+    }
+    let mut content = Vec::new();
+    let mut total = 0;
+    for source in store.sources(project.id)? {
+        if source.freshness != Freshness::Fresh {
+            return Err(Error::SourceStale(
+                "snapshot requires fresh registered sources".into(),
+            ));
+        }
+        let (_, _, snapshot) = awr_source::inspect_registered_source(root, &source)?;
+        if snapshot.fingerprint != source.fingerprint {
+            return Err(conflict("source changed while capturing runtime snapshot"));
+        }
+        total += snapshot.bytes.len() as u64;
+        if total > TOTAL_CAP || content.len() >= FILE_COUNT {
+            return Err(Error::InvalidInput(
+                "source snapshot exceeds total size/file cap".into(),
+            ));
+        }
+        content.push((source, snapshot.bytes));
+    }
+    Ok((state, content))
+}
+fn binding(root: &Path, runtime: &Path) -> Result<Value> {
+    require_clear(runtime)?;
+    let store = Store::read_snapshot(&runtime.join("state.db"), FILE_CAP)?;
+    let project = store.project_by_root(root)?;
+    let doctor = store.doctor()?;
+    if !doctor.ok {
+        return Err(Error::Storage(
+            "snapshot database integrity check failed".into(),
+        ));
+    }
+    let (state, source_bytes) = sources(&store, root)?;
+    let (program, _) = program()?;
+    Ok(
+        json!({"version":1,"read_only":true,"program":program,"schema_version":doctor.schema_version,"project":project,"configuration_fingerprint":fingerprint(&exact_read(&runtime.join("project.toml"),65536)?),"source_state_fingerprint":state,"sources":source_bytes.into_iter().map(|(s,_)|s).collect::<Vec<_>>(),"source_currentness_verified":true,"management_binding_rewritten":false}),
+    )
+}
+fn backup(
+    root: &Path,
+    runtime: &Path,
+    output: &Path,
+    companion: Option<&Path>,
+    source_sha: Option<&str>,
+) -> Result<Value> {
+    require_clear(runtime)?;
+    if source_sha.is_some_and(|s| s.len() != 40 || !s.bytes().all(|b| b.is_ascii_hexdigit())) {
+        return Err(Error::InvalidInput(
+            "source-sha must be a full Git SHA; this remains a caller assertion".into(),
+        ));
+    }
+    let output = if output.is_absolute() {
+        output.to_owned()
+    } else {
+        root.join(output)
+    };
+    let parent = output
+        .parent()
+        .ok_or_else(|| Error::InvalidInput("backup output needs a parent".into()))?
+        .canonicalize()?;
+    let output = parent.join(
+        output
+            .file_name()
+            .ok_or_else(|| Error::InvalidInput("backup output needs a name".into()))?,
+    );
+    if output.starts_with(runtime) || exists(&output)? {
+        return Err(conflict("backup needs a new directory outside .awr"));
+    }
+    let before = inventory(runtime, None)?;
+    let store = Store::read_snapshot(&runtime.join("state.db"), FILE_CAP)?;
+    let project = store.project_by_root(root)?;
+    let doctor = store.doctor()?;
+    if !doctor.ok {
+        return Err(Error::Storage(
+            "backup requires an intact current-schema database".into(),
+        ));
+    }
+    let (state, content) = sources(&store, root)?;
+    let (program, program_bytes) = program()?;
+    let companion = companion
+        .map(|p| -> Result<(Program, Vec<u8>)> {
+            let path = if p.is_absolute() {
+                p.to_owned()
+            } else {
+                root.join(p)
+            }
+            .canonicalize()?;
+            let bytes = exact_read(&path, FILE_CAP)?;
+            Ok((
+                Program {
+                    original_path: path,
+                    version: "caller-selected; bytes verified".into(),
+                    binary: describe(MCP_PAYLOAD.into(), &bytes),
+                },
+                bytes,
+            ))
+        })
+        .transpose()?;
+    private_dir(&output)?; // New, private staging directory. Only a final manifest seals it.
+    write_payload(&output, CLI_PAYLOAD, &program_bytes, true)?;
+    if let Some((_, bytes)) = &companion {
+        write_payload(&output, MCP_PAYLOAD, bytes, true)?;
+    }
+    private_dir(&output.join("runtime"))?;
+    store.export_snapshot(&output.join("runtime/state.db"))?;
+    let database = describe(
+        "runtime/state.db".into(),
+        &exact_read(&output.join("runtime/state.db"), FILE_CAP)?,
+    );
+    for (path, expected) in &before {
+        let bytes = exact_read(&runtime.join(relative(path)?), FILE_CAP)?;
+        if describe(expected.path.clone(), &bytes) != *expected {
+            return Err(conflict(
+                "runtime files changed during backup; discard the unsealed directory and retry",
+            ));
+        }
+        write_payload(&output, &expected.path, &bytes, false)?;
+    }
+    let mut copies = Vec::new();
+    for (source, bytes) in content {
+        let payload = write_payload(
+            &output,
+            &format!("sources/{}.bin", source.id),
+            &bytes,
+            false,
+        )?;
+        copies.push(SourceCopy {
+            source,
+            content: payload,
+        });
+    }
+    if inventory(runtime, None)? != before || sources(&store, root)?.0 != state {
+        return Err(conflict(
+            "snapshot inputs changed; output remains unsealed, retry with a new directory",
+        ));
+    }
+    let mut snapshot = Snapshot {
+        version: 1,
+        id: Id::new(),
+        created_at: awr_core::now_millis()?,
+        project_root: root.to_owned(),
+        project_id: project.id,
+        project_revision: project.project_revision,
+        schema_version: doctor.schema_version,
+        program,
+        companion: companion.map(|(p, _)| p),
+        caller_source_sha: source_sha.map(str::to_owned),
+        source_state_fingerprint: state,
+        sources: copies,
+        runtime_files: before,
+        database,
+        fingerprint: String::new(),
+    };
+    let total = snapshot.database.bytes
+        + snapshot.program.binary.bytes
+        + snapshot.companion.as_ref().map_or(0, |p| p.binary.bytes)
+        + snapshot
+            .runtime_files
+            .values()
+            .map(|b| b.bytes)
+            .sum::<u64>()
+        + snapshot
+            .sources
+            .iter()
+            .map(|s| s.content.bytes)
+            .sum::<u64>();
+    if total > TOTAL_CAP || snapshot.runtime_files.len() + snapshot.sources.len() + 3 > FILE_COUNT {
+        return Err(Error::InvalidInput(
+            "combined backup exceeds total size/file cap; output remains unsealed".into(),
+        ));
+    }
+    snapshot.fingerprint = snapshot_fingerprint(&snapshot)?;
+    write_new(
+        &output.join("snapshot.json"),
+        &serde_json::to_vec_pretty(&snapshot)?,
+        false,
+    )?;
+    Ok(
+        json!({"phase":"completed","backup":output,"snapshot":snapshot,"scope":"registered_sources_and_persistent_awr_runtime","excluded":"external artifacts, host-owned state outside .awr, unregistered business files, transient locks","management_binding_rewritten":false,"source_sha_provenance":"caller_assertion_only"}),
+    )
+}
+fn checked(backup: &Path) -> Result<(PathBuf, Snapshot, Store)> {
+    let root = backup.canonicalize()?;
+    awr_source::open_dir_exact(&root)?;
+    let snapshot: Snapshot =
+        serde_json::from_slice(&exact_read(&root.join("snapshot.json"), 16 * 1024 * 1024)?)?;
+    if snapshot.version != 1
+        || snapshot.schema_version != awr_store::SCHEMA_VERSION
+        || snapshot.fingerprint != snapshot_fingerprint(&snapshot)?
+    {
+        return Err(conflict("unsupported or altered snapshot manifest"));
+    }
+    if snapshot.database.path != "runtime/state.db"
+        || snapshot.program.binary.path != CLI_PAYLOAD
+        || snapshot
+            .companion
+            .as_ref()
+            .is_some_and(|p| p.binary.path != MCP_PAYLOAD)
+    {
+        return Err(conflict("invalid snapshot payload layout"));
+    }
+    let mut payloads = vec![&snapshot.database, &snapshot.program.binary];
+    if let Some(c) = &snapshot.companion {
+        payloads.push(&c.binary);
+    }
+    let mut names = BTreeSet::new();
+    let mut total = 0;
+    for (name, blob) in &snapshot.runtime_files {
+        relative(name)?;
+        if excluded_runtime(name, None) || blob.path != format!("runtime/{name}") {
+            return Err(conflict("invalid runtime file binding"));
+        }
+        payloads.push(blob);
+    }
+    if !snapshot.runtime_files.contains_key("project.toml") {
+        return Err(conflict("snapshot has no project configuration"));
+    }
+    for copy in &snapshot.sources {
+        if copy.content.path != format!("sources/{}.bin", copy.source.id)
+            || copy.content.sha256 != copy.source.fingerprint
+        {
+            return Err(conflict("source payload binding differs"));
+        }
+        payloads.push(&copy.content);
+    }
+    for blob in payloads {
+        if blob.bytes > FILE_CAP {
+            return Err(Error::InvalidInput(
+                "snapshot payload exceeds file cap".into(),
+            ));
+        }
+        if !names.insert(&blob.path) {
+            return Err(conflict("duplicate snapshot payload"));
+        }
+        total += blob.bytes;
+        if total > TOTAL_CAP || names.len() > FILE_COUNT {
+            return Err(Error::InvalidInput(
+                "snapshot exceeds total size/file cap".into(),
+            ));
+        }
+        blob_bytes(&root, blob)?;
+    }
+    for suffix in ["-wal", "-shm", "-journal", "-restore.pending"] {
+        if exists(&root.join(format!("runtime/state.db{suffix}")))? {
+            return Err(conflict(
+                "sealed database must not have sidecars or a pending restore",
+            ));
+        }
+    }
+    let store = Store::read_snapshot(&root.join("runtime/state.db"), FILE_CAP)?;
+    let project = store.project_by_root(&snapshot.project_root)?;
+    if !store.doctor()?.ok
+        || project.id != snapshot.project_id
+        || project.project_revision != snapshot.project_revision
+        || awr_source::source_state_fingerprint(&store, project.id)?
+            != snapshot.source_state_fingerprint
+        || serde_json::to_value(store.sources(project.id)?)?
+            != serde_json::to_value(
+                snapshot
+                    .sources
+                    .iter()
+                    .map(|s| &s.source)
+                    .collect::<Vec<_>>(),
+            )?
+    {
+        return Err(conflict(
+            "database identity, history or source bindings differ from snapshot",
+        ));
+    }
+    Ok((root, snapshot, store))
+}
+fn database_files(runtime: &Path) -> Result<BTreeMap<String, Option<Blob>>> {
+    DATABASE_FILES
+        .into_iter()
+        .map(|name| {
+            let path = runtime.join(name);
+            Ok((
+                name.into(),
+                if exists(&path)? {
+                    Some(describe(name.into(), &exact_read(&path, FILE_CAP)?))
+                } else {
+                    None
+                },
+            ))
+        })
+        .collect()
+}
+fn matches_target(
+    root: &Path,
+    runtime: &Path,
+    snapshot: &Snapshot,
+    store: &Store,
+    id: Option<Id>,
+) -> Result<BTreeMap<String, Blob>> {
+    if snapshot.project_root != root {
+        return Err(conflict(
+            "restore is bound to the original canonical project root",
+        ));
+    }
+    if program()?.0.binary.sha256 != snapshot.program.binary.sha256
+        || snapshot.program.version != env!("CARGO_PKG_VERSION")
+    {
+        return Err(conflict(
+            "executing CLI differs from backup; explicitly run the retained matching executable",
+        ));
+    }
+    if let Some(p) = &snapshot.companion {
+        if fingerprint(&exact_read(&p.original_path, FILE_CAP)?) != p.binary.sha256 {
+            return Err(conflict(
+                "companion executable no longer matches its backup binding",
+            ));
+        }
+    }
+    let inventory = inventory(runtime, id)?;
+    for (name, expected) in &snapshot.runtime_files {
+        if inventory.get(name) != Some(expected) {
+            return Err(conflict(format!(
+                "known runtime/configuration file changed or is missing: {name}; restore never overwrites it"
+            )));
+        }
+    }
+    if sources(store, root)?.0 != snapshot.source_state_fingerprint {
+        return Err(conflict("authoritative sources no longer match backup"));
+    }
+    Ok(inventory
+        .into_iter()
+        .filter(|(name, _)| !snapshot.runtime_files.contains_key(name))
+        .collect())
+}
+fn preview(
+    root: &Path,
+    runtime: &Path,
+    backup: &Path,
+    lease: Option<&RuntimeLease>,
+) -> Result<Value> {
+    require_clear(runtime)?;
+    let (backup, snapshot, store) = checked(backup)?;
+    let added = matches_target(root, runtime, &snapshot, &store, None)?;
+    let before = database_files(runtime)?;
+    let current = if let Some(lease) = lease {
+        Store::read_snapshot_with_lease(&runtime.join("state.db"), FILE_CAP, lease)
+    } else {
+        Store::read_snapshot(&runtime.join("state.db"), FILE_CAP)
+    };
+    let (revision, currentness) = match current {
+        Ok(current) => {
+            let p = current.project_by_root(root)?;
+            if p.id != snapshot.project_id {
+                return Err(conflict("target database belongs to another project"));
+            }
+            if awr_source::source_state_fingerprint(&current, p.id)?
+                != snapshot.source_state_fingerprint
+            {
+                return Err(conflict("current database has different source bindings"));
+            }
+            (Some(p.project_revision), "owned_current_schema")
+        }
+        Err(error) => {
+            if before.values().any(Option::is_some) {
+                return Err(conflict(format!(
+                    "target database ownership cannot be verified; retain and inspect it before recovery: {error}"
+                )));
+            }
+            (
+                None,
+                "missing; ownership bound by matching backup/configuration/sources",
+            )
+        }
+    };
+    if database_files(runtime)? != before {
+        return Err(conflict(
+            "target database changed during restore preview; retry offline",
+        ));
+    }
+    let mut value = json!({"version":1,"phase":"preview","read_only":true,"project_root":root,"project_id":snapshot.project_id,"backup":backup,"backup_fingerprint":snapshot.fingerprint,"program_sha256":snapshot.program.binary.sha256,"current_revision":revision,"current_database":currentness,"restore_revision":snapshot.project_revision,"before_database":before,"preserved_additional_runtime_files":added,"source_files_overwritten":0,"known_runtime_files_overwritten":0,"offline_required":true,"history_after_restore_revision_will_be_removed":revision.is_some_and(|r|r>snapshot.project_revision),"rollback_retained":true});
+    value["fingerprint"] = json!(seal(&value)?);
+    Ok(value)
+}
+fn journal_path(runtime: &Path, id: Id) -> PathBuf {
+    runtime
+        .join("restores")
+        .join(id.to_string())
+        .join("receipt.json")
+}
+fn save_journal(runtime: &Path, journal: &RestoreJournal) -> Result<()> {
+    let path = journal_path(runtime, journal.id);
+    let parent = path.parent().unwrap();
+    let tmp = parent.join(format!("receipt-{}.tmp", Id::new()));
+    write_new(&tmp, &serde_json::to_vec_pretty(journal)?, false)?;
+    let dir = awr_source::open_dir_exact(parent)?;
+    dir.rename(tmp.file_name().unwrap(), &dir, path.file_name().unwrap())?;
+    sync_dir(parent)
+}
+fn pending_id(runtime: &Path) -> Result<Id> {
+    let bytes = exact_read(
+        &awr_store::restore_pending_path(&runtime.join("state.db")),
+        128,
+    )?;
+    std::str::from_utf8(&bytes)
+        .map_err(|_| conflict("invalid restore marker"))?
+        .parse()
+        .map_err(|_| conflict("invalid restore marker"))
+}
+fn read_journal(runtime: &Path, id: Id) -> Result<RestoreJournal> {
+    let journal: RestoreJournal =
+        serde_json::from_slice(&exact_read(&journal_path(runtime, id), 16 * 1024 * 1024)?)?;
+    if journal.version != 1
+        || journal.id != id
+        || !["prepared", "completed"].contains(&journal.phase.as_str())
+    {
+        return Err(conflict("restore receipt identity differs"));
+    }
+    Ok(journal)
+}
+fn finish_restore(
+    root: &Path,
+    runtime: &Path,
+    mut journal: RestoreJournal,
+    lease: &RuntimeLease,
+) -> Result<Value> {
+    if journal.project_root != root || pending_id(runtime)? != journal.id {
+        return Err(conflict("pending restore project identity differs"));
+    }
+    let (backup, snapshot, store) = checked(&journal.backup)?;
+    if snapshot.fingerprint != journal.backup_fingerprint
+        || snapshot.project_id != journal.project_id
+        || snapshot.project_revision != journal.restored_revision
+    {
+        return Err(conflict("pending restore backup differs"));
+    }
+    matches_target(root, runtime, &snapshot, &store, Some(journal.id))?;
+    if journal
+        .before_database
+        .keys()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        != DATABASE_FILES
+            .into_iter()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+    {
+        return Err(conflict("invalid recorded database inventory"));
+    }
+    let journal_dir = journal_path(runtime, journal.id)
+        .parent()
+        .unwrap()
+        .to_owned();
+    for (name, blob) in &journal.rollback {
+        if !DATABASE_FILES.contains(&name.as_str()) || blob.path != format!("rollback/{name}") {
+            return Err(conflict("invalid rollback binding"));
+        }
+        let bytes = blob_bytes(&journal_dir, blob)?;
+        if journal.before_database.get(name) != Some(&Some(describe(name.clone(), &bytes))) {
+            return Err(conflict("rollback bytes differ from recorded database"));
+        }
+    }
+    for (name, before) in &journal.before_database {
+        if before.is_some() != journal.rollback.contains_key(name) {
+            return Err(conflict("incomplete rollback snapshot"));
+        }
+    }
+    let current = database_files(runtime)?;
+    let installed = current["state.db"].as_ref().is_some_and(|b| {
+        b.sha256 == snapshot.database.sha256 && b.bytes == snapshot.database.bytes
+    });
+    if installed {
+        if DATABASE_FILES[1..].iter().any(|n| current[*n].is_some()) {
+            return Err(conflict(
+                "restored database acquired new sidecars; recovery refuses external changes",
+            ));
+        }
+    } else {
+        if current["state.db"] != journal.before_database["state.db"]
+            || DATABASE_FILES[1..]
+                .iter()
+                .any(|n| current[*n].is_some() && current[*n] != journal.before_database[*n])
+        {
+            return Err(conflict(
+                "database bytes changed outside the recorded restore; retain pending state for inspection",
+            ));
+        }
+        if journal.phase == "completed" {
+            return Err(conflict(
+                "completed restore database no longer matches; never replay history replacement",
+            ));
+        }
+        let candidate = journal_dir.join("candidate.db");
+        let bytes = blob_bytes(&backup, &snapshot.database)?;
+        if exists(&candidate)? {
+            if exact_read(&candidate, FILE_CAP)? != bytes {
+                return Err(conflict("staged restore bytes changed"));
+            }
+        } else {
+            write_new(&candidate, &bytes, false)?;
+        }
+        // Last compare before the replacement. Pending marker + lease block cooperating clients.
+        if database_files(runtime)? != current {
+            return Err(conflict("database changed before restore replacement"));
+        }
+        let dir = awr_source::open_dir_exact(runtime)?;
+        for name in &DATABASE_FILES[1..] {
+            if current[*name].is_some() {
+                dir.remove_file(name)?;
+            }
+        }
+        let from = awr_source::open_dir_exact(&journal_dir)?;
+        from.rename("candidate.db", &dir, "state.db")?;
+        sync_dir(runtime)?;
+    }
+    let restored = Store::read_snapshot_with_lease(&runtime.join("state.db"), FILE_CAP, lease)?;
+    let p = restored.project_by_root(root)?;
+    if !restored.doctor()?.ok
+        || p.id != snapshot.project_id
+        || p.project_revision != snapshot.project_revision
+    {
+        return Err(conflict(
+            "restored database validation failed; rollback retained and opens remain blocked",
+        ));
+    }
+    journal.phase = "completed".into();
+    save_journal(runtime, &journal)?;
+    fs::remove_file(awr_store::restore_pending_path(&runtime.join("state.db")))?;
+    sync_dir(runtime)?;
+    Ok(
+        json!({"phase":"completed","restore_id":journal.id,"project_id":p.id,"project_revision":p.project_revision,"receipt":journal_path(runtime,journal.id),"rollback":journal_dir.join("rollback"),"source_files_overwritten":0,"known_runtime_files_overwritten":0,"next_action":"Restart clients, inspect doctor findings and explicitly compile fresh context; do not replay old host requests."}),
+    )
+}
+fn restore(
+    root: &Path,
+    runtime: &Path,
+    backup: &Path,
+    expected: &str,
+    offline: bool,
+) -> Result<Value> {
+    if !offline {
+        return Err(Error::InvalidInput(
+            "restore requires explicit offline acknowledgement".into(),
+        ));
+    }
+    require_clear(runtime)?;
+    let lease = RuntimeLease::exclusive(&runtime.join("state.db"))?;
+    let plan = preview(root, runtime, backup, Some(&lease))?;
+    if plan["fingerprint"].as_str() != Some(expected) {
+        return Err(conflict("restore preview is stale; review a new preview"));
+    }
+    let (backup, snapshot, _) = checked(backup)?;
+    let before_database = database_files(runtime)?;
+    if serde_json::to_value(&before_database)? != plan["before_database"] {
+        return Err(conflict("database changed after reviewed preview"));
+    }
+    let id = Id::new();
+    private_dir(&runtime.join("restores"))?;
+    let dir = runtime.join("restores").join(id.to_string());
+    private_dir(&dir)?;
+    private_dir(&dir.join("rollback"))?;
+    let mut rollback = BTreeMap::new();
+    for (name, before) in &before_database {
+        if let Some(before) = before {
+            let bytes = exact_read(&runtime.join(name), FILE_CAP)?;
+            if describe(name.clone(), &bytes) != *before {
+                return Err(conflict("database changed while retaining rollback"));
+            }
+            rollback.insert(
+                name.clone(),
+                write_payload(&dir, &format!("rollback/{name}"), &bytes, false)?,
+            );
+        }
+    }
+    let journal = RestoreJournal {
+        version: 1,
+        id,
+        phase: "prepared".into(),
+        created_at: awr_core::now_millis()?,
+        project_root: root.to_owned(),
+        project_id: snapshot.project_id,
+        backup,
+        backup_fingerprint: snapshot.fingerprint,
+        preview: plan,
+        before_database,
+        rollback,
+        restored_revision: snapshot.project_revision,
+    };
+    save_journal(runtime, &journal)?;
+    write_new(
+        &awr_store::restore_pending_path(&runtime.join("state.db")),
+        id.to_string().as_bytes(),
+        false,
+    )?;
+    finish_restore(root, runtime, journal, &lease)
+}
+
+pub fn run(root: &Path, command: &RuntimeCommand, _json_output: bool) -> Result<()> {
+    // Backup checking does not require the original project to exist.
+    let value = if let RuntimeCommand::Check { backup } = command {
+        let backup = if backup.is_absolute() {
+            backup.to_owned()
+        } else {
+            root.join(backup)
+        };
+        let (path, snapshot, _) = checked(&backup)?;
+        json!({"phase":"verified","read_only":true,"backup":path,"snapshot":snapshot,"target_matches_checked":false})
+    } else {
+        let root = root.canonicalize()?;
+        let runtime = crate::source::runtime_dir(&root, false)?;
+        awr_source::open_dir_exact(&runtime)?;
+        let resolve = |p: &Path| {
+            if p.is_absolute() {
+                p.to_owned()
+            } else {
+                root.join(p)
+            }
+        };
+        match command {
+            RuntimeCommand::Binding => binding(&root, &runtime)?,
+            RuntimeCommand::Backup {
+                output,
+                companion,
+                source_sha,
+            } => backup(
+                &root,
+                &runtime,
+                output,
+                companion.as_deref(),
+                source_sha.as_deref(),
+            )?,
+            RuntimeCommand::RestorePreview { backup } => {
+                preview(&root, &runtime, &resolve(backup), None)?
+            }
+            RuntimeCommand::Restore {
+                backup,
+                expected_preview,
+                offline,
+            } => restore(
+                &root,
+                &runtime,
+                &resolve(backup),
+                expected_preview,
+                *offline,
+            )?,
+            RuntimeCommand::RestoreStatus { id } => {
+                let pending = exists(&awr_store::restore_pending_path(&runtime.join("state.db")))?;
+                let id = if let Some(id) = id {
+                    Some(*id)
+                } else if pending {
+                    Some(pending_id(&runtime)?)
+                } else {
+                    None
+                };
+                json!({"read_only":true,"pending":pending,"receipt":id.map(|id|read_journal(&runtime,id)).transpose()?})
+            }
+            RuntimeCommand::RestoreRecover { offline } => {
+                if !offline {
+                    return Err(Error::InvalidInput(
+                        "recovery requires explicit offline acknowledgement".into(),
+                    ));
+                }
+                let lease = RuntimeLease::exclusive(&runtime.join("state.db"))?;
+                let id = pending_id(&runtime)?;
+                finish_restore(&root, &runtime, read_journal(&runtime, id)?, &lease)?
+            }
+            RuntimeCommand::Check { .. } => unreachable!(),
+        }
+    };
+    println!("{}", serde_json::to_string_pretty(&value)?);
+    Ok(())
+}

--- a/crates/awr-cli/src/runtime_snapshot.rs
+++ b/crates/awr-cli/src/runtime_snapshot.rs
@@ -97,6 +97,7 @@ struct Program {
 #[serde(deny_unknown_fields)]
 struct SourceCopy {
     source: Source,
+    observed_locator: String,
     content: Blob,
 }
 #[derive(Clone, Serialize, Deserialize)]
@@ -330,7 +331,10 @@ fn require_clear(runtime: &Path) -> Result<()> {
     }
     Ok(())
 }
-fn sources(store: &Store, root: &Path) -> Result<(String, Vec<(Source, Vec<u8>)>)> {
+fn sources(
+    store: &Store,
+    root: &Path,
+) -> Result<(String, Vec<(Source, awr_source::SourceSnapshot)>)> {
     let project = store.project_by_root(root)?;
     let state = awr_source::source_state_fingerprint(store, project.id)?;
     let mut check = store.memory_snapshot(FILE_CAP)?;
@@ -356,7 +360,7 @@ fn sources(store: &Store, root: &Path) -> Result<(String, Vec<(Source, Vec<u8>)>
                 "source snapshot exceeds total size/file cap".into(),
             ));
         }
-        content.push((source, snapshot.bytes));
+        content.push((source, snapshot));
     }
     Ok((state, content))
 }
@@ -457,15 +461,16 @@ fn backup(
         write_payload(&output, &expected.path, &bytes, false)?;
     }
     let mut copies = Vec::new();
-    for (source, bytes) in content {
+    for (source, observed) in content {
         let payload = write_payload(
             &output,
             &format!("sources/{}.bin", source.id),
-            &bytes,
+            &observed.bytes,
             false,
         )?;
         copies.push(SourceCopy {
             source,
+            observed_locator: observed.locator,
             content: payload,
         });
     }
@@ -556,9 +561,7 @@ fn checked(backup: &Path) -> Result<(PathBuf, Snapshot, Store)> {
         return Err(conflict("snapshot has no project configuration"));
     }
     for copy in &snapshot.sources {
-        if copy.content.path != format!("sources/{}.bin", copy.source.id)
-            || copy.content.sha256 != copy.source.fingerprint
-        {
+        if copy.content.path != format!("sources/{}.bin", copy.source.id) {
             return Err(conflict("source payload binding differs"));
         }
         payloads.push(&copy.content);
@@ -579,6 +582,29 @@ fn checked(backup: &Path) -> Result<(PathBuf, Snapshot, Store)> {
             ));
         }
         blob_bytes(&root, blob)?;
+    }
+    for copy in &snapshot.sources {
+        let observed = awr_source::SourceSnapshot {
+            locator: copy.observed_locator.clone(),
+            fingerprint: copy.source.fingerprint.clone(),
+            bytes: blob_bytes(&root, &copy.content)?,
+        };
+        let location_matches = if let Some(original) = copy.source.locator.strip_prefix("git://") {
+            let original_path = original.split_once(':').map(|(_, p)| p);
+            let observed_path = observed
+                .locator
+                .strip_prefix("git://")
+                .and_then(|s| s.split_once(':'))
+                .map(|(_, p)| p);
+            original_path.is_some() && original_path == observed_path
+        } else {
+            copy.source.locator == observed.locator
+        };
+        if !location_matches || !observed.verify_fingerprint() {
+            return Err(conflict(
+                "source bytes or resolved locator differ from recorded fingerprint",
+            ));
+        }
     }
     for suffix in ["-wal", "-shm", "-journal", "-restore.pending"] {
         if exists(&root.join(format!("runtime/state.db{suffix}")))? {

--- a/crates/awr-cli/src/search.rs
+++ b/crates/awr-cli/src/search.rs
@@ -16,9 +16,12 @@ pub struct SearchArgs {
     work_item_key: Option<String>,
     #[arg(long, default_value_t = 10)]
     limit: usize,
+    /// Read last recorded facts without refreshing authoritative files.
+    #[arg(long)]
+    cached: bool,
 }
 pub fn run(root: &Path, args: &SearchArgs, json_output: bool) -> Result<()> {
-    let mut project = QueryProject::open(root)?;
+    let mut project = QueryProject::open_read(root, args.cached)?;
     let kind = args.kind.as_ref().map(|s| {
         if s == "work" {
             "work_item".into()

--- a/crates/awr-cli/src/source.rs
+++ b/crates/awr-cli/src/source.rs
@@ -142,10 +142,9 @@ pub fn initialize(
         })
     })?;
     manifest.validate()?;
-    if expected_preview.is_some() {
-        let plan = crate::intake_plan::preview(&root, &manifest, &BTreeMap::new(), false)?;
-        crate::intake_plan::check_expected(&plan, expected_preview)?;
-    }
+    let plan = crate::intake_plan::preview(&root, &manifest, &BTreeMap::new(), false)?;
+    crate::intake_plan::check_expected(&plan, expected_preview)?;
+    crate::intake_plan::require_applicable(&plan)?;
     if existing.is_none() && root.join(".awr/state.db").exists() {
         return Err(Error::SourceConflict("database exists without project.toml; restore its matching manifest before initializing".into()));
     }
@@ -277,6 +276,7 @@ fn configure(
         ));
     }
     crate::intake_plan::check_expected(&plan, expected)?;
+    crate::intake_plan::require_applicable(&plan)?;
     if root.metadata()?.permissions().readonly() {
         return Err(Error::RuleViolation(
             "project directory is read-only".into(),
@@ -304,6 +304,7 @@ fn configure(
     let _lock = crate::client::lock(&root, "mutations", "source-configuration")?;
     let current = crate::intake_plan::preview(&root, &candidate, &BTreeMap::new(), true)?;
     crate::intake_plan::check_expected(&current, expected)?;
+    crate::intake_plan::require_applicable(&current)?;
     let permissions = awr_source::open_file_exact(&root.join(".awr/project.toml"))?
         .metadata()?
         .permissions();

--- a/crates/awr-cli/src/source.rs
+++ b/crates/awr-cli/src/source.rs
@@ -12,6 +12,12 @@ use std::{
 
 #[derive(Debug, Subcommand)]
 pub enum SourceCommand {
+    /// Preview or accept a single file-source binding relocation; content must be unchanged.
+    Relocate(crate::source_relocation::RelocateArgs),
+    /// Inspect a relocation receipt and current source/configuration bindings without refreshing.
+    RelocateStatus { fingerprint: String },
+    /// Resume a reviewed interrupted relocation after validating its saved before/after state.
+    RelocateRecover { fingerprint: String },
     /// Read source lifecycle/change receipts in an immutable event window without refreshing files.
     Changes(crate::source_changes::ChangesArgs),
     /// Preview or apply an exact replacement source mapping while preserving project identity.
@@ -302,6 +308,16 @@ fn configure(
         return Ok(());
     }
     let _lock = crate::client::lock(&root, "mutations", "source-configuration")?;
+    let mut store = Store::open_existing(&runtime.join("state.db"))?;
+    let guard = store.lock_sources()?;
+    if root
+        .join(".awr/mutations/source-relocation.pending")
+        .exists()
+    {
+        return Err(Error::SourceConflict(
+            "source relocation pending; recover it before configuring sources".into(),
+        ));
+    }
     let current = crate::intake_plan::preview(&root, &candidate, &BTreeMap::new(), true)?;
     crate::intake_plan::check_expected(&current, expected)?;
     crate::intake_plan::require_applicable(&current)?;
@@ -352,10 +368,8 @@ fn configure(
     directory.rename(&stage, &directory, "project.toml")?;
     receipt["write_outcome"] = serde_json::json!("applied");
     receipt["configuration_write_performed"] = serde_json::json!(true);
-    let indexed = (|| -> Result<awr_source::IndexReport> {
-        let mut store = Store::open(&runtime.join("state.db"))?;
-        index_project(&mut store, &root, &candidate, false)
-    })();
+    let indexed =
+        awr_source::index_project_locked(&mut store, &root, &candidate, false, &guard, None);
     let failure = match indexed {
         Ok(report) => {
             let failed = !report.ok;
@@ -385,7 +399,7 @@ fn configure(
     Ok(())
 }
 
-fn save_configuration_receipt(directory: &Path, receipt: &Value) -> Result<()> {
+pub(crate) fn save_configuration_receipt(directory: &Path, receipt: &Value) -> Result<()> {
     let dir = awr_source::open_dir_exact(directory)?;
     let stage = format!("receipt-{}.tmp", awr_core::Id::new());
     let mut options = cap_std::fs::OpenOptions::new();
@@ -523,6 +537,13 @@ pub(crate) fn discover(root: &Path) -> Result<(Option<Manifest>, Vec<Value>, Vec
 
 pub fn run(root: &Path, command: &SourceCommand, json_output: bool) -> Result<()> {
     match command {
+        SourceCommand::Relocate(args) => return crate::source_relocation::run(root, args),
+        SourceCommand::RelocateStatus { fingerprint } => {
+            return crate::source_relocation::status(root, fingerprint);
+        }
+        SourceCommand::RelocateRecover { fingerprint } => {
+            return crate::source_relocation::recover(root, fingerprint);
+        }
         SourceCommand::Changes(args) => return crate::source_changes::run(root, args, json_output),
         SourceCommand::ConfigureStatus {
             preview_fingerprint,
@@ -554,7 +575,10 @@ pub fn run(root: &Path, command: &SourceCommand, json_output: bool) -> Result<()
     let manifest = Manifest::load(&root)?;
     let runtime = runtime_dir(&root, false)?;
     match command {
-        SourceCommand::Configure { .. }
+        SourceCommand::Relocate(_)
+        | SourceCommand::RelocateStatus { .. }
+        | SourceCommand::RelocateRecover { .. }
+        | SourceCommand::Configure { .. }
         | SourceCommand::Changes(_)
         | SourceCommand::ConfigureStatus { .. }
         | SourceCommand::Show(_)

--- a/crates/awr-cli/src/source_changes.rs
+++ b/crates/awr-cli/src/source_changes.rs
@@ -49,7 +49,7 @@ pub fn run(root: &Path, args: &ChangesArgs, _json_output: bool) -> Result<()> {
         let count=event.payload["changes"].as_array().map(Vec::len);
         let content_changed=supported && before["fingerprint"]!=after["fingerprint"] && after["fingerprint"].as_str().is_some_and(|s|!s.is_empty());
         let membership_changed=matches!(event.event_type.as_str(),"source.registered"|"source.retired");
-        let configuration_changed=event.event_type=="source.configured";
+        let configuration_changed=matches!(event.event_type.as_str(),"source.configured"|"source.relocated");
         let freshness_changed=before["freshness"]!=after["freshness"];
         json!({"event_id":event.id,"event_type":event.event_type,"project_revision":event.project_revision,"created_at":event.created_at,"source_id":event.payload["source_id"],"change_schema":event.payload["change_schema"],"change_details_available":supported,
             "before":before,"after":after,"content_changed":if supported {Some(content_changed)}else{None},"membership_changed":membership_changed,"configuration_changed":configuration_changed,"freshness_changed":freshness_changed,

--- a/crates/awr-cli/src/source_relocation.rs
+++ b/crates/awr-cli/src/source_relocation.rs
@@ -1,0 +1,421 @@
+//! Single-source relocation with an explicit, recoverable identity binding.
+use awr_core::{Error, Id, Result, Source};
+use awr_source::{
+    Locator, Manifest, ParseContext, SourceSpec, fingerprint, source_adapter, source_configuration,
+    source_read_cap,
+};
+use awr_store::Store;
+use clap::Args;
+use serde_json::{Value, json};
+use std::{
+    fs,
+    io::Write,
+    path::{Component, Path, PathBuf},
+};
+
+#[derive(Debug, Args)]
+pub struct RelocateArgs {
+    #[arg(long)]
+    pub source: Id,
+    /// Existing destination file inside this project, with unchanged contents.
+    #[arg(long)]
+    pub to: PathBuf,
+    #[arg(long)]
+    pub accept: bool,
+    #[arg(long, requires = "accept")]
+    pub expected_preview: Option<String>,
+}
+const MARKER: &str = ".awr/mutations/source-relocation.pending";
+fn relative(path: &Path) -> Result<()> {
+    if path.is_absolute()
+        || path.as_os_str().is_empty()
+        || path
+            .components()
+            .any(|c| !matches!(c, Component::Normal(_) | Component::CurDir))
+    {
+        return Err(Error::RuleViolation(
+            "relocation paths must be relative files inside this project".into(),
+        ));
+    }
+    Ok(())
+}
+fn read(root: &Path, path: &str) -> Result<Option<Vec<u8>>> {
+    crate::intake_plan::current(root, path, awr_source::YAML_READ_CAP)
+}
+fn directory(root: &Path, key: &str) -> Result<PathBuf> {
+    let hash = key.strip_prefix("sha256:").ok_or_else(|| {
+        Error::InvalidInput("relocation requires its SHA256 preview fingerprint".into())
+    })?;
+    if hash.len() != 64 || !hash.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(Error::InvalidInput("invalid relocation fingerprint".into()));
+    }
+    Ok(root
+        .join(".awr/mutations")
+        .join(format!("source-relocate-{hash}")))
+}
+fn plan(root: &Path, args: &RelocateArgs) -> Result<Value> {
+    relative(&args.to)?;
+    let manifest = Manifest::load(root)?;
+    let mut store = Store::preview_snapshot(&root.join(".awr/state.db"), 256 * 1024 * 1024)?;
+    let project = store.project_by_root(root)?;
+    let source = store.source(project.id, args.source)?;
+    if source.fingerprint.is_empty() {
+        return Err(Error::SourceStale(
+            "relocation requires an indexed source baseline".into(),
+        ));
+    }
+    let index = manifest
+        .sources
+        .iter()
+        .position(|s| source_configuration(s, false)["mapping_key"] == source.config["mapping_key"])
+        .ok_or_else(|| {
+            Error::SourceConflict("source is not bound to the current manifest".into())
+        })?;
+    let previous = &manifest.sources[index];
+    let old_path = previous.path.as_ref().ok_or_else(|| {
+        Error::Unsupported("relocation currently requires a file path mapping".into())
+    })?;
+    relative(old_path)?;
+    if previous.adapter == "markdown-directory-v1" {
+        return Err(Error::Unsupported(
+            "relocate one explicitly mapped file, not a directory inventory".into(),
+        ));
+    }
+    if Locator::File(root.join(old_path)).identity()? != source.locator {
+        return Err(Error::SourceConflict(
+            "source path and retained identity do not match".into(),
+        ));
+    }
+    let old_bytes = crate::intake_plan::current(
+        root,
+        old_path
+            .to_str()
+            .ok_or_else(|| Error::InvalidInput("source path must be UTF-8".into()))?,
+        source_read_cap(&source.adapter)?,
+    )?;
+    if old_bytes
+        .as_ref()
+        .is_some_and(|b| fingerprint(b) != source.fingerprint)
+    {
+        return Err(Error::SourceConflict(
+            "original source changed; reindex it before relocating".into(),
+        ));
+    }
+    let mut candidate = manifest.clone();
+    candidate.sources[index].path = Some(args.to.clone());
+    candidate.sources[index].locator = None;
+    candidate.validate()?;
+    let spec = &candidate.sources[index];
+    let locator = Locator::from_spec(root, &candidate, spec)?;
+    if !matches!(&locator, Locator::File(p) if p.starts_with(root)) {
+        return Err(Error::RuleViolation(
+            "relocation target escapes the project".into(),
+        ));
+    }
+    let snapshot = locator.read(root, source_read_cap(&source.adapter)?)?;
+    if snapshot.fingerprint != source.fingerprint {
+        return Err(Error::SourceConflict(
+            "relocation requires unchanged contents; edit and refresh separately".into(),
+        ));
+    }
+    let old_ids = store.projection_ids(&source)?;
+    let config = source_configuration(
+        spec,
+        manifest.project.context_profile == awr_source::ContextProfile::Minimal,
+    );
+    let guard = store.lock_sources()?;
+    let moved = store.relocate_source(&source, &snapshot.locator, config.clone(), &guard)?;
+    let adapter = source_adapter(&source.adapter)?;
+    let batch = adapter.parse(
+        &snapshot,
+        &ParseContext {
+            source: &moved,
+            existing_ids: old_ids.clone(),
+        },
+        spec,
+    )?;
+    adapter.project(&mut store, &moved, &snapshot, batch)?;
+    if store.projection_ids(&moved)? != old_ids {
+        return Err(Error::Unsupported("adapter keys depend on the old locator; identity-preserving relocation is unavailable for this mapping".into()));
+    }
+    let after =
+        toml::to_string_pretty(&candidate).map_err(|e| Error::InvalidInput(e.to_string()))?;
+    let effect = crate::intake_plan::effect(root, ".awr/project.toml", after)?;
+    let mut plan = json!({"version":1,"operation":"source.relocate","project_root":root,"project_id":project.id,
+        "source":source,"from":old_path,"to":args.to,"old_file_present":old_bytes.is_some(),
+        "target_locator":snapshot.locator,"target_fingerprint":snapshot.fingerprint,"target_config":config,
+        "spec":spec,"configuration":effect,"preserved_object_count":old_ids.len(),"can_apply":true,
+        "source_write_performed":false,"runtime_write_performed":false,
+        "effects":["replace manifest mapping", "retain source identity and append relocation event", "refresh projection references"],
+        "content_policy":"destination already exists with identical bytes; original is neither moved nor removed", "filesystem_atomic":false});
+    plan["fingerprint"] = json!(fingerprint(&serde_json::to_vec(&plan)?));
+    Ok(plan)
+}
+fn load(root: &Path, key: &str) -> Result<Value> {
+    let directory = directory(root, key)?;
+    let bytes =
+        awr_source::read_source_capped(&directory.join("receipt.json"), awr_source::YAML_READ_CAP)?;
+    let v: Value = serde_json::from_slice(&bytes)?;
+    if v["plan"]["project_root"] != json!(root) || v["plan"]["fingerprint"] != key {
+        return Err(Error::SourceConflict(
+            "relocation receipt belongs to another project or request".into(),
+        ));
+    }
+    Ok(v)
+}
+fn observed(root: &Path, receipt: &Value) -> Result<Value> {
+    let p = &receipt["plan"];
+    let store = Store::preview_snapshot(&root.join(".awr/state.db"), 256 * 1024 * 1024)?;
+    let project = store.project_by_root(root)?;
+    let source: Source = serde_json::from_value(p["source"].clone())?;
+    if project.id != source.project_id {
+        return Err(Error::SourceConflict(
+            "relocation project identity changed".into(),
+        ));
+    }
+    let source = store.source(project.id, source.id)?;
+    Ok(
+        json!({"configuration_fingerprint":read(root,".awr/project.toml")?.map(|b|fingerprint(&b)),
+        "source_locator":source.locator,"source_fingerprint":source.fingerprint,"source_revision":source.revision,
+        "pending_marker":read(root,MARKER)?.map(|b|String::from_utf8_lossy(&b).into_owned()),"project_revision":project.project_revision}),
+    )
+}
+pub fn status(root: &Path, key: &str) -> Result<()> {
+    let root = root.canonicalize()?;
+    let receipt = load(&root, key)?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(
+            &json!({"receipt":receipt,"observed":observed(&root,&receipt)?,"read_only":true})
+        )?
+    );
+    Ok(())
+}
+pub fn run(root: &Path, args: &RelocateArgs) -> Result<()> {
+    let root = root.canonicalize()?;
+    crate::source::runtime_dir(&root, false)?;
+    if args.accept {
+        let key = args
+            .expected_preview
+            .as_deref()
+            .ok_or_else(|| Error::InvalidInput("accept requires --expected-preview".into()))?;
+        if directory(&root, key)?.join("receipt.json").exists() {
+            let receipt = load(&root, key)?;
+            if receipt["plan"]["source"]["id"] != json!(args.source)
+                || receipt["plan"]["to"] != json!(args.to)
+            {
+                return Err(Error::SourceConflict(
+                    "request arguments differ from the recorded relocation".into(),
+                ));
+            }
+            if receipt["write_outcome"] == "completed" {
+                return status(&root, key);
+            }
+            return Err(Error::SourceConflict(
+                "relocation has a receipt; inspect relocate-status and use relocate-recover".into(),
+            ));
+        }
+    }
+    let preview = plan(&root, args)?;
+    if !args.accept {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({"status":"preview","preview":preview}))?
+        );
+        return Ok(());
+    }
+    let key = args.expected_preview.as_deref().unwrap();
+    crate::intake_plan::check_expected(&preview, Some(key))?;
+    let mut store = Store::open_existing(&root.join(".awr/state.db"))?;
+    let guard = store.lock_sources()?;
+    let current = plan(&root, args)?;
+    crate::intake_plan::check_expected(&current, Some(key))?;
+    if read(&root, MARKER)?.is_some() {
+        return Err(Error::SourceConflict(
+            "another relocation is pending".into(),
+        ));
+    }
+    let directory = directory(&root, key)?;
+    fs::create_dir_all(directory.parent().unwrap())?;
+    awr_source::open_dir_exact(directory.parent().unwrap())?;
+    fs::create_dir(&directory)?;
+    let receipt =
+        json!({"version":1,"plan":preview,"write_outcome":"pending","filesystem_atomic":false});
+    crate::source::save_configuration_receipt(&directory, &receipt)?;
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(root.join(MARKER))?;
+    file.write_all(key.as_bytes())?;
+    file.sync_all()?;
+    drop(file);
+    finish(&root, key, receipt, &mut store, &guard)
+}
+pub fn recover(root: &Path, key: &str) -> Result<()> {
+    let root = root.canonicalize()?;
+    let receipt = load(&root, key)?;
+    if receipt["write_outcome"] == "completed" && read(&root, MARKER)?.is_none() {
+        return status(&root, key);
+    }
+    let mut store = Store::open_existing(&root.join(".awr/state.db"))?;
+    let guard = store.lock_sources()?;
+    finish(&root, key, receipt, &mut store, &guard)
+}
+fn finish(
+    root: &Path,
+    key: &str,
+    mut receipt: Value,
+    store: &mut Store,
+    guard: &awr_store::SourceLock,
+) -> Result<()> {
+    let directory = directory(root, key)?;
+    let result = (|| -> Result<()> {
+        let p = receipt["plan"].clone();
+        let before: Source = serde_json::from_value(p["source"].clone())?;
+        let project = store.project_by_root(root)?;
+        if project.id != before.project_id {
+            return Err(Error::SourceConflict("project identity changed".into()));
+        }
+        let marker = read(root, MARKER)?;
+        if marker.as_deref().is_some_and(|m| m != key.as_bytes()) {
+            return Err(Error::SourceConflict(
+                "another relocation is pending".into(),
+            ));
+        }
+        let text = p["configuration"]["after_text"]
+            .as_str()
+            .ok_or_else(|| Error::InvalidInput("missing relocation manifest".into()))?;
+        let manifest = Manifest::parse(text)?;
+        let spec: SourceSpec = serde_json::from_value(p["spec"].clone())?;
+        let target = Locator::from_spec(root, &manifest, &spec)?
+            .read(root, source_read_cap(&spec.adapter)?)?;
+        if target.fingerprint != p["target_fingerprint"] || target.locator != p["target_locator"] {
+            return Err(Error::SourceConflict(
+                "destination changed; retain receipt and restore reviewed bytes before recovery"
+                    .into(),
+            ));
+        }
+        let old = read(root, p["from"].as_str().unwrap())?;
+        if old
+            .as_ref()
+            .is_some_and(|b| fingerprint(b) != before.fingerprint)
+        {
+            return Err(Error::SourceConflict(
+                "original source changed after relocation preview".into(),
+            ));
+        }
+        let config = read(root, ".awr/project.toml")?
+            .ok_or_else(|| Error::SourceConflict("source manifest missing".into()))?;
+        let hash = fingerprint(&config);
+        if hash != p["configuration"]["before_fingerprint"]
+            && hash != p["configuration"]["after_fingerprint"]
+        {
+            return Err(Error::SourceConflict(
+                "source manifest changed outside this relocation".into(),
+            ));
+        }
+        if hash != p["configuration"]["after_fingerprint"]
+            && awr_source::open_file_exact(&root.join(".awr/project.toml"))?
+                .metadata()?
+                .permissions()
+                .readonly()
+        {
+            return Err(Error::RuleViolation(
+                "source manifest is read-only; preserve the pending receipt".into(),
+            ));
+        }
+        let source = store.source(project.id, before.id)?;
+        if source.locator == before.locator {
+            if source.revision != before.revision
+                || source.fingerprint != before.fingerprint
+                || source.config != before.config
+            {
+                return Err(Error::SourceConflict(
+                    "original source binding changed".into(),
+                ));
+            }
+        } else if source.locator != target.locator
+            || source.config != p["target_config"]
+            || source.fingerprint != target.fingerprint
+        {
+            return Err(Error::SourceConflict(
+                "retained source no longer matches either relocation state".into(),
+            ));
+        }
+        // Checks above are read-only. A receipt created before its marker is recoverable too.
+        if marker.is_none() {
+            let mut f = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(root.join(MARKER))?;
+            f.write_all(key.as_bytes())?;
+            f.sync_all()?;
+        }
+        if source.locator == before.locator {
+            store.relocate_source(&before, &target.locator, p["target_config"].clone(), guard)?;
+        }
+        receipt["write_outcome"] = json!("binding_relocated");
+        crate::source::save_configuration_receipt(&directory, &receipt)?;
+        if hash != p["configuration"]["after_fingerprint"] {
+            let file = awr_source::open_file_exact(&root.join(".awr/project.toml"))?;
+            let permissions = file.metadata()?.permissions();
+            if permissions.readonly() {
+                return Err(Error::RuleViolation(
+                    "source manifest is read-only; relocation remains recoverable".into(),
+                ));
+            }
+            drop(file);
+            let stage = directory.join(format!("manifest-{}.tmp", Id::new()));
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&stage)?;
+            file.write_all(text.as_bytes())?;
+            file.set_permissions(permissions)?;
+            file.sync_all()?;
+            drop(file);
+            if read(root, ".awr/project.toml")? != Some(config) {
+                return Err(Error::SourceConflict(
+                    "manifest changed before replacement".into(),
+                ));
+            }
+            fs::rename(stage, root.join(".awr/project.toml"))?;
+        }
+        receipt["write_outcome"] = json!("configuration_relocated");
+        crate::source::save_configuration_receipt(&directory, &receipt)?;
+        let report =
+            awr_source::index_project_locked(store, root, &manifest, false, guard, Some(key))?;
+        let ok = report.ok;
+        receipt["index"] = serde_json::to_value(report)?;
+        if !ok {
+            return Err(Error::SourceStale(
+                "relocation indexed with issues; inspect its receipt before recovering".into(),
+            ));
+        }
+        if Locator::from_spec(root, &manifest, &spec)?
+            .read(root, source_read_cap(&spec.adapter)?)?
+            .fingerprint
+            != target.fingerprint
+        {
+            return Err(Error::SourceConflict(
+                "destination changed during relocation; inspect and recover the retained receipt"
+                    .into(),
+            ));
+        }
+        receipt["write_outcome"] = json!("completed");
+        receipt["ok"] = json!(true);
+        receipt["error"] = Value::Null;
+        crate::source::save_configuration_receipt(&directory, &receipt)?;
+        if read(root, MARKER)?.as_deref() == Some(key.as_bytes()) {
+            fs::remove_file(root.join(MARKER))?;
+        }
+        Ok(())
+    })();
+    if let Err(error) = &result {
+        receipt["ok"] = json!(false);
+        receipt["error"] = serde_json::to_value(error.report())?;
+        crate::source::save_configuration_receipt(&directory, &receipt)?;
+    }
+    println!("{}", serde_json::to_string_pretty(&receipt)?);
+    result
+}

--- a/crates/awr-cli/tests/host_capabilities.rs
+++ b/crates/awr-cli/tests/host_capabilities.rs
@@ -48,6 +48,10 @@ fn negotiation_needs_no_project_tty_model_or_environment() {
         "不存在的 project",
         "--require",
         "context.compile",
+        "--require",
+        "intake.semantic_preflight",
+        "--require",
+        "source.relocate",
     ]);
     assert_eq!(result["protocol"]["version"], 1);
     assert_eq!(result["program"]["version"], env!("CARGO_PKG_VERSION"));

--- a/crates/awr-cli/tests/host_intake.rs
+++ b/crates/awr-cli/tests/host_intake.rs
@@ -338,7 +338,7 @@ fn explicit_configuration_change_preserves_runtime_and_rejects_stale_or_identity
 }
 
 #[test]
-fn partial_source_failure_retains_partial_results_and_nonzero_exit() {
+fn known_source_failure_is_rejected_before_any_initialization() {
     let p = Project::new();
     p.write("missing.toml", &(fs::read_to_string(p.0.join("mapping.toml")).unwrap() + "\n[[sources]]\ndomain='plan'\nrole='supporting'\npath='not-present.md'\nadapter='markdown-heading-v1'\n"));
     let preview = p.ok(&["init", "--manifest", "missing.toml"]);
@@ -362,14 +362,11 @@ fn partial_source_failure_retains_partial_results_and_nonzero_exit() {
         serde_json::from_slice::<Value>(&result.stderr).unwrap()["code"],
         "SourceStale"
     );
-    assert_eq!(
-        serde_json::from_slice::<Value>(&result.stdout).unwrap()["index"]["indexed"],
-        1
-    );
-    assert_eq!(
-        p.ok(&["object", "show", "work", "W", "--cached"])["ok"],
-        true
-    );
+    assert!(result.stdout.is_empty());
+    let error: Value = serde_json::from_slice(&result.stderr).unwrap();
+    assert_eq!(error["details"]["configuration_write_performed"], false);
+    assert_eq!(error["details"]["runtime_write_performed"], false);
+    assert!(!p.0.join(".awr").exists());
 }
 
 #[cfg(unix)]
@@ -402,4 +399,137 @@ fn a_linked_ignore_target_is_rejected_and_readonly_preview_does_not_initialize()
     );
     assert!(!p.0.join(".awr").exists());
     assert!(!accept.status.success());
+}
+
+fn tree_bytes(root: &std::path::Path) -> std::collections::BTreeMap<PathBuf, String> {
+    fn walk(
+        root: &std::path::Path,
+        path: &std::path::Path,
+        out: &mut std::collections::BTreeMap<PathBuf, String>,
+    ) {
+        for entry in fs::read_dir(path).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                walk(root, &path, out);
+            } else {
+                out.insert(
+                    path.strip_prefix(root).unwrap().to_owned(),
+                    awr_source::fingerprint(&fs::read(path).unwrap()),
+                );
+            }
+        }
+    }
+    let mut result = Default::default();
+    walk(root, root, &mut result);
+    result
+}
+
+#[test]
+fn semantic_preview_rejects_malformed_source_without_creating_runtime() {
+    let p = Project::new();
+    p.write("work-ledger.yaml", "work_items: [\n");
+    let before = tree_bytes(&p.0);
+    let plan = p.ok(&["init", "--manifest", "mapping.toml"]);
+    assert_eq!(plan["preview"]["can_apply"], false);
+    assert_eq!(plan["preview"]["semantic"]["can_execute"], false);
+    assert!(
+        !plan["preview"]["source_issues"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    p.error(
+        &["init", "--manifest", "mapping.toml", "--accept"],
+        "SourceStale",
+    );
+    assert_eq!(tree_bytes(&p.0), before);
+}
+
+#[test]
+fn unresolved_business_references_are_visible_but_do_not_prevent_intake() {
+    let p = Project::new();
+    p.write("work-ledger.yaml", "work_items:\n- id: W\n  title: Write the guide\n  goal: absent\n  status: ready\n  acceptance: [Useful guide]\n  next_action: Draft it\n");
+    let plan = p.ok(&["init", "--manifest", "mapping.toml"]);
+    let semantic = &plan["preview"]["semantic"];
+    assert_eq!(plan["preview"]["can_apply"], true);
+    assert_eq!(semantic["can_execute"], false);
+    assert!(
+        semantic["gaps"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|g| g["code"] == "work_goal_unresolved")
+    );
+    assert_eq!(
+        plan["preview"]["fingerprint"],
+        p.ok(&["init", "--manifest", "mapping.toml"])["preview"]["fingerprint"]
+    );
+    p.init();
+}
+
+#[test]
+fn replacement_identity_conflicts_are_preflighted_against_a_readonly_history_snapshot() {
+    let p = Project::new();
+    p.init();
+    let work = p.ok(&["work", "show", "W"]);
+    let session = p.ok(&[
+        "session",
+        "start",
+        "--work",
+        "W",
+        "--agent",
+        "fixture",
+        "--provider",
+        "local",
+        "--model",
+        "none",
+        "--expected-revision",
+        &work["project_revision"].to_string(),
+    ]);
+    let ledger = fs::read_to_string(p.0.join("work-ledger.yaml")).unwrap();
+    p.write("relocated.yaml", &ledger);
+    let mapping = fs::read_to_string(p.0.join("mapping.toml"))
+        .unwrap()
+        .replace("work-ledger.yaml", "relocated.yaml");
+    p.write("replacement.toml", &mapping);
+    let before = tree_bytes(&p.0);
+    let plan = p.ok(&["source", "configure", "--manifest", "replacement.toml"]);
+    assert_eq!(plan["preview"]["can_apply"], false);
+    assert!(
+        !plan["preview"]["source_issues"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(
+        plan["preview"]["fingerprint"],
+        p.ok(&["source", "configure", "--manifest", "replacement.toml"])["preview"]["fingerprint"]
+    );
+    p.error(
+        &[
+            "source",
+            "configure",
+            "--manifest",
+            "replacement.toml",
+            "--accept",
+            "--expected-preview",
+            plan["preview"]["fingerprint"].as_str().unwrap(),
+        ],
+        "SourceStale",
+    );
+    assert_eq!(
+        tree_bytes(&p.0),
+        before,
+        "preview and rejected acceptance must not alter persisted files"
+    );
+    let saved = p.ok(&[
+        "session",
+        "show",
+        session["session"]["id"].as_str().unwrap(),
+    ]);
+    assert_eq!(saved["session"]["id"], session["session"]["id"]);
+    assert_eq!(
+        p.ok(&["work", "show", "W"])["work"]["id"],
+        work["work"]["id"]
+    );
 }

--- a/crates/awr-cli/tests/organization_change.rs
+++ b/crates/awr-cli/tests/organization_change.rs
@@ -1,0 +1,220 @@
+use awr_core::Id;
+use serde_json::{Value, json};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+struct Project(PathBuf);
+impl Drop for Project {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+fn run(root: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_awr"))
+        .args(["--project", root.to_str().unwrap(), "--json"])
+        .args(args)
+        .output()
+        .unwrap()
+}
+fn ok(root: &Path, args: &[&str]) -> Value {
+    let r = run(root, args);
+    assert!(
+        r.status.success(),
+        "{args:?}\n{}\n{}",
+        String::from_utf8_lossy(&r.stdout),
+        String::from_utf8_lossy(&r.stderr)
+    );
+    serde_json::from_slice(&r.stdout).unwrap()
+}
+const WORK: &str = "custom_contract: {target: 17, accepted: 3} # retain this exact contract\ncurrent:\n  stage: 'P1' # original style\n  focus: W\n  area: [W]\n  next: Read notes\n  extra: {anything: untouched}\ngoals:\n- id: G\n  title: A useful guide\n  status: active\nmilestones:\n- id: P1\n  title: Draft\n  status: in_progress\n- id: P2\n  title: Publish\n  status: planned\nwork_items:\n- id: W\n  title: Write guide\n  status: in_progress\n  milestone: P1\n  goal: G\n  acceptance: [Useful guide]\n  next_action: Draft examples\n- id: DONE\n  title: Old guide\n  status: completed\n  milestone: P1\n- id: LATER\n  title: Publish guide\n  status: planned\n  milestone: P2\n";
+impl Project {
+    fn new() -> Self {
+        let p = Self(std::env::temp_dir().join(format!("awr-organization-{}", Id::new())));
+        fs::create_dir(&p.0).unwrap();
+        fs::write(p.0.join("map.toml"),"[project]\nname='Guide'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n").unwrap();
+        fs::write(p.0.join("work.yaml"), WORK).unwrap();
+        ok(&p.0, &["init", "--manifest", "map.toml", "--accept"]);
+        p
+    }
+    fn request(&self) -> Value {
+        let w = ok(&self.0, &["work", "show", "W"]);
+        json!({"version":1,"request_key":"focus-review","actor":{"origin":"ai_accepted","host":"fixture","subject":"writer"},"reason":"Review current delivery","source_id":w["source_ref"]["source_id"],"source_fingerprint":w["source_ref"]["source_fingerprint"],"mapping":{"phase":"/current/stage","scope":"/current/area","focus":"/current/focus","next_action":"/current/next"},"values":{"phase":"P1","scope":["W","LATER"],"focus":"W","next_action":"Review the worked examples"}})
+    }
+    fn input(&self, r: &Value) {
+        fs::write(self.0.join("request.json"), serde_json::to_vec(r).unwrap()).unwrap();
+    }
+    fn preview(&self, r: &Value) -> Value {
+        self.input(r);
+        ok(
+            &self.0,
+            &["organization", "preview", "--input", "request.json"],
+        )
+    }
+    fn apply(&self, p: &Value) -> Value {
+        ok(
+            &self.0,
+            &[
+                "organization",
+                "change",
+                "--input",
+                "request.json",
+                "--expected-preview",
+                p["preview"]["fingerprint"].as_str().unwrap(),
+                "--expected-revision",
+                &p["preview"]["project_revision"].to_string(),
+            ],
+        )
+    }
+}
+#[test]
+fn explicit_metadata_preview_is_readonly_and_preserves_contracts_identity_and_style() {
+    let p = Project::new();
+    let r = p.request();
+    let work = ok(&p.0, &["work", "show", "W"]);
+    let before = fs::read(p.0.join("work.yaml")).unwrap();
+    let db = fs::read(p.0.join(".awr/state.db")).unwrap();
+    let plan = p.preview(&r);
+    assert_eq!(fs::read(p.0.join("work.yaml")).unwrap(), before);
+    assert_eq!(fs::read(p.0.join(".awr/state.db")).unwrap(), db);
+    assert_eq!(plan["preview"]["entity_changes"], 0);
+    let result = p.apply(&plan);
+    fs::write(
+        p.0.join("fields.json"),
+        serde_json::to_vec(&r["mapping"]).unwrap(),
+    )
+    .unwrap();
+    let read = ok(
+        &p.0,
+        &[
+            "organization",
+            "show",
+            "--source",
+            r["source_id"].as_str().unwrap(),
+            "--mapping",
+            "fields.json",
+        ],
+    );
+    assert_eq!(read["fields"], plan["preview"]["after"]);
+    assert_eq!(result["phase"], "completed");
+    let after = fs::read_to_string(p.0.join("work.yaml")).unwrap();
+    assert!(after.starts_with(WORK.lines().next().unwrap()));
+    assert!(after.contains("stage: 'P1' # original style"));
+    assert!(after.contains("extra: {anything: untouched}"));
+    assert!(after.ends_with(&WORK[WORK.find("goals:").unwrap()..]));
+    let new = ok(&p.0, &["work", "show", "W"]);
+    assert_eq!(new["work"]["id"], work["work"]["id"]);
+    assert_eq!(new["acceptance"], work["acceptance"]);
+    let replay = p.apply(&plan);
+    assert_eq!(replay["source_write_performed"], false);
+    assert_eq!(replay["project_revision"], result["project_revision"]);
+}
+#[test]
+fn references_stale_sources_and_completion_bypasses_are_rejected() {
+    let p = Project::new();
+    let original = p.request();
+    for (field, value) in [
+        ("focus", json!("DONE")),
+        ("phase", json!("P2")),
+        ("scope", json!(["LATER"])),
+        ("focus", json!("ABSENT")),
+    ] {
+        let mut r = original.clone();
+        r["values"][field] = value;
+        p.input(&r);
+        assert!(
+            !run(
+                &p.0,
+                &["organization", "preview", "--input", "request.json"]
+            )
+            .status
+            .success()
+        );
+    }
+    let mut r = original.clone();
+    r["mapping"]["focus"] = json!("/work_items/0/status");
+    p.input(&r);
+    assert!(
+        !run(
+            &p.0,
+            &["organization", "preview", "--input", "request.json"]
+        )
+        .status
+        .success()
+    );
+    let plan = p.preview(&original);
+    fs::write(p.0.join("work.yaml"), format!("{WORK}# user edit\n")).unwrap();
+    let changed = fs::read(p.0.join("work.yaml")).unwrap();
+    assert!(
+        !run(
+            &p.0,
+            &[
+                "organization",
+                "change",
+                "--input",
+                "request.json",
+                "--expected-preview",
+                plan["preview"]["fingerprint"].as_str().unwrap(),
+                "--expected-revision",
+                &plan["preview"]["project_revision"].to_string()
+            ]
+        )
+        .status
+        .success()
+    );
+    assert_eq!(fs::read(p.0.join("work.yaml")).unwrap(), changed);
+}
+#[test]
+fn interrupted_metadata_write_recovers_only_matching_bytes() {
+    let p = Project::new();
+    let request = p.request();
+    let preview = p.preview(&request);
+    let result = p.apply(&preview);
+    let path = p.0.join(result["receipt"].as_str().unwrap());
+    let mut receipt: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    receipt["phase"] = json!("prepared");
+    fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+    let before = fs::read(p.0.join("work.yaml")).unwrap();
+    let revision = result["project_revision"].to_string();
+    let recovered = ok(
+        &p.0,
+        &[
+            "organization",
+            "recover",
+            "--key",
+            "focus-review",
+            "--expected-revision",
+            &revision,
+        ],
+    );
+    assert_eq!(recovered["phase"], "completed");
+    assert_eq!(fs::read(p.0.join("work.yaml")).unwrap(), before);
+    receipt["phase"] = json!("prepared");
+    fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+    fs::write(
+        p.0.join("work.yaml"),
+        format!(
+            "{}# external followup\n",
+            String::from_utf8(before).unwrap()
+        ),
+    )
+    .unwrap();
+    let current = fs::read(p.0.join("work.yaml")).unwrap();
+    assert!(
+        !run(
+            &p.0,
+            &[
+                "organization",
+                "recover",
+                "--key",
+                "focus-review",
+                "--expected-revision",
+                &recovered["project_revision"].to_string()
+            ]
+        )
+        .status
+        .success()
+    );
+    assert_eq!(fs::read(p.0.join("work.yaml")).unwrap(), current);
+}

--- a/crates/awr-cli/tests/query_concurrency.rs
+++ b/crates/awr-cli/tests/query_concurrency.rs
@@ -1,0 +1,165 @@
+use awr_core::Id;
+use serde_json::Value;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+    sync::{Arc, Barrier},
+    thread,
+    time::Duration,
+};
+struct Project(PathBuf);
+impl Drop for Project {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+fn run(root: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_awr"))
+        .args(["--project", root.to_str().unwrap(), "--json"])
+        .args(args)
+        .output()
+        .unwrap()
+}
+fn ok(root: &Path, args: &[&str]) -> Value {
+    let r = run(root, args);
+    assert!(
+        r.status.success(),
+        "{args:?}: {}\n{}",
+        String::from_utf8_lossy(&r.stdout),
+        String::from_utf8_lossy(&r.stderr)
+    );
+    serde_json::from_slice(&r.stdout).unwrap()
+}
+impl Project {
+    fn new() -> Self {
+        let p = Self(std::env::temp_dir().join(format!("awr-parallel-{}", Id::new())));
+        fs::create_dir(&p.0).unwrap();
+        fs::write(p.0.join("mapping.toml"),"[project]\nname='Guide'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n").unwrap();
+        p.source("First");
+        ok(&p.0, &["init", "--manifest", "mapping.toml", "--accept"]);
+        p
+    }
+    fn source(&self, edition: &str) {
+        let mut text="goals:\n- id: G\n  title: Publish a useful guide\n  summary: Explain the complete workflow\n  status: active\nwork_items:\n".to_owned();
+        for i in 0..80 {
+            text.push_str(&format!("- id: W{i:03}\n  title: {edition} section {i}\n  status: ready\n  goal: G\n  acceptance: [Useful section]\n  next_action: Draft section {i}\n"));
+        }
+        fs::write(self.0.join("work.yaml"), text).unwrap();
+    }
+}
+#[test]
+fn stable_and_changed_sources_support_parallel_status_work_and_context_reads() {
+    let p = Project::new();
+    for edition in ["First", "Revised"] {
+        if edition == "Revised" {
+            p.source(edition);
+        }
+        let barrier = Arc::new(Barrier::new(12));
+        let joins = (0..12)
+            .map(|i| {
+                let root = p.0.clone();
+                let barrier = barrier.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    match i % 3 {
+                        0 => {
+                            let v = ok(&root, &["status"]);
+                            assert_eq!(v["snapshot"]["coherent"], true);
+                            assert_eq!(v["total"], 80);
+                            v["project_revision"].clone()
+                        }
+                        1 => {
+                            let v = ok(&root, &["work", "show", "W000"]);
+                            assert_eq!(v["snapshot"]["coherent"], true);
+                            assert_eq!(v["work"]["title"], format!("{edition} section 0"));
+                            v["project_revision"].clone()
+                        }
+                        _ => {
+                            let v = ok(&root, &["context", "compile", "--work", "W000"]);
+                            assert_eq!(v["completeness"]["complete"], true);
+                            v["project_revision"].clone()
+                        }
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        let revisions = joins
+            .into_iter()
+            .map(|j| j.join().unwrap())
+            .collect::<Vec<_>>();
+        assert!(revisions.iter().all(|r| r == &revisions[0]));
+    }
+}
+#[test]
+fn runtime_revision_and_source_token_have_distinct_lifetimes() {
+    let p = Project::new();
+    let before = ok(&p.0, &["status"]);
+    ok(
+        &p.0,
+        &[
+            "session",
+            "start",
+            "--work",
+            "W000",
+            "--agent",
+            "fixture",
+            "--provider",
+            "local",
+            "--model",
+            "none",
+            "--expected-revision",
+            &before["project_revision"].to_string(),
+        ],
+    );
+    let after = ok(&p.0, &["status"]);
+    assert_ne!(before["project_revision"], after["project_revision"]);
+    assert_eq!(
+        before["snapshot"]["source_state_fingerprint"],
+        after["snapshot"]["source_state_fingerprint"]
+    );
+    p.source("Updated");
+    let changed = ok(&p.0, &["status"]);
+    assert_ne!(
+        after["snapshot"]["source_state_fingerprint"],
+        changed["snapshot"]["source_state_fingerprint"]
+    );
+}
+#[test]
+fn cached_read_is_explicit_and_source_failures_remain_visible_on_refresh() {
+    let p = Project::new();
+    fs::remove_file(p.0.join("work.yaml")).unwrap();
+    let bytes = fs::read(p.0.join(".awr/state.db")).unwrap();
+    let names = || {
+        fs::read_dir(p.0.join(".awr"))
+            .unwrap()
+            .map(|p| p.unwrap().file_name())
+            .collect::<std::collections::BTreeSet<_>>()
+    };
+    let before = names();
+    let cached = ok(&p.0, &["status", "--cached"]);
+    assert_eq!(cached["read_only"], true);
+    assert_eq!(cached["source_refresh_performed"], false);
+    assert_eq!(cached["snapshot"]["source_currentness_verified"], false);
+    assert_eq!(cached["total"], 80);
+    assert!(fs::read(p.0.join(".awr/state.db")).unwrap() == bytes);
+    assert_eq!(names(), before);
+    let failure = run(&p.0, &["status"]);
+    assert!(!failure.status.success());
+    let value: Value = serde_json::from_slice(&failure.stdout).unwrap();
+    assert_eq!(value["ok"], false);
+    assert!(!value["source_issues"].as_array().unwrap().is_empty());
+    assert_eq!(value["snapshot"]["source_currentness_verified"], false);
+}
+#[test]
+fn a_reader_waits_for_the_source_transition_guard_then_uses_a_coherent_snapshot() {
+    let p = Project::new();
+    let store = awr_store::Store::open_existing(&p.0.join(".awr/state.db")).unwrap();
+    let guard = store.lock_sources().unwrap();
+    let root = p.0.clone();
+    let worker = thread::spawn(move || ok(&root, &["status"]));
+    thread::sleep(Duration::from_millis(100));
+    drop(guard);
+    let result = worker.join().unwrap();
+    assert_eq!(result["snapshot"]["coherent"], true);
+}

--- a/crates/awr-cli/tests/runtime_snapshot.rs
+++ b/crates/awr-cli/tests/runtime_snapshot.rs
@@ -22,11 +22,15 @@ impl Drop for Fixture {
     }
 }
 impl Fixture {
-    fn new() -> Self {
+    fn uninitialized() -> Self {
         let f = Self(std::env::temp_dir().join(format!("awr-snapshot-{}", Id::new())));
         fs::create_dir(&f.0).unwrap();
         fs::write(f.0.join("work.yaml"),"goals:\n- id: G\n  title: Deliver a useful guide\n  status: active\nwork_items:\n- id: W\n  title: Draft a guide\n  status: in_progress\n  goal: G\n  acceptance: [Useful examples]\n  next_action: Review examples\n").unwrap();
         fs::write(f.0.join("map.toml"),"[project]\nname='Guide'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n").unwrap();
+        f
+    }
+    fn new() -> Self {
+        let f = Self::uninitialized();
         f.ok(&["init", "--manifest", "map.toml", "--accept"]);
         fs::write(
             f.0.join(".awr/runtime-binding.json"),
@@ -492,4 +496,64 @@ fn backup_includes_committed_wal_and_restore_retains_displaced_sidecars() {
         f.ok(&["runtime", "binding"])["project"]["project_revision"],
         event.project_revision
     );
+}
+
+#[test]
+fn git_backups_bind_resolved_commit_and_refuse_a_new_commit_with_identical_blob_bytes() {
+    let f = Fixture::uninitialized();
+    let git = |args: &[&str]| {
+        let r = Command::new("git")
+            .arg("-C")
+            .arg(&f.0)
+            .args([
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-c",
+                "user.name=Snapshot Fixture",
+                "-c",
+                "user.email=snapshot@example.invalid",
+            ])
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(r.status.success(), "{}", String::from_utf8_lossy(&r.stderr));
+        String::from_utf8(r.stdout).unwrap()
+    };
+    git(&["init"]);
+    git(&["add", "work.yaml"]);
+    git(&["commit", "-m", "Initial source"]);
+    let commit = git(&["rev-parse", "HEAD"]);
+    let path = f.0.join("map.toml");
+    let mut manifest = awr_source::Manifest::parse(&fs::read_to_string(&path).unwrap()).unwrap();
+    manifest.sources[0].path = None;
+    manifest.sources[0].locator = Some("git://HEAD:work.yaml".into());
+    fs::write(path, toml::to_string_pretty(&manifest).unwrap()).unwrap();
+    f.ok(&["init", "--manifest", "map.toml", "--accept"]);
+    let backup = f.backup();
+    let source = &backup["snapshot"]["sources"][0];
+    assert_eq!(
+        source["observed_locator"],
+        format!("git://{}:work.yaml", commit.trim())
+    );
+    assert_ne!(source["source"]["fingerprint"], source["content"]["sha256"]);
+    f.advance();
+    let restored = f.restore(&f.preview());
+    assert_eq!(
+        restored["project_revision"],
+        backup["snapshot"]["project_revision"]
+    );
+    // Same bytes at a different immutable commit are a distinct source binding.
+    git(&[
+        "commit",
+        "--allow-empty",
+        "-m",
+        "Advance the source revision",
+    ]);
+    assert_eq!(
+        f.ok(&["runtime", "check", "--backup", "backup"])["phase"],
+        "verified"
+    );
+    let original = fs::read(f.0.join("work.yaml")).unwrap();
+    f.reject(&["runtime", "restore-preview", "--backup", "backup"]);
+    assert_eq!(fs::read(f.0.join("work.yaml")).unwrap(), original);
 }

--- a/crates/awr-cli/tests/runtime_snapshot.rs
+++ b/crates/awr-cli/tests/runtime_snapshot.rs
@@ -1,0 +1,495 @@
+use awr_core::{EventDraft, Id};
+use awr_store::Store;
+use serde_json::{Value, json};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+struct Fixture(PathBuf);
+fn copied_program(root: &Path) -> PathBuf {
+    root.join(if cfg!(windows) {
+        "backup/program/awr.exe"
+    } else {
+        "backup/program/awr"
+    })
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+impl Fixture {
+    fn new() -> Self {
+        let f = Self(std::env::temp_dir().join(format!("awr-snapshot-{}", Id::new())));
+        fs::create_dir(&f.0).unwrap();
+        fs::write(f.0.join("work.yaml"),"goals:\n- id: G\n  title: Deliver a useful guide\n  status: active\nwork_items:\n- id: W\n  title: Draft a guide\n  status: in_progress\n  goal: G\n  acceptance: [Useful examples]\n  next_action: Review examples\n").unwrap();
+        fs::write(f.0.join("map.toml"),"[project]\nname='Guide'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n").unwrap();
+        f.ok(&["init", "--manifest", "map.toml", "--accept"]);
+        fs::write(
+            f.0.join(".awr/runtime-binding.json"),
+            "{\"host\":\"synthetic-host\",\"version\":1}\n",
+        )
+        .unwrap();
+        f
+    }
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_awr"))
+            .args(["--project", self.0.to_str().unwrap(), "--json"])
+            .args(args)
+            .output()
+            .unwrap()
+    }
+    fn ok(&self, args: &[&str]) -> Value {
+        let r = self.run(args);
+        assert!(
+            r.status.success(),
+            "{args:?}: {} {}",
+            String::from_utf8_lossy(&r.stdout),
+            String::from_utf8_lossy(&r.stderr)
+        );
+        serde_json::from_slice(&r.stdout).unwrap()
+    }
+    fn reject(&self, args: &[&str]) -> String {
+        let r = self.run(args);
+        assert!(!r.status.success(), "unexpected success {args:?}");
+        String::from_utf8(r.stderr).unwrap()
+    }
+    fn db(&self) -> PathBuf {
+        self.0.join(".awr/state.db")
+    }
+    fn revision(&self) -> String {
+        self.ok(&["session", "list"])["project_revision"].to_string()
+    }
+    fn advance(&self) {
+        let mut s = Store::open_existing(&self.db()).unwrap();
+        let p = s.project_by_root(&self.0).unwrap();
+        s.append_event(
+            p.id,
+            p.project_revision,
+            EventDraft::new("work.progress", "Review additional examples"),
+        )
+        .unwrap();
+    }
+    fn backup(&self) -> Value {
+        self.ok(&["runtime", "backup", "--output", "backup"])
+    }
+    fn preview(&self) -> Value {
+        self.ok(&["runtime", "restore-preview", "--backup", "backup"])
+    }
+    fn restore(&self, p: &Value) -> Value {
+        self.ok(&[
+            "runtime",
+            "restore",
+            "--backup",
+            "backup",
+            "--expected-preview",
+            p["fingerprint"].as_str().unwrap(),
+            "--offline",
+        ])
+    }
+}
+fn tree(root: &Path) -> BTreeMap<String, Vec<u8>> {
+    fn walk(root: &Path, p: &Path, out: &mut BTreeMap<String, Vec<u8>>) {
+        for e in fs::read_dir(p).unwrap() {
+            let p = e.unwrap().path();
+            if p.is_dir() {
+                walk(root, &p, out);
+            } else {
+                out.insert(
+                    p.strip_prefix(root).unwrap().to_str().unwrap().into(),
+                    fs::read(p).unwrap(),
+                );
+            }
+        }
+    }
+    let mut result = BTreeMap::new();
+    walk(root, root, &mut result);
+    result
+}
+#[test]
+fn backup_and_matching_restore_preserve_history_identity_and_new_user_files() {
+    let f = Fixture::new();
+    let session = f.ok(&[
+        "session",
+        "start",
+        "--work",
+        "W",
+        "--agent",
+        "writer",
+        "--provider",
+        "fixture",
+        "--model",
+        "test",
+        "--expected-revision",
+        &f.revision(),
+    ]);
+    let sid = session["session"]["id"].as_str().unwrap();
+    let context = f.ok(&["context", "compile", "--session", sid, "--work", "W"]);
+    assert!(
+        context["work_context"]["rendered_context"]
+            .as_str()
+            .unwrap()
+            .contains("Useful examples")
+    );
+    let hash = context["work_context"]["context_hash"].as_str().unwrap();
+    let checkpoint = f.ok(&[
+        "session",
+        "checkpoint",
+        "--session",
+        sid,
+        "--context-hash",
+        hash,
+        "--digest",
+        "Draft reviewed",
+        "--next-action",
+        "Revise the final example",
+        "--expected-revision",
+        &f.revision(),
+    ]);
+    fs::write(f.0.join("report.txt"), "Example review completed").unwrap();
+    let evidence = json!({"external_key":"GUIDE-REVIEW","work_item_key":"W","evidence_type":"report","level":"locally_verified","summary":"Reviewed the guide","locator":"report.txt","sha256":awr_source::fingerprint(b"Example review completed").trim_start_matches("sha256:"),"source_sha":"a".repeat(40),"command":"review guide","scope":["W"],"branch_id":null,"verified_at":1});
+    fs::write(
+        f.0.join("evidence.json"),
+        serde_json::to_vec(&evidence).unwrap(),
+    )
+    .unwrap();
+    let added = f.ok(&[
+        "evidence",
+        "add",
+        "--input",
+        "evidence.json",
+        "--expected-revision",
+        &f.revision(),
+    ]);
+    let before = tree(&f.0.join(".awr"));
+    let binding = f.ok(&["runtime", "binding"]);
+    let backup = f.backup();
+    let retained = Command::new(copied_program(&f.0))
+        .args([
+            "--json",
+            "runtime",
+            "check",
+            "--backup",
+            f.0.join("backup").to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        retained.status.success(),
+        "{}",
+        String::from_utf8_lossy(&retained.stderr)
+    );
+    assert_eq!(tree(&f.0.join(".awr")), before);
+    assert_eq!(backup["snapshot"]["project_id"], binding["project"]["id"]);
+    assert_eq!(
+        f.ok(&["runtime", "check", "--backup", "backup"])["phase"],
+        "verified"
+    );
+    f.advance();
+    fs::write(f.0.join("new-user-file.txt"), "Keep the newer draft").unwrap();
+    fs::write(
+        f.0.join(".awr/new-host-note.json"),
+        "{\"note\":\"keep me\"}",
+    )
+    .unwrap();
+    let before_preview = tree(&f.0.join(".awr"));
+    let plan = f.preview();
+    assert_eq!(tree(&f.0.join(".awr")), before_preview);
+    assert_eq!(plan["history_after_restore_revision_will_be_removed"], true);
+    assert!(
+        plan["preserved_additional_runtime_files"]
+            .get("new-host-note.json")
+            .is_some()
+    );
+    let result = f.restore(&plan);
+    assert_eq!(
+        result["project_revision"],
+        backup["snapshot"]["project_revision"]
+    );
+    assert_eq!(
+        fs::read_to_string(f.0.join("new-user-file.txt")).unwrap(),
+        "Keep the newer draft"
+    );
+    assert_eq!(
+        fs::read(f.0.join(".awr/new-host-note.json")).unwrap(),
+        before_preview["new-host-note.json"]
+    );
+    assert_eq!(
+        f.ok(&["session", "show", sid])["session"]["id"],
+        session["session"]["id"]
+    );
+    let cp = f.ok(&[
+        "object",
+        "show",
+        "checkpoint",
+        checkpoint["checkpoint"]["id"].as_str().unwrap(),
+        "--full",
+    ]);
+    assert!(cp.to_string().contains("Draft reviewed"));
+    assert_eq!(
+        f.ok(&["evidence", "show", "GUIDE-REVIEW"])["evidence"]["id"],
+        added["evidence"]["id"]
+    );
+    assert_eq!(f.ok(&["runtime", "restore-status"])["pending"], false);
+    assert!(
+        Path::new(result["rollback"].as_str().unwrap())
+            .join("state.db")
+            .is_file()
+    );
+}
+#[test]
+fn source_configuration_auxiliary_drift_and_stale_previews_never_overwrite() {
+    let f = Fixture::new();
+    f.backup();
+    f.advance();
+    let plan = f.preview();
+    f.advance();
+    let db = fs::read(f.db()).unwrap();
+    assert!(
+        f.reject(&[
+            "runtime",
+            "restore",
+            "--backup",
+            "backup",
+            "--expected-preview",
+            plan["fingerprint"].as_str().unwrap(),
+            "--offline"
+        ])
+        .contains("stale")
+    );
+    assert_eq!(fs::read(f.db()).unwrap(), db);
+    for name in [
+        "work.yaml",
+        ".awr/project.toml",
+        ".awr/runtime-binding.json",
+    ] {
+        let path = f.0.join(name);
+        let original = fs::read(&path).unwrap();
+        let mut changed = original.clone();
+        changed.extend_from_slice(b"\n# New user change\n");
+        fs::write(&path, &changed).unwrap();
+        f.reject(&["runtime", "restore-preview", "--backup", "backup"]);
+        assert_eq!(fs::read(&path).unwrap(), changed);
+        assert_eq!(fs::read(f.db()).unwrap(), db);
+        fs::write(path, original).unwrap();
+    }
+    let program = copied_program(&f.0);
+    let bytes = fs::read(&program).unwrap();
+    fs::write(&program, b"altered").unwrap();
+    f.reject(&["runtime", "check", "--backup", "backup"]);
+    fs::write(program, bytes).unwrap();
+    assert!(!f.0.join(".awr/state.db-restore.pending").exists());
+    let other = Fixture::new();
+    other.reject(&[
+        "runtime",
+        "restore-preview",
+        "--backup",
+        f.0.join("backup").to_str().unwrap(),
+    ]);
+}
+#[test]
+fn offline_restore_requires_closed_clients_and_matching_program_bytes() {
+    let f = Fixture::new();
+    f.backup();
+    f.advance();
+    let p = f.preview();
+    f.reject(&[
+        "runtime",
+        "restore",
+        "--backup",
+        "backup",
+        "--expected-preview",
+        p["fingerprint"].as_str().unwrap(),
+    ]);
+    let held = Store::open_existing(&f.db()).unwrap();
+    assert!(
+        f.reject(&[
+            "runtime",
+            "restore",
+            "--backup",
+            "backup",
+            "--expected-preview",
+            p["fingerprint"].as_str().unwrap(),
+            "--offline"
+        ])
+        .contains("in use")
+    );
+    drop(held);
+    // A resealed manifest with an altered program still fails target matching.
+    let path = f.0.join("backup/snapshot.json");
+    let original = fs::read(&path).unwrap();
+    let mut s: Value = serde_json::from_slice(&original).unwrap();
+    let mut binary = fs::read(copied_program(&f.0)).unwrap();
+    binary.push(0);
+    fs::write(copied_program(&f.0), &binary).unwrap();
+    s["program"]["binary"]["sha256"] = json!(awr_source::fingerprint(&binary));
+    s["program"]["binary"]["bytes"] = json!(binary.len());
+    s["fingerprint"] = json!("");
+    s["fingerprint"] = json!(awr_source::fingerprint(&serde_json::to_vec(&s).unwrap()));
+    fs::write(&path, serde_json::to_vec(&s).unwrap()).unwrap();
+    assert_eq!(
+        f.ok(&["runtime", "check", "--backup", "backup"])["phase"],
+        "verified"
+    );
+    assert!(
+        f.reject(&["runtime", "restore-preview", "--backup", "backup"])
+            .contains("executing CLI differs")
+    );
+    binary.pop();
+    fs::write(copied_program(&f.0), binary).unwrap();
+    fs::write(path, original).unwrap();
+    f.restore(&f.preview());
+}
+#[test]
+fn interrupted_restore_can_resume_before_or_after_install_but_refuses_external_drift() {
+    let f = Fixture::new();
+    f.backup();
+    f.advance();
+    let result = f.restore(&f.preview());
+    let path = PathBuf::from(result["receipt"].as_str().unwrap());
+    let dir = path.parent().unwrap();
+    let mut receipt: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    receipt["phase"] = json!("prepared");
+    // Reconstruct an interruption immediately after the durable marker and before replacement.
+    fs::copy(dir.join("rollback/state.db"), f.db()).unwrap();
+    fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+    fs::write(
+        f.0.join(".awr/state.db-restore.pending"),
+        result["restore_id"].as_str().unwrap(),
+    )
+    .unwrap();
+    assert!(f.reject(&["session", "list"]).contains("restore"));
+    assert_eq!(
+        f.ok(&["runtime", "restore-status"])["receipt"]["phase"],
+        "prepared"
+    );
+    let source = f.0.join("work.yaml");
+    let before = fs::read(&source).unwrap();
+    fs::write(
+        &source,
+        [before.clone(), b"# User edit\n".to_vec()].concat(),
+    )
+    .unwrap();
+    f.reject(&["runtime", "restore-recover", "--offline"]);
+    assert!(f.0.join(".awr/state.db-restore.pending").exists());
+    fs::write(source, before).unwrap();
+    let good_db = fs::read(f.db()).unwrap();
+    fs::write(f.db(), b"External database replacement").unwrap();
+    assert!(
+        f.reject(&["runtime", "restore-recover", "--offline"])
+            .contains("outside the recorded restore")
+    );
+    fs::write(f.db(), good_db).unwrap();
+    let recovered = f.ok(&["runtime", "restore-recover", "--offline"]);
+    assert_eq!(recovered["project_revision"], result["project_revision"]);
+    // Interruption after completed receipt, before marker removal: only finalize, never rewind again.
+    fs::write(
+        f.0.join(".awr/state.db-restore.pending"),
+        result["restore_id"].as_str().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        f.ok(&["runtime", "restore-recover", "--offline"])["project_revision"],
+        result["project_revision"]
+    );
+    f.advance();
+    fs::write(
+        f.0.join(".awr/state.db-restore.pending"),
+        result["restore_id"].as_str().unwrap(),
+    )
+    .unwrap();
+    f.reject(&["runtime", "restore-recover", "--offline"]);
+}
+#[test]
+fn missing_database_can_restore_but_existing_unknown_database_is_never_overwritten() {
+    let f = Fixture::new();
+    let backup = f.backup();
+    let unknown = b"An unrelated or corrupt database";
+    fs::write(f.db(), unknown).unwrap();
+    assert!(
+        f.reject(&["runtime", "restore-preview", "--backup", "backup"])
+            .contains("ownership")
+    );
+    assert_eq!(fs::read(f.db()).unwrap(), unknown);
+    fs::remove_file(f.db()).unwrap();
+    let plan = f.preview();
+    assert!(plan["current_revision"].is_null());
+    assert_eq!(
+        f.restore(&plan)["project_id"],
+        backup["snapshot"]["project_id"]
+    );
+}
+#[test]
+fn unregistered_directory_additions_and_payload_traversal_are_rejected() {
+    let f = Fixture::new();
+    fs::create_dir(f.0.join("notes")).unwrap();
+    fs::write(f.0.join("notes/one.md"), "# A note\nInitial note\n").unwrap();
+    let path = f.0.join(".awr/project.toml");
+    let mut text = fs::read_to_string(&path).unwrap();
+    text.push_str("\n[[sources]]\ndomain='decisions'\nrole='supporting'\npath='notes'\nadapter='markdown-directory-v1'\n");
+    fs::write(path, text).unwrap();
+    f.ok(&["source", "reindex"]);
+    f.backup();
+    fs::write(f.0.join("notes/two.md"), "# Another note\nAdded later\n").unwrap();
+    f.reject(&["runtime", "restore-preview", "--backup", "backup"]);
+    let path = f.0.join("backup/snapshot.json");
+    let mut s: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    s["database"]["path"] = json!("../../.awr/state.db");
+    s["fingerprint"] = json!("");
+    s["fingerprint"] = json!(awr_source::fingerprint(&serde_json::to_vec(&s).unwrap()));
+    fs::write(path, serde_json::to_vec(&s).unwrap()).unwrap();
+    f.reject(&["runtime", "check", "--backup", "backup"]);
+}
+
+#[test]
+fn backup_includes_committed_wal_and_restore_retains_displaced_sidecars() {
+    let f = Fixture::new();
+    let mut held = Store::open_existing(&f.db()).unwrap();
+    let p = held.project_by_root(&f.0).unwrap();
+    let event = held
+        .append_event(
+            p.id,
+            p.project_revision,
+            EventDraft::new("work.progress", "Committed in the WAL"),
+        )
+        .unwrap();
+    assert!(f.0.join(".awr/state.db-wal").metadata().unwrap().len() > 0);
+    let backup = f.backup();
+    assert_eq!(
+        backup["snapshot"]["project_revision"],
+        event.project_revision
+    );
+    let later = held
+        .append_event(
+            p.id,
+            event.project_revision,
+            EventDraft::new("work.progress", "Later WAL history"),
+        )
+        .unwrap();
+    let names = ["state.db", "state.db-wal", "state.db-shm"];
+    let displaced: Vec<_> = names
+        .iter()
+        .map(|n| fs::read(f.0.join(".awr").join(n)).unwrap())
+        .collect();
+    drop(held);
+    // Reproduce files left by a stopped writer without checkpointing its WAL into the main file.
+    for (name, bytes) in names.iter().zip(&displaced) {
+        fs::write(f.0.join(".awr").join(name), bytes).unwrap();
+    }
+    let plan = f.preview();
+    assert_eq!(plan["current_revision"], later.project_revision);
+    let restored = f.restore(&plan);
+    assert_eq!(restored["project_revision"], event.project_revision);
+    let rollback = Path::new(restored["rollback"].as_str().unwrap());
+    for (name, bytes) in names.iter().zip(&displaced) {
+        assert_eq!(fs::read(rollback.join(name)).unwrap(), *bytes);
+    }
+    assert!(!f.0.join(".awr/state.db-wal").exists());
+    assert_eq!(
+        f.ok(&["runtime", "binding"])["project"]["project_revision"],
+        event.project_revision
+    );
+}

--- a/crates/awr-cli/tests/self_use_content.rs
+++ b/crates/awr-cli/tests/self_use_content.rs
@@ -1,0 +1,92 @@
+use awr_core::Id;
+use serde_json::Value;
+use std::{fs, path::PathBuf, process::Command};
+
+struct Project(PathBuf);
+impl Project {
+    fn new() -> Self {
+        let p = Self(std::env::temp_dir().join(format!("awr-public-notes-{}", Id::new())));
+        fs::create_dir(&p.0).unwrap();
+        fs::write(p.0.join("mapping.toml"), "[project]\nname='Public notes'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n").unwrap();
+        p
+    }
+    fn source(&self, summary: &str) -> String {
+        let text = format!(
+            "goals:\n- id: G\n  title: Publish a guide\n  status: active\nwork_items:\n- id: W\n  title: Review a guide\n  status: ready\n  goal: G\n  next_action: Review the guide\n  acceptance: [A useful guide]\n  summary: {}\n",
+            serde_json::to_string(summary).unwrap()
+        );
+        fs::write(self.0.join("work.yaml"), &text).unwrap();
+        text
+    }
+    fn run(&self, args: &[&str]) -> (bool, Value, String) {
+        let p = Command::new(env!("CARGO_BIN_EXE_awr"))
+            .args(["--project", self.0.to_str().unwrap(), "--json"])
+            .args(args)
+            .output()
+            .unwrap();
+        (
+            p.status.success(),
+            serde_json::from_slice(&p.stdout).unwrap_or(Value::Null),
+            String::from_utf8(p.stderr).unwrap(),
+        )
+    }
+}
+impl Drop for Project {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn public_command_and_permission_notes_survive_intake_query_and_reindex() {
+    let p = Project::new();
+    let first = "PROJECT_ROOT=/public/guide EXPECTED_ITEMS=42 cargo test --offline";
+    let source = p.source(first);
+    let (ok, preview, error) = p.run(&["init", "--manifest", "mapping.toml"]);
+    assert!(ok, "{error}");
+    assert_eq!(preview["preview"]["source_issues"], serde_json::json!([]));
+    assert!(!p.0.join(".awr").exists());
+    let (ok, _, error) = p.run(&[
+        "init",
+        "--manifest",
+        "mapping.toml",
+        "--accept",
+        "--expected-preview",
+        preview["preview"]["fingerprint"].as_str().unwrap(),
+    ]);
+    assert!(ok, "{error}");
+    let (ok, work, error) = p.run(&["work", "show", "W"]);
+    assert!(ok, "{error}");
+    assert_eq!(work["work"]["summary"], first);
+    assert_eq!(fs::read_to_string(p.0.join("work.yaml")).unwrap(), source);
+    let second = "Completed native authorization: 用户明确确认；原文和历史保持不变。";
+    p.source(second);
+    let (ok, work2, error) = p.run(&["work", "show", "W"]);
+    assert!(ok, "{error}");
+    assert_eq!(work2["work"]["id"], work["work"]["id"]);
+    assert_eq!(work2["work"]["summary"], second);
+}
+
+#[test]
+fn ambiguous_fields_and_dumps_return_categories_without_echo_and_can_recover() {
+    let p = Project::new();
+    p.source("Public guide");
+    assert!(p.run(&["init", "--manifest", "mapping.toml", "--accept"]).0);
+    let old = p.run(&["work", "show", "W"]).1["work"]["id"].clone();
+    for (text, category) in [
+        ("authorization: synthetic-private-value", "labelled_value"),
+        ("export HOME=/synthetic-private-value", "environment_dump"),
+    ] {
+        let source = p.source(text);
+        let (ok, result, error) = p.run(&["status"]);
+        assert!(!ok);
+        assert_eq!(result["source_issues"][0]["code"], "RuleViolation");
+        assert_eq!(result["source_issues"][0]["details"]["category"], category);
+        assert!(!format!("{result}{error}").contains("synthetic-private-value"));
+        assert_eq!(fs::read_to_string(p.0.join("work.yaml")).unwrap(), source);
+    }
+    p.source("Expected count GUIDE_ITEMS=42; review the guide.");
+    let (ok, work, error) = p.run(&["work", "show", "W"]);
+    assert!(ok, "{error}");
+    assert_eq!(work["work"]["id"], old);
+}

--- a/crates/awr-cli/tests/source_relocation.rs
+++ b/crates/awr-cli/tests/source_relocation.rs
@@ -1,0 +1,305 @@
+use awr_core::Id;
+use serde_json::{Value, json};
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Output},
+};
+struct Project(PathBuf);
+impl Drop for Project {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+impl Project {
+    fn new() -> Self {
+        let p = Self(std::env::temp_dir().join(format!("awr-move-{}", Id::new())));
+        fs::create_dir(&p.0).unwrap();
+        p.write("work.yaml","goals:\n- id: G\n  title: Publish a guide\n  status: active\n  summary: Explain the workflow\nwork_items:\n- id: W\n  title: Draft the guide\n  status: ready\n  goal: G\n  acceptance: [Useful guide]\n  next_action: Draft the introduction\n- id: R\n  title: Review the guide\n  status: planned\n  depends_on: [W]\n");
+        p.write("mapping.toml","[project]\nname='Guide'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n");
+        p.ok(&["init", "--manifest", "mapping.toml", "--accept"]);
+        p
+    }
+    fn write(&self, path: &str, text: &str) {
+        let p = self.0.join(path);
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(p, text).unwrap();
+    }
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_awr"))
+            .args(["--project", self.0.to_str().unwrap(), "--json"])
+            .args(args)
+            .output()
+            .unwrap()
+    }
+    fn ok(&self, args: &[&str]) -> Value {
+        let r = self.run(args);
+        assert!(
+            r.status.success(),
+            "{}\n{}",
+            String::from_utf8_lossy(&r.stdout),
+            String::from_utf8_lossy(&r.stderr)
+        );
+        serde_json::from_slice(&r.stdout).unwrap()
+    }
+    fn fail(&self, args: &[&str], code: &str) {
+        let r = self.run(args);
+        assert!(!r.status.success());
+        assert_eq!(
+            serde_json::from_slice::<Value>(&r.stderr).unwrap()["code"],
+            code,
+            "args={args:?}, stderr={}",
+            String::from_utf8_lossy(&r.stderr)
+        );
+    }
+    fn source(&self) -> String {
+        self.ok(&["source", "list"])["sources"][0]["id"]
+            .as_str()
+            .unwrap()
+            .into()
+    }
+    fn copy(&self) {
+        let text = fs::read_to_string(self.0.join("work.yaml")).unwrap();
+        self.write("plans/ledger.yaml", &text);
+    }
+    fn preview(&self, id: &str) -> Value {
+        self.ok(&[
+            "source",
+            "relocate",
+            "--source",
+            id,
+            "--to",
+            "plans/ledger.yaml",
+        ])["preview"]
+            .clone()
+    }
+    fn apply(&self, id: &str, key: &str) -> Value {
+        self.ok(&[
+            "source",
+            "relocate",
+            "--source",
+            id,
+            "--to",
+            "plans/ledger.yaml",
+            "--accept",
+            "--expected-preview",
+            key,
+        ])
+    }
+}
+#[test]
+fn relocation_preserves_graph_sessions_checkpoints_evidence_and_old_location_history() {
+    let p = Project::new();
+    let work = p.ok(&["work", "show", "W"]);
+    let review = p.ok(&["work", "show", "R"]);
+    let s = p.ok(&[
+        "session",
+        "start",
+        "--work",
+        "W",
+        "--agent",
+        "fixture",
+        "--provider",
+        "local",
+        "--model",
+        "none",
+        "--claim",
+        "--expected-revision",
+        &work["project_revision"].to_string(),
+    ]);
+    let sid = s["session"]["id"].as_str().unwrap();
+    let context = p.ok(&["context", "compile", "--work", "W", "--session", sid]);
+    assert_eq!(context["completeness"]["complete"], true);
+    let cp = p.ok(&[
+        "session",
+        "checkpoint",
+        "--session",
+        sid,
+        "--context-hash",
+        context["work_context"]["context_hash"].as_str().unwrap(),
+        "--digest",
+        "Guide outline drafted",
+        "--next-action",
+        "Write introduction",
+        "--expected-revision",
+        &context["project_revision"].to_string(),
+    ]);
+    p.write("evidence.json",&json!({"external_key":"E","work_item_key":"W","evidence_type":"observation","level":"designed","summary":"Guide outline","locator":"guide.txt","sha256":null,"source_sha":null,"command":null,"scope":["W"],"branch_id":null,"verified_at":null}).to_string());
+    p.write("guide.txt", "A guide outline");
+    let evidence = p.ok(&[
+        "evidence",
+        "add",
+        "--input",
+        "evidence.json",
+        "--expected-revision",
+        &cp["project_revision"].to_string(),
+    ]);
+    let evidence_before = p.ok(&[
+        "evidence",
+        "show",
+        evidence["evidence"]["id"].as_str().unwrap(),
+    ]);
+    let source = p.source();
+    p.copy();
+    // A file already moved by the user is supported against the indexed baseline.
+    fs::remove_file(p.0.join("work.yaml")).unwrap();
+    let manifest = fs::read(p.0.join(".awr/project.toml")).unwrap();
+    let before = fs::read(p.0.join(".awr/state.db")).unwrap();
+    let preview = p.preview(&source);
+    assert_eq!(preview["old_file_present"], false);
+    assert_eq!(preview["fingerprint"], p.preview(&source)["fingerprint"]);
+    assert_eq!(fs::read(p.0.join(".awr/project.toml")).unwrap(), manifest);
+    assert!(fs::read(p.0.join(".awr/state.db")).unwrap() == before);
+    let key = preview["fingerprint"].as_str().unwrap();
+    let result = p.apply(&source, key);
+    assert_eq!(result["write_outcome"], "completed");
+    assert_eq!(p.source(), source);
+    assert_eq!(
+        p.ok(&["work", "show", "W"])["work"]["id"],
+        work["work"]["id"]
+    );
+    let after = p.ok(&["work", "show", "R"]);
+    assert_eq!(after["work"]["id"], review["work"]["id"]);
+    assert_eq!(review["required_dependencies"][0]["external_key"], "W");
+    assert_eq!(after["required_dependencies"][0]["external_key"], "W");
+    assert_eq!(after["required_dependencies"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        p.ok(&["session", "show", sid])["session"]["last_checkpoint_id"],
+        cp["checkpoint"]["id"]
+    );
+    assert!(!evidence_before["evidence"].is_null());
+    let evidence_after = p.ok(&[
+        "evidence",
+        "show",
+        evidence["evidence"]["id"].as_str().unwrap(),
+    ]);
+    assert_eq!(evidence_after["evidence"], evidence_before["evidence"]);
+    let history = p.ok(&["source", "history", &source]);
+    let relocation = history["events"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["type"] == "source.relocated")
+        .unwrap();
+    let event = p.ok(&[
+        "event",
+        "show",
+        relocation["id"].as_str().unwrap(),
+        "--full",
+    ]);
+    let text = event.to_string();
+    assert!(text.contains("work.yaml") && text.contains("plans/ledger.yaml"));
+    let changes = p.ok(&["source", "changes"]);
+    assert!(
+        changes["changes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e["event_type"] == "source.relocated" && e["configuration_changed"] == true)
+    );
+    let revision = p.ok(&["work", "show", "W"])["project_revision"].clone();
+    p.apply(&source, key);
+    assert_eq!(p.ok(&["work", "show", "W"])["project_revision"], revision);
+}
+#[test]
+fn changed_previews_and_colliding_destinations_are_rejected_before_binding_changes() {
+    let p = Project::new();
+    let id = p.source();
+    p.copy();
+    let plan = p.preview(&id);
+    let before = fs::read(p.0.join(".awr/project.toml")).unwrap();
+    p.write("plans/ledger.yaml", "work_items: []\n");
+    p.fail(
+        &[
+            "source",
+            "relocate",
+            "--source",
+            &id,
+            "--to",
+            "plans/ledger.yaml",
+            "--accept",
+            "--expected-preview",
+            plan["fingerprint"].as_str().unwrap(),
+        ],
+        "SourceConflict",
+    );
+    assert_eq!(fs::read(p.0.join(".awr/project.toml")).unwrap(), before);
+    p.copy();
+    p.write(
+        ".awr/project.toml",
+        &(String::from_utf8(before).unwrap() + "\n# User note\n"),
+    );
+    p.fail(
+        &[
+            "source",
+            "relocate",
+            "--source",
+            &id,
+            "--to",
+            "plans/ledger.yaml",
+            "--accept",
+            "--expected-preview",
+            plan["fingerprint"].as_str().unwrap(),
+        ],
+        "SourceConflict",
+    );
+    // A retained source owns the destination even if it has no colliding work keys.
+    p.write("empty.yaml", "work_items: []\n");
+    let base = fs::read_to_string(p.0.join(".awr/project.toml")).unwrap();
+    let config = fs::read_to_string(p.0.join(".awr/project.toml")).unwrap()
+        + "\n[[sources]]\ndomain='ledger'\nrole='supporting'\npath='empty.yaml'\nadapter='yaml-ledger-v1'\n";
+    p.write(".awr/project.toml", &config);
+    p.ok(&["source", "reindex"]);
+    p.write(".awr/project.toml", &base);
+    p.ok(&["source", "reindex"]);
+    p.write(
+        "empty.yaml",
+        &fs::read_to_string(p.0.join("work.yaml")).unwrap(),
+    );
+    p.fail(
+        &["source", "relocate", "--source", &id, "--to", "empty.yaml"],
+        "SourceConflict",
+    );
+    assert_eq!(p.source(), id);
+}
+#[test]
+fn interrupted_binding_can_be_inspected_recovered_and_rejects_external_edits() {
+    let p = Project::new();
+    let id = p.source();
+    p.copy();
+    let plan = p.preview(&id);
+    let key = plan["fingerprint"].as_str().unwrap();
+    let before = fs::read_to_string(p.0.join(".awr/project.toml")).unwrap();
+    let mut receipt = p.apply(&id, key);
+    // Inject the durable state after binding commit but before manifest replacement.
+    let dir = format!(
+        ".awr/mutations/source-relocate-{}",
+        key.strip_prefix("sha256:").unwrap()
+    );
+    receipt["write_outcome"] = json!("binding_relocated");
+    receipt["ok"] = json!(false);
+    p.write(&format!("{dir}/receipt.json"), &receipt.to_string());
+    p.write(".awr/project.toml", &before);
+    p.write(".awr/mutations/source-relocation.pending", key);
+    p.fail(&["source", "reindex"], "SourceConflict");
+    assert_eq!(
+        p.ok(&["source", "relocate-status", key])["observed"]["pending_marker"],
+        key
+    );
+    p.write("plans/ledger.yaml", "work_items: []\n");
+    p.fail(&["source", "relocate-recover", key], "SourceConflict");
+    assert_eq!(
+        fs::read_to_string(p.0.join(".awr/project.toml")).unwrap(),
+        before
+    );
+    p.copy();
+    let recovered = p.ok(&["source", "relocate-recover", key]);
+    assert_eq!(recovered["write_outcome"], "completed");
+    assert!(
+        !p.0.join(".awr/mutations/source-relocation.pending")
+            .exists()
+    );
+    assert_eq!(p.source(), id);
+    p.ok(&["source", "relocate-recover", key]);
+    p.ok(&["work", "show", "W"]);
+}

--- a/crates/awr-cli/tests/status_summary.rs
+++ b/crates/awr-cli/tests/status_summary.rs
@@ -1,0 +1,97 @@
+use awr_core::Id;
+use serde_json::Value;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+struct Project(PathBuf);
+impl Drop for Project {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+fn run(root: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_awr"))
+        .args(["--project", root.to_str().unwrap(), "--json"])
+        .args(args)
+        .output()
+        .unwrap()
+}
+fn ok(root: &Path, args: &[&str]) -> Value {
+    let r = run(root, args);
+    assert!(
+        r.status.success(),
+        "{args:?}: {}\n{}",
+        String::from_utf8_lossy(&r.stdout),
+        String::from_utf8_lossy(&r.stderr)
+    );
+    serde_json::from_slice(&r.stdout).unwrap()
+}
+impl Project {
+    fn new() -> Self {
+        let p = Self(std::env::temp_dir().join(format!("awr-summary-{}", Id::new())));
+        fs::create_dir(&p.0).unwrap();
+        fs::write(p.0.join("mapping.toml"),"[project]\nname='Guide'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n").unwrap();
+        p.source("First");
+        ok(&p.0, &["init", "--manifest", "mapping.toml", "--accept"]);
+        p
+    }
+    fn source(&self, edition: &str) {
+        let mut text="goals:\n- id: G\n  title: Publish a useful guide\n  summary: Explain the complete workflow\n  status: active\nwork_items:\n".to_owned();
+        for i in 0..80 {
+            text.push_str(&format!("- id: W{i:03}\n  title: {edition} section {i}\n  status: {}\n  goal: G\n  acceptance: [Useful section]\n  next_action: Draft section {i}\n", if i<8 {"in_progress"}else if i<18 {"blocked"}else{"ready"}));
+        }
+        fs::write(self.0.join("work.yaml"), text).unwrap();
+    }
+}
+
+#[test]
+fn summary_preserves_counts_focus_and_explicit_omissions() {
+    let p = Project::new();
+    let full = ok(&p.0, &["status"]);
+    let summary = ok(&p.0, &["status", "--view", "summary", "--goal", "G"]);
+    assert!(full.get("view").is_none());
+    assert_eq!(summary["schema_version"], 1);
+    assert_eq!(summary["total"], full["total"]);
+    assert_eq!(summary["counts"], full["counts"]);
+    for key in ["current_total", "ready_count", "blocked_count"] {
+        assert_eq!(summary[key], full[key]);
+    }
+    assert_eq!(summary["current_total"], 8);
+    assert_eq!(summary["current"].as_array().unwrap().len(), 5);
+    assert_eq!(summary["omissions"]["current"], 3);
+    assert!(summary["omissions"]["blockers"].as_u64().unwrap() > 0);
+    assert_eq!(summary["source_freshness"]["fresh"], 1);
+    assert_eq!(
+        summary["suggested_work"]["key"],
+        full["suggested_work"]["external_key"]
+    );
+    assert!(serde_json::to_vec(&summary).unwrap().len() < serde_json::to_vec(&full).unwrap().len());
+}
+#[test]
+fn exact_scope_never_silently_hides_invalid_selection() {
+    let p = Project::new();
+    let selected = ok(
+        &p.0,
+        &[
+            "status", "--view", "summary", "--goal", "G", "--work", "W000", "--work", "W079",
+        ],
+    );
+    assert_eq!(selected["total"], 2);
+    assert_eq!(selected["omissions"]["outside_scope"], 78);
+    assert_eq!(selected["current_total"], 1);
+    assert_eq!(selected["ready_count"], 1);
+    for args in [
+        vec!["status", "--work", "W000"],
+        vec!["status", "--view", "summary", "--goal", "MISSING"],
+        vec!["status", "--view", "summary", "--work", "MISSING"],
+        vec!["status", "--view", "summary", "--milestone", "MISSING"],
+    ] {
+        assert!(!run(&p.0, &args).status.success(), "{args:?}");
+    }
+    fs::remove_file(p.0.join("work.yaml")).unwrap();
+    let cached = ok(&p.0, &["status", "--cached", "--view", "summary"]);
+    assert_eq!(cached["snapshot"]["source_currentness_verified"], false);
+    assert!(!run(&p.0, &["status", "--view", "summary"]).status.success());
+}

--- a/crates/awr-context/src/bootstrap.rs
+++ b/crates/awr-context/src/bootstrap.rs
@@ -1,6 +1,5 @@
 use crate::{RuleScopeInput, SourceVersion, select_rules};
 use awr_core::*;
-use awr_source::{Manifest, index_project};
 use awr_store::Store;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -220,8 +219,9 @@ fn bootstrap_selected(
         ));
     }
     let root = root.canonicalize()?;
-    let manifest = Manifest::load(&root)?;
-    let refresh = index_project(store, &root, &manifest, false)?;
+    let snapshot = awr_source::refresh_snapshot(store, &root)?;
+    let refresh = snapshot.refresh;
+    let store = &snapshot.store;
     let project = store.project(refresh.project_id)?;
     let sources = store.sources(project.id)?;
     let mut gaps = Vec::new();

--- a/crates/awr-context/src/compile.rs
+++ b/crates/awr-context/src/compile.rs
@@ -1,7 +1,6 @@
 use crate::completeness::{CompletenessFacts, assess_completeness};
 use crate::*;
 use awr_core::*;
-use awr_source::{Manifest, index_project};
 use awr_store::Store;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, path::Path};
@@ -365,7 +364,9 @@ fn compile_context_selected(
         ));
     }
     let root = root.canonicalize()?;
-    let refresh = index_project(store, &root, &Manifest::load(&root)?, false)?;
+    let snapshot = awr_source::refresh_snapshot(store, &root)?;
+    let refresh = snapshot.refresh;
+    let store = &snapshot.store;
     let project = store.project(refresh.project_id)?;
     let branch = match reference {
         Some(reference) => store.resolve_branch(project.id, reference)?,

--- a/crates/awr-context/src/delta.rs
+++ b/crates/awr-context/src/delta.rs
@@ -63,8 +63,9 @@ fn context_delta_selected(
             "work and agent selectors must not be empty".into(),
         ));
     }
-    let refresh =
-        awr_source::index_project(store, root, &awr_source::Manifest::load(root)?, false)?;
+    let snapshot = awr_source::refresh_snapshot(store, root)?;
+    let refresh = snapshot.refresh;
+    let store = &snapshot.store;
     let project = store.project_by_root(&root.canonicalize()?)?;
     let branch = match reference {
         Some(reference) => store.resolve_branch(project.id, reference)?,

--- a/crates/awr-core/src/error.rs
+++ b/crates/awr-core/src/error.rs
@@ -121,6 +121,7 @@ impl Error {
             code: self.code(),
             message: crate::safe_diagnostic(&self.to_string()),
             details: (match self {
+                Self::RuleViolation(message) => crate::secrets::sensitive_rejection_details(message),
                 Self::RevisionConflict { expected, actual } => {
                     Some(serde_json::json!({"expected": expected, "actual": actual}))
                 }

--- a/crates/awr-core/src/error.rs
+++ b/crates/awr-core/src/error.rs
@@ -11,6 +11,11 @@ pub enum Error {
     SourceUnavailable(String),
     #[error("source is stale: {0}")]
     SourceStale(String),
+    #[error("source preflight rejected this mapping; inspect the source issues before applying")]
+    IntakePreflightRejected {
+        issues: serde_json::Value,
+        intake_staged: bool,
+    },
     #[error("source fingerprint conflict: {0}")]
     SourceConflict(String),
     #[error("revision conflict: expected {expected}, actual {actual}")]
@@ -92,6 +97,7 @@ impl Error {
             Self::NotFound(_) => "NotFound",
             Self::SourceUnavailable(_) => "SourceUnavailable",
             Self::SourceStale(_) => "SourceStale",
+            Self::IntakePreflightRejected { .. } => "SourceStale",
             Self::SourceConflict(_) => "SourceConflict",
             Self::RevisionConflict { .. } => "RevisionConflict",
             Self::DependencyBlocked(_) => "DependencyBlocked",
@@ -121,6 +127,11 @@ impl Error {
             code: self.code(),
             message: crate::safe_diagnostic(&self.to_string()),
             details: (match self {
+                Self::IntakePreflightRejected { issues, intake_staged } => Some(serde_json::json!({
+                    "can_apply":false,"source_issues":issues,"source_write_performed":intake_staged,
+                    "configuration_write_performed":false,"runtime_write_performed":intake_staged,
+                    "intake_staged":intake_staged
+                })),
                 Self::RuleViolation(message) => crate::secrets::sensitive_rejection_details(message),
                 Self::RevisionConflict { expected, actual } => {
                     Some(serde_json::json!({"expected": expected, "actual": actual}))

--- a/crates/awr-core/src/event_payload.rs
+++ b/crates/awr-core/src/event_payload.rs
@@ -113,6 +113,7 @@ fn domain_fields(kind: &str, payload: &Value) -> Result<()> {
         kind,
         "source.registered"
             | "source.configured"
+            | "source.relocated"
             | "source.retired"
             | "source.freshness_changed"
             | "source.projected"

--- a/crates/awr-core/src/secrets.rs
+++ b/crates/awr-core/src/secrets.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::{borrow::Cow, sync::LazyLock};
 
-pub const SECRET_POLICY_VERSION: u32 = 3;
+pub const SECRET_POLICY_VERSION: u32 = 4;
 pub const SENSITIVE_CONTENT_WITHHELD: &str = "[sensitive content withheld]";
 const REJECTION: &str =
     "sensitive content is not accepted; remove secret values or use explicit redacted placeholders";
@@ -51,6 +51,106 @@ static ENV_ASSIGNMENT: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?:^|[\s;])(?:export[ \t]+)?[A-Z_][A-Z0-9_]{1,80}[ \t]*=[ \t]*")
         .expect("fixed environment assignment pattern")
 });
+
+/// A diagnostic category is safe to disclose; matched text and key names are not.
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SensitiveCategory {
+    Credential,
+    LabelledValue,
+    EnvironmentDump,
+    PrivatePrompt,
+}
+impl SensitiveCategory {
+    fn rejection(self) -> String {
+        format!("{REJECTION}; category={}", self.name())
+    }
+    fn name(self) -> &'static str {
+        match self {
+            Self::Credential => "credential",
+            Self::LabelledValue => "labelled_value",
+            Self::EnvironmentDump => "environment_dump",
+            Self::PrivatePrompt => "private_prompt",
+        }
+    }
+}
+
+pub(crate) fn sensitive_rejection_details(message: &str) -> Option<Value> {
+    [SensitiveCategory::Credential, SensitiveCategory::LabelledValue,
+        SensitiveCategory::EnvironmentDump, SensitiveCategory::PrivatePrompt]
+        .into_iter().find(|category| message == category.rejection()).map(|category| {
+            serde_json::json!({"policy_version": SECRET_POLICY_VERSION, "category": category,
+                "next_action": "Inspect this source locally. Keep credentials outside AWR; use explicit redacted placeholders for values. Describe public configuration and permission outcomes as prose, not a credential field or environment dump."})
+        })
+}
+
+// Environment dumps and explicit exports retain their boundary. An incidental
+// assignment in a command/prose string is not an environment dump. Sensitive key
+// labels and recognizable credentials are still checked independently everywhere.
+fn environment_assignment(text: &str, matched: &str, start: usize) -> bool {
+    if matched.trim_start().starts_with("export") {
+        return true;
+    }
+    let line_start = text[..start].rfind('\n').map_or(0, |n| n + 1);
+    let prefix = text[line_start..start].trim();
+    let line = text[line_start..].lines().next().unwrap_or("").trim();
+    (prefix.is_empty() || prefix.chars().all(|c| matches!(c, '`' | '\'' | '"')))
+        && !inline_command(line)
+}
+fn inline_command(line: &str) -> bool {
+    let mut assignment = false;
+    for word in line.split_whitespace() {
+        if let Some((name, value)) = word.split_once('=') {
+            if !env_name(name)
+                || name != name.to_ascii_uppercase()
+                || value.is_empty()
+                || value.contains(['\'', '"', '`', ';'])
+            {
+                return false;
+            }
+            assignment = true;
+        } else {
+            return assignment
+                && word.chars().any(char::is_alphabetic)
+                && word
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || "_-./".contains(c));
+        }
+    }
+    false
+}
+
+// "completed native authorization: the user accepted ..." is a narrative event,
+// unlike a line/header/JSON/YAML field named authorization. Only the former may
+// carry prose. A single opaque word or an authentication scheme remains a value.
+fn narrative_authorization(text: &str, matched: &str, start: usize, end: usize) -> bool {
+    if matched.trim() != "authorization:" {
+        return false;
+    }
+    let prefix = text[..start].rsplit('\n').next().unwrap_or("").trim();
+    if !prefix.chars().last().is_some_and(char::is_alphabetic) {
+        return false;
+    }
+    let rest = text[end..].trim_start().lines().next().unwrap_or("");
+    let first = rest.split_whitespace().next().unwrap_or("");
+    if first.to_ascii_lowercase().starts_with("bearer")
+        || first.to_ascii_lowercase().starts_with("basic")
+    {
+        return false;
+    }
+    if first.is_ascii() {
+        first.chars().all(char::is_alphabetic)
+            && first.len() < 24
+            && rest.split_whitespace().take(3).count() == 3
+    } else {
+        // A CJK sentence has explicit prose punctuation, unlike an opaque value.
+        rest.chars().any(|c| matches!(c, '，' | '。' | '；' | '：'))
+            && first
+                .chars()
+                .next()
+                .is_some_and(|c| ('\u{3400}'..='\u{9fff}').contains(&c))
+    }
+}
 
 static PRIVATE_BLOCK: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
@@ -150,9 +250,9 @@ fn has_value(rest: &str) -> bool {
     !matches!(value, "null" | "~" | "{}" | "[]") && !placeholder(value)
 }
 
-pub fn contains_sensitive_text(text: &str) -> bool {
+pub fn sensitive_text_category(text: &str) -> Option<SensitiveCategory> {
     let text = normalized(text);
-    KNOWN.is_match(&text)
+    if KNOWN.is_match(&text)
         || BEARER_AUTH.captures_iter(&text).any(|capture| {
             let value = &capture[1];
             // An unlabelled ordinary word is prose, not proof of an opaque token.
@@ -174,23 +274,43 @@ pub fn contains_sensitive_text(text: &str) -> bool {
                 .or_else(|_| STANDARD_NO_PAD.decode(&capture[1]))
                 .is_ok_and(|bytes| bytes.contains(&b':'))
         })
-        || ASSIGNMENT
-            .find_iter(&text)
-            .any(|m| has_value(&text[m.end()..]) && !definition_after_assignment(&text[m.end()..]))
-        || ENV_ASSIGNMENT
-            .find_iter(&text)
-            .any(|m| has_value(&text[m.end()..]) && !definition_after_assignment(&text[m.end()..]))
-        || PRIVATE_BLOCK
-            .find_iter(&text)
-            .any(|m| has_value(&text[m.end()..]))
-        || ENV_BLOCK.find_iter(&text).any(|m| {
-            let rest = &text[m.end()..];
-            let value = rest.trim_start();
-            let whitespace = &rest[..rest.len() - value.len()];
-            (value.starts_with(['{', '[']) || whitespace.contains('\n'))
-                && has_value(value)
-                && !definition_after_assignment(rest)
-        })
+    {
+        return Some(SensitiveCategory::Credential);
+    }
+    if ASSIGNMENT.find_iter(&text).any(|m| {
+        has_value(&text[m.end()..])
+            && !definition_after_assignment(&text[m.end()..])
+            && !narrative_authorization(&text, m.as_str(), m.start(), m.end())
+    }) {
+        return Some(SensitiveCategory::LabelledValue);
+    }
+    if ENV_ASSIGNMENT.find_iter(&text).any(|m| {
+        environment_assignment(&text, m.as_str(), m.start())
+            && has_value(&text[m.end()..])
+            && !definition_after_assignment(&text[m.end()..])
+    }) {
+        return Some(SensitiveCategory::EnvironmentDump);
+    }
+    if PRIVATE_BLOCK
+        .find_iter(&text)
+        .any(|m| has_value(&text[m.end()..]))
+    {
+        return Some(SensitiveCategory::PrivatePrompt);
+    }
+    if ENV_BLOCK.find_iter(&text).any(|m| {
+        let rest = &text[m.end()..];
+        let value = rest.trim_start();
+        let whitespace = &rest[..rest.len() - value.len()];
+        (value.starts_with(['{', '[']) || whitespace.contains('\n'))
+            && has_value(value)
+            && !definition_after_assignment(rest)
+    }) {
+        return Some(SensitiveCategory::EnvironmentDump);
+    }
+    None
+}
+pub fn contains_sensitive_text(text: &str) -> bool {
+    sensitive_text_category(text).is_some()
 }
 
 fn secret_key(key: &str) -> bool {
@@ -384,21 +504,32 @@ fn sensitive_field(key: &str, value: &Value) -> bool {
         && !public_definition(value)
 }
 pub fn contains_sensitive_value(value: &Value) -> bool {
+    sensitive_value_category(value).is_some()
+}
+pub fn sensitive_value_category(value: &Value) -> Option<SensitiveCategory> {
     match value {
-        Value::String(s) => contains_sensitive_text(s),
-        Value::Array(values) => values.iter().any(contains_sensitive_value),
-        Value::Object(values) => values.iter().any(|(key, value)| {
-            contains_sensitive_text(key)
-                || sensitive_field(key, value)
-                || contains_sensitive_value(value)
+        Value::String(s) => sensitive_text_category(s),
+        Value::Array(values) => values.iter().find_map(sensitive_value_category),
+        Value::Object(values) => values.iter().find_map(|(key, value)| {
+            sensitive_text_category(key).or_else(|| {
+                if sensitive_field(key, value) {
+                    Some(if env_key(key) {
+                        SensitiveCategory::EnvironmentDump
+                    } else {
+                        SensitiveCategory::LabelledValue
+                    })
+                } else {
+                    sensitive_value_category(value)
+                }
+            })
         }),
-        _ => false,
+        _ => None,
     }
 }
 
 pub fn ensure_public_text(text: &str) -> Result<()> {
-    if contains_sensitive_text(text) {
-        Err(Error::RuleViolation(REJECTION.into()))
+    if let Some(category) = sensitive_text_category(text) {
+        Err(Error::RuleViolation(category.rejection()))
     } else {
         Ok(())
     }
@@ -416,8 +547,8 @@ pub fn ensure_public_bytes(bytes: &[u8]) -> Result<()> {
     Ok(())
 }
 pub fn ensure_public_value(value: &Value) -> Result<()> {
-    if contains_sensitive_value(value) {
-        Err(Error::RuleViolation(REJECTION.into()))
+    if let Some(category) = sensitive_value_category(value) {
+        Err(Error::RuleViolation(category.rejection()))
     } else {
         Ok(())
     }
@@ -488,6 +619,58 @@ pub fn redact_sensitive_value(value: Value) -> Value {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn command_configuration_and_permission_narratives_are_not_dumps_or_headers() {
+        for text in [
+            "Expected count APP_EXPECTED_TASKS=134; keep the original source.",
+            "# APP_EXPECTED_TASKS=134",
+            "PROJECT_ROOT=/public/project EXPECTED_ITEMS=134 cargo test --offline",
+            "TASK_LIMIT=25 ./check",
+            "passed normal native authorization: 官方设备确认后应用继续工作；重开保留原记录。",
+            "Completed native authorization: the user confirmed this operation.",
+        ] {
+            ensure_public_text(text).unwrap_or_else(|e| panic!("{text}: {e}"));
+            ensure_public_value(&json!({"summary":text})).unwrap();
+            ensure_public_bytes(&serde_json::to_vec(&json!({"summary":text})).unwrap()).unwrap();
+            ensure_public_text(&public_summary(text, 240).unwrap()).unwrap();
+        }
+        for text in [
+            "APP_VALUE=unknown-value",
+            "HOME=/private PATH=/private/bin",
+            "Run export HOME=/private",
+            "API_KEY=unknown-value cargo test",
+            "Run API_KEY=unknown-value cargo test",
+            "Authorization: the user confirmed this operation.",
+            "native authorization: unknown-value",
+            "native authorization: Bearer word",
+            "native authorization: Basic word",
+            "native authorization: aBcdEfgHijKlmNopQrStUvWxyz extra words",
+            "authorization: 用户明确允许本轮编辑",
+        ] {
+            assert!(ensure_public_text(text).is_err(), "{text}");
+        }
+        assert!(
+            ensure_public_value(&json!({"authorization":"the user confirmed this operation"}))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn rejection_categories_preserve_the_legacy_code_without_disclosing_values() {
+        for (text, category) in [
+            ("export HOME=/private", "environment_dump"),
+            ("password: synthetic-private-value", "labelled_value"),
+            ("Basic YTpi", "credential"),
+            ("# Private prompt\nprivate material", "private_prompt"),
+        ] {
+            let report = ensure_public_text(text).unwrap_err().report();
+            assert_eq!(report.code, "RuleViolation");
+            assert_eq!(report.details.as_ref().unwrap()["category"], category);
+            assert_eq!(report.details.as_ref().unwrap()["policy_version"], 4);
+            assert!(!serde_json::to_string(&report).unwrap().contains(text));
+        }
+    }
 
     #[test]
     fn labelled_values_and_environment_are_rejected_without_echo() {

--- a/crates/awr-mcp/src/arguments.rs
+++ b/crates/awr-mcp/src/arguments.rs
@@ -5,6 +5,11 @@ use serde_json::Value;
 #[derive(Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct StatusArgs {
+    pub view: Option<String>,
+    #[serde(default)]
+    pub work: Vec<String>,
+    pub goal: Option<String>,
+    pub milestone: Option<String>,
     pub branch: Option<String>,
     pub source_sha: Option<String>,
 }

--- a/crates/awr-mcp/src/operations.rs
+++ b/crates/awr-mcp/src/operations.rs
@@ -115,6 +115,20 @@ pub(crate) fn call(root: &Path, name: &str, args: JsonObject) -> Result<CallTool
 }
 
 fn status(view: &ReadProject, args: StatusArgs) -> Result<Value> {
+    let scope = awr_runtime::StatusScope {
+        work: args.work,
+        goal: args.goal,
+        milestone: args.milestone,
+    };
+    let summary = match args.view.as_deref().unwrap_or("full") {
+        "full" if scope.is_empty() => false,
+        "summary" => true,
+        _ => {
+            return Err(Error::InvalidInput(
+                "view must be full or summary; scopes require summary".into(),
+            ));
+        }
+    };
     let branch = branch(&view.store, &view.project, args.branch.as_deref())?;
     let works = view.store.work_items(view.project.id)?;
     let ready = view
@@ -129,6 +143,16 @@ fn status(view: &ReadProject, args: StatusArgs) -> Result<Value> {
         &works,
         &ready,
     )?;
+    if summary {
+        return awr_runtime::summarize_status(
+            &view.store,
+            &view.project,
+            &scope,
+            &works,
+            &ready,
+            &organization,
+        );
+    }
     let mut counts = BTreeMap::<String, usize>::new();
     for work in &works {
         *counts

--- a/crates/awr-mcp/src/project.rs
+++ b/crates/awr-mcp/src/project.rs
@@ -35,25 +35,18 @@ pub(crate) fn database(root: &Path) -> Result<PathBuf> {
 pub(crate) struct ReadProject {
     pub store: Store,
     pub project: Project,
-    origin: Store,
     source_warnings: usize,
+    source_state_fingerprint: String,
 }
 impl ReadProject {
     pub fn open(root: &Path) -> Result<Self> {
-        let origin = Store::open_readonly(&database(root)?)?;
-        let project = origin.project_by_root(root)?;
-        let store = origin.memory_snapshot(256 * 1024 * 1024)?;
-        let actual = store.project(project.id)?.project_revision;
-        if actual != project.project_revision {
-            return Err(Error::RevisionConflict {
-                expected: project.project_revision,
-                actual,
-            });
-        }
+        let store = Store::read_snapshot(&database(root)?, 256 * 1024 * 1024)?;
+        let project = store.project_by_root(root)?;
+        let source_state_fingerprint = awr_source::source_state_fingerprint(&store, project.id)?;
         let mut view = Self {
+            source_state_fingerprint,
             store,
             project,
-            origin,
             source_warnings: 0,
         };
         view.finish(root)?;
@@ -77,13 +70,6 @@ impl ReadProject {
         {
             return Err(Error::SourceStale("source files or mappings differ from their indexed projection; run awr source reindex and inspect again".into()));
         }
-        let actual = self.origin.project(self.project.id)?.project_revision;
-        if actual != revision {
-            return Err(Error::RevisionConflict {
-                expected: revision,
-                actual,
-            });
-        }
         self.source_warnings = refresh
             .sources
             .iter()
@@ -92,7 +78,9 @@ impl ReadProject {
         Ok(())
     }
     pub fn metadata(&self) -> Value {
-        json!({"ok":true,"project_revision":self.project.project_revision,"freshness_basis":"source_verified_readonly","source_refresh_performed":false,"read_only":true,"source_issues":[],"source_warnings":self.source_warnings})
+        json!({"ok":true,"project_revision":self.project.project_revision,"freshness_basis":"source_verified_readonly","source_refresh_performed":false,"read_only":true,"source_issues":[],"source_warnings":self.source_warnings,
+            "snapshot":{"version":1,"storage":"private_memory","coherent":true,"project_revision":self.project.project_revision,
+            "source_state_fingerprint":self.source_state_fingerprint,"source_refresh_revision":null,"source_currentness_verified":true}})
     }
 }
 
@@ -119,4 +107,44 @@ pub(crate) fn write_project(root: &Path, expected: Revision) -> Result<(Store, P
         });
     }
     Ok((store, project))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn runtime_events_do_not_invalidate_a_read_snapshot_but_source_changes_do() {
+        let root = std::env::temp_dir().join(format!("awr-mcp-snapshot-{}", Id::new()));
+        std::fs::create_dir_all(root.join(".awr")).unwrap();
+        let root = root.canonicalize().unwrap();
+        std::fs::write(root.join(".awr/project.toml"),"[project]\nname='Snapshot fixture'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n").unwrap();
+        std::fs::write(
+            root.join("work.yaml"),
+            "work_items:\n- id: W\n  title: Write a guide\n  status: ready\n",
+        )
+        .unwrap();
+        let mut origin = Store::open(&root.join(".awr/state.db")).unwrap();
+        let report =
+            index_project(&mut origin, &root, &Manifest::load(&root).unwrap(), false).unwrap();
+        let mut read = ReadProject::open(&root).unwrap();
+        origin
+            .append_event(
+                report.project_id,
+                report.project_revision,
+                EventDraft::new("work.observed", "Another reader observed the outline"),
+            )
+            .unwrap();
+        read.finish(&root).unwrap();
+        assert_eq!(read.project.project_revision, report.project_revision);
+        assert!(
+            origin.project(report.project_id).unwrap().project_revision
+                > read.project.project_revision
+        );
+        assert_eq!(read.metadata()["snapshot"]["coherent"], true);
+        std::fs::remove_file(root.join("work.yaml")).unwrap();
+        assert!(read.finish(&root).is_err());
+        drop(read);
+        drop(origin);
+        std::fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/crates/awr-mcp/src/schema.rs
+++ b/crates/awr-mcp/src/schema.rs
@@ -73,7 +73,7 @@ pub fn tools() -> Vec<Tool> {
             TOOL_NAMES[0],
             "Read project progress, organization gaps, ordered repair actions and business readiness. Optional source_sha verifies completion reports. Never refresh persistent state; after source edits run awr source reindex before rechecking.",
             object(
-                json!({"branch":branch(),"source_sha":optional(text())}),
+                json!({"branch":branch(),"source_sha":optional(text()),"view":{"type":"string","enum":["full","summary"],"default":"full"},"work":strings(),"goal":optional(text()),"milestone":optional(text())}),
                 &[],
             ),
             true,

--- a/crates/awr-mcp/tests/cli_parity.py
+++ b/crates/awr-mcp/tests/cli_parity.py
@@ -210,6 +210,8 @@ class Parity(unittest.TestCase):
         self.session()
         for cli, tool, args in [
             (["status"], "awr_project_status", {}),
+            (["status", "--view", "summary"], "awr_project_status", {"view": "summary"}),
+            (["status", "--view", "summary", "--work", "W"], "awr_project_status", {"view": "summary", "work": ["W"]}),
             (["ready", "--limit", "1"], "awr_work_ready", {"limit": 1}),
             (["work", "show", "W"], "awr_work_get", {"work": "W"}),
             (["search", "analysis", "--type", "work"], "awr_search", {"text": "analysis", "kind": "work"}),

--- a/crates/awr-mcp/tests/cli_parity.py
+++ b/crates/awr-mcp/tests/cli_parity.py
@@ -60,7 +60,7 @@ WORK = """work_items:
   next_action: Review next steps
   acceptance: [Follow-up is available]
 """
-TRANSPORT_FIELDS = ("freshness_basis", "source_refresh_performed", "read_only")
+TRANSPORT_FIELDS = ("freshness_basis", "source_refresh_performed", "read_only", "snapshot")
 TOOLS = set()
 
 
@@ -192,6 +192,17 @@ class Parity(unittest.TestCase):
         self.assertEqual(mcp["freshness_basis"], "source_verified_readonly")
         self.assertFalse(mcp["source_refresh_performed"])
         self.assertTrue(mcp["read_only"])
+        self.assertTrue(mcp["snapshot"]["coherent"])
+        if "snapshot" in cli:
+            self.assertTrue(cli["snapshot"]["coherent"])
+            for key in ("version", "storage", "project_revision", "source_state_fingerprint", "source_currentness_verified"):
+                self.assertEqual(cli["snapshot"][key], mcp["snapshot"][key])
+            self.assertIsNotNone(cli["snapshot"]["source_refresh_revision"])
+        else:
+            # CLI context packs retain their existing hash-bearing wire contract.
+            self.assertIn("work_context", cli)
+            self.assertEqual(cli["project_revision"], mcp["snapshot"]["project_revision"])
+        self.assertIsNone(mcp["snapshot"]["source_refresh_revision"])
         self.assertEqual({k: v for k, v in cli.items() if k not in TRANSPORT_FIELDS},
                          {k: v for k, v in mcp.items() if k not in TRANSPORT_FIELDS})
 

--- a/crates/awr-mcp/tests/security_secrets.py
+++ b/crates/awr-mcp/tests/security_secrets.py
@@ -16,6 +16,18 @@ TOOLS = ["awr_project_status", "awr_work_ready", "awr_work_get", "awr_search",
 
 
 class SecretTransports(unittest.TestCase):
+    def test_public_notes_and_classified_diagnostics_share_the_transport_contract(self):
+        summary = "PROJECT_ROOT=/public/project EXPECTED_ITEMS=42 cargo test --offline"
+        response = self.client.rpc("tools/call", {"name": "awr_event_append", "arguments": {
+            "expected_revision": self.revision(), "event_type": "work.observed", "summary": summary,
+            "payload": {"body": "Completed native authorization: 用户确认；原记录保留。"}}})
+        self.assertFalse(response["result"].get("isError", False), response)
+        result = self.tool_error("awr_event_append", {"expected_revision": self.revision(),
+            "event_type": "work.observed", "summary": "password: " + SENTINEL})
+        self.assertEqual(result["code"], "RuleViolation")
+        self.assertEqual(result["details"]["category"], "labelled_value")
+        self.assertEqual(result["details"]["policy_version"], 4)
+
     def setUp(self):
         self.temp = tempfile.TemporaryDirectory(prefix="awr-secret-transport-")
         self.addCleanup(self.temp.cleanup)

--- a/crates/awr-runtime/src/lib.rs
+++ b/crates/awr-runtime/src/lib.rs
@@ -147,3 +147,6 @@ pub use ordinary::*;
 
 mod batch;
 pub use batch::*;
+
+mod status_summary;
+pub use status_summary::{StatusScope, summarize_status};

--- a/crates/awr-runtime/src/lib.rs
+++ b/crates/awr-runtime/src/lib.rs
@@ -150,3 +150,9 @@ pub use batch::*;
 
 mod status_summary;
 pub use status_summary::{StatusScope, summarize_status};
+
+mod organization_change;
+pub use organization_change::{
+    OrganizationChange, change_organization, organization_preview, organization_status,
+    read_organization, recover_organization,
+};

--- a/crates/awr-runtime/src/organization_change.rs
+++ b/crates/awr-runtime/src/organization_change.rs
@@ -1,0 +1,460 @@
+//! Recoverable, explicitly mapped project metadata maintenance.
+use crate::mutation_apply::{
+    SourceReplacement, directory, named_lock, new_file, recovery_root, source_lock,
+};
+use awr_core::*;
+use awr_source::*;
+use awr_store::Store;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ffi::OsStr,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OrganizationChange {
+    pub version: u32,
+    pub request_key: String,
+    pub actor: HostActor,
+    pub reason: String,
+    pub source_id: Id,
+    pub source_fingerprint: String,
+    pub mapping: BTreeMap<String, String>,
+    pub values: Map<String, Value>,
+}
+#[derive(Serialize, Deserialize)]
+struct Plan {
+    root: PathBuf,
+    project_id: Id,
+    project_revision: Revision,
+    source: Source,
+    configuration_fingerprint: String,
+    request: OrganizationChange,
+    path: PathBuf,
+    before: String,
+    after: String,
+    preview: Value,
+}
+#[derive(Serialize, Deserialize)]
+struct Receipt {
+    plan: Plan,
+    phase: String,
+    project_revision: Revision,
+}
+fn hash(v: &impl Serialize) -> Result<String> {
+    Ok(fingerprint(&serde_json::to_vec(v)?))
+}
+fn name(key: &str) -> Result<String> {
+    if key.is_empty() || key.len() > 512 || key.chars().any(char::is_control) {
+        return Err(Error::InvalidInput(
+            "bounded organization request key required".into(),
+        ));
+    }
+    Ok(format!(
+        "organization-{}",
+        hash(&key)?.trim_start_matches("sha256:")
+    ))
+}
+fn manifest_hash(root: &Path) -> Result<String> {
+    Ok(fingerprint(&read_capped(
+        &root.join(".awr/project.toml"),
+        YAML_READ_CAP,
+    )?))
+}
+fn semantics(value: &mut Value) {
+    match value {
+        Value::Object(o) => {
+            o.remove("source_ref");
+            for v in o.values_mut() {
+                semantics(v);
+            }
+        }
+        Value::Array(a) => {
+            for v in a {
+                semantics(v);
+            }
+        }
+        _ => (),
+    }
+}
+fn validate_values(store: &Store, project: Id, fields: &Value) -> Result<()> {
+    let text = |key: &str| -> Result<Option<&str>> {
+        match &fields[key] {
+            Value::Null => Ok(None),
+            Value::String(s) if !s.trim().is_empty() && s.len() <= 4096 => Ok(Some(s)),
+            _ => Err(Error::InvalidInput(format!(
+                "{key} must be a bounded nonempty string or null"
+            ))),
+        }
+    };
+    let phase = text("phase")?;
+    let focus = text("focus")?;
+    text("next_action")?;
+    if let Some(phase) = phase {
+        let p = store.plan(project, phase)?;
+        if p.source.freshness != Freshness::Fresh {
+            return Err(Error::SourceStale("phase source is stale".into()));
+        }
+    }
+    let scope = match &fields["scope"] {
+        Value::Null => None,
+        Value::Array(a) if a.len() <= 100 => {
+            let mut keys = BTreeSet::new();
+            for v in a {
+                let key = v
+                    .as_str()
+                    .ok_or_else(|| Error::InvalidInput("scope requires work keys".into()))?;
+                store.work_item(project, key)?;
+                if !keys.insert(key) {
+                    return Err(Error::InvalidInput("duplicate scope work key".into()));
+                }
+            }
+            Some(keys)
+        }
+        _ => {
+            return Err(Error::InvalidInput(
+                "scope requires up to 100 exact work keys".into(),
+            ));
+        }
+    };
+    if let Some(key) = focus {
+        let w = store.work_item(project, key)?;
+        if w.item.archived
+            || matches!(
+                w.item.status,
+                WorkStatus::Completed | WorkStatus::Cancelled | WorkStatus::Unknown
+            )
+        {
+            return Err(Error::InvalidTransition("current focus requires nonterminal, recognized source work; use domain actions to reopen it".into()));
+        }
+        if scope.as_ref().is_some_and(|s| !s.contains(key)) {
+            return Err(Error::SourceConflict(
+                "focus is outside the selected scope".into(),
+            ));
+        }
+        if phase.is_some_and(|p| w.item.milestone.as_deref() != Some(p)) {
+            return Err(Error::SourceConflict(
+                "focus and phase disagree with the source work milestone".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+fn plan(store: &Store, root: &Path, request: OrganizationChange) -> Result<Plan> {
+    ensure_public_data(&request)?;
+    request.actor.validate()?;
+    name(&request.request_key)?;
+    if request.version != 1 || request.reason.trim().is_empty() || request.reason.len() > 4096 {
+        return Err(Error::InvalidInput(
+            "organization version 1 and bounded reason required".into(),
+        ));
+    }
+    let project = store.project_by_root(root)?;
+    for source in store.sources(project.id)? {
+        if source.freshness != Freshness::Fresh {
+            return Err(Error::SourceStale(
+                "refresh all registered sources before organization changes".into(),
+            ));
+        }
+        let (_, _, current) = inspect_registered_source(root, &source)?;
+        if current.fingerprint != source.fingerprint {
+            return Err(Error::SourceConflict(
+                "registered source changed; refresh and preview again".into(),
+            ));
+        }
+    }
+    let source = store.source(project.id, request.source_id)?;
+    if source.adapter != "yaml-ledger-v1" || source.role != "primary" {
+        return Err(Error::MutationUnsupported(
+            "organization metadata requires a primary YAML ledger".into(),
+        ));
+    }
+    if source.fingerprint != request.source_fingerprint {
+        return Err(Error::SourceConflict(
+            "organization source fingerprint changed".into(),
+        ));
+    }
+    let (locator, spec, before) = inspect_registered_source(root, &source)?;
+    let Locator::File(path) = locator else {
+        return Err(Error::MutationUnsupported(
+            "organization changes require a local file source".into(),
+        ));
+    };
+    if path.starts_with(root.join(".awr")) {
+        return Err(Error::MutationUnsupported(
+            "runtime paths are not business metadata".into(),
+        ));
+    }
+    let (after, before_fields, after_fields) =
+        edit_organization_fields(before.text()?, &request.mapping, &request.values)?;
+    validate_values(store, project.id, &after_fields)?;
+    let after_snapshot = SourceSnapshot {
+        locator: before.locator.clone(),
+        fingerprint: fingerprint(after.as_bytes()),
+        bytes: after.as_bytes().to_vec(),
+    };
+    let context = ParseContext {
+        source: &source,
+        existing_ids: store.projection_ids(&source)?,
+    };
+    let adapter = source_adapter(&source.adapter)?;
+    let mut old = serde_json::to_value(adapter.parse(&before, &context, &spec)?)?;
+    let mut new = serde_json::to_value(adapter.parse(&after_snapshot, &context, &spec)?)?;
+    semantics(&mut old);
+    semantics(&mut new);
+    // Adapters allocate provisional edge IDs; the store retains relation identity.
+    // Compare every edge endpoint, relation and required flag, excluding that allocation.
+    for batch in [&mut old, &mut new] {
+        for edge in batch["edges"].as_array_mut().unwrap() {
+            edge.as_object_mut().unwrap().remove("id");
+        }
+    }
+    if old != new {
+        return Err(Error::MutationUnsupported("organization metadata cannot alter projected entities, lifecycle, acceptance or evidence".into()));
+    }
+    let configuration_fingerprint = manifest_hash(root)?;
+    let mut preview = json!({"version":1,"operation":"organization.change","request_key":request.request_key,"project_id":project.id,"project_revision":project.project_revision,"source_id":source.id,"source_revision":source.revision,"source_fingerprint":source.fingerprint,"configuration_fingerprint":configuration_fingerprint,"mapping":request.mapping,"before":before_fields,"after":after_fields,"after_fingerprint":after_snapshot.fingerprint,"can_apply":true,"entity_changes":0,"acceptance_changes":0,"request_fingerprint":hash(&request)?});
+    preview["fingerprint"] = json!(hash(&preview)?);
+    Ok(Plan {
+        root: root.to_owned(),
+        project_id: project.id,
+        project_revision: project.project_revision,
+        source,
+        configuration_fingerprint,
+        request,
+        path,
+        before: before.text()?.into(),
+        after,
+        preview,
+    })
+}
+fn save(root: &Path, r: &Receipt) -> Result<()> {
+    let base = recovery_root(root)?;
+    let key = name(&r.plan.request.request_key)?;
+    let dir = directory(&base, &key, &root.join(".awr/mutations").join(&key))?;
+    let temporary = format!("{}.tmp", Id::new());
+    let mut file = new_file(&dir, OsStr::new(&temporary))?;
+    file.write_all(&serde_json::to_vec(r)?)?;
+    file.sync_all()?;
+    drop(file);
+    dir.rename(&temporary, &dir, "receipt.json")?;
+    crate::fs_sync::sync_directory(&dir)
+}
+fn load(root: &Path, key: &str) -> Result<Option<Receipt>> {
+    let path = root
+        .join(".awr/mutations")
+        .join(name(key)?)
+        .join("receipt.json");
+    if !path.try_exists()? {
+        return Ok(None);
+    }
+    let r: Receipt = serde_json::from_slice(&read_capped(&path, YAML_READ_CAP * 3)?)?;
+    if r.plan.root != root
+        || r.plan.request.request_key != key
+        || r.plan.preview["after_fingerprint"] != fingerprint(r.plan.after.as_bytes())
+        || r.plan.source.fingerprint != fingerprint(r.plan.before.as_bytes())
+        || r.plan.preview["request_fingerprint"] != hash(&r.plan.request)?
+    {
+        return Err(Error::SourceConflict(
+            "organization receipt binding differs".into(),
+        ));
+    }
+    let mut preview = r.plan.preview.clone();
+    let digest = preview
+        .as_object_mut()
+        .unwrap()
+        .remove("fingerprint")
+        .unwrap_or(Value::Null);
+    if digest != hash(&preview)? {
+        return Err(Error::SourceConflict("organization preview changed".into()));
+    }
+    Ok(Some(r))
+}
+fn report(r: &Receipt) -> Value {
+    json!({"ok":r.phase=="completed","phase":r.phase,"project_id":r.plan.project_id,"project_revision":r.project_revision,"preview":r.plan.preview,"receipt":format!(".awr/mutations/{}/receipt.json",name(&r.plan.request.request_key).unwrap()),"source_write_performed":r.phase=="completed","configuration_write_performed":false,"effects":"exact mapped source metadata; source history and projections refreshed"})
+}
+pub fn organization_status(store: &Store, root: &Path, key: &str) -> Result<Value> {
+    let r = load(root, key)?.ok_or_else(|| Error::NotFound("organization request".into()))?;
+    if store.project_by_root(root)?.id != r.plan.project_id {
+        return Err(Error::SourceConflict(
+            "organization project identity changed".into(),
+        ));
+    }
+    let mut v = report(&r);
+    v["source_write_performed"] = json!(false);
+    v["read_only"] = json!(true);
+    Ok(v)
+}
+pub fn organization_preview(
+    store: &Store,
+    root: &Path,
+    request: OrganizationChange,
+) -> Result<Value> {
+    let p = plan(store, root, request)?;
+    Ok(
+        json!({"ok":true,"preview":p.preview,"read_only":true,"source_write_performed":false,"runtime_write_performed":false}),
+    )
+}
+fn apply(store: &mut Store, root: &Path, mut r: Receipt, expected: Revision) -> Result<Value> {
+    let _file_guard = source_lock(root, r.plan.source.id)?;
+    let guard = store.lock_sources()?;
+    let actual_revision = store.project(r.plan.project_id)?.project_revision;
+    if actual_revision != expected {
+        return Err(Error::RevisionConflict {
+            expected,
+            actual: actual_revision,
+        });
+    }
+    if manifest_hash(root)? != r.plan.configuration_fingerprint {
+        return Err(Error::SourceConflict(
+            "organization configuration changed; preserve the receipt for review".into(),
+        ));
+    }
+    let source = store.source(r.plan.project_id, r.plan.source.id)?;
+    if source.config != r.plan.source.config || source.locator != r.plan.source.locator {
+        return Err(Error::SourceConflict(
+            "organization source binding changed".into(),
+        ));
+    }
+    let (_, _, actual) = inspect_registered_source(root, &source)?;
+    if actual.bytes == r.plan.before.as_bytes() {
+        // Repeat all reference and protected-entity checks against the current state.
+        let mut request = r.plan.request.clone();
+        request.source_fingerprint = source.fingerprint.clone();
+        let current = plan(store, root, request)?;
+        if current.after != r.plan.after || current.path != r.plan.path {
+            return Err(Error::SourceConflict(
+                "organization plan no longer matches".into(),
+            ));
+        }
+        let permissions = std::fs::metadata(&r.plan.path)?.permissions();
+        let mut staged =
+            SourceReplacement::prepare(&r.plan.path, r.plan.after.as_bytes(), permissions)?;
+        if inspect_registered_source(root, &source)?.2.bytes != actual.bytes {
+            return Err(Error::SourceConflict(
+                "organization source changed before write".into(),
+            ));
+        }
+        let actual_revision = store.project(r.plan.project_id)?.project_revision;
+        if actual_revision != expected {
+            return Err(Error::RevisionConflict {
+                expected,
+                actual: actual_revision,
+            });
+        }
+        staged.install()?;
+        staged.sync_parent()?;
+    } else if actual.bytes != r.plan.after.as_bytes() {
+        return Err(Error::SourceConflict(
+            "source differs from both recorded states; preserve external changes".into(),
+        ));
+    }
+    let indexed = index_project_locked(store, root, &Manifest::load(root)?, false, &guard, None)?;
+    if !indexed.ok {
+        return Err(Error::SourceStale("organization file may be saved; inspect receipt and recover after fixing source issues".into()));
+    }
+    r.phase = "completed".into();
+    r.project_revision = indexed.project_revision;
+    save(root, &r)?;
+    Ok(report(&r))
+}
+pub fn change_organization(
+    store: &mut Store,
+    root: &Path,
+    request: OrganizationChange,
+    expected: Revision,
+    preview: &str,
+) -> Result<Value> {
+    let key = name(&request.request_key)?;
+    let _request_guard = named_lock(root, &format!("{key}.lock"))?;
+    if let Some(r) = load(root, &request.request_key)? {
+        if hash(&r.plan.request)? != hash(&request)? || r.plan.preview["fingerprint"] != preview {
+            return Err(Error::SourceConflict(
+                "request key belongs to a different organization plan".into(),
+            ));
+        }
+        if r.phase == "completed" {
+            let mut v = report(&r);
+            v["replayed"] = json!(true);
+            v["source_write_performed"] = json!(false);
+            return Ok(v);
+        }
+        return Err(Error::MutationConflict(
+            "organization request is pending; inspect and recover explicitly".into(),
+        ));
+    }
+    let p = plan(store, root, request)?;
+    if p.project_revision != expected {
+        return Err(Error::RevisionConflict {
+            expected,
+            actual: p.project_revision,
+        });
+    }
+    if p.preview["fingerprint"] != preview {
+        return Err(Error::SourceConflict(
+            "organization preview is stale".into(),
+        ));
+    }
+    let r = Receipt {
+        project_revision: p.project_revision,
+        plan: p,
+        phase: "prepared".into(),
+    };
+    save(root, &r)?;
+    apply(store, root, r, expected)
+}
+pub fn recover_organization(
+    store: &mut Store,
+    root: &Path,
+    key: &str,
+    expected: Revision,
+) -> Result<Value> {
+    let _request_guard = named_lock(root, &format!("{}.lock", name(key)?))?;
+    let r = load(root, key)?.ok_or_else(|| Error::NotFound("organization request".into()))?;
+    let project = store.project_by_root(root)?;
+    if project.id != r.plan.project_id {
+        return Err(Error::SourceConflict("organization project changed".into()));
+    }
+    if project.project_revision != expected {
+        return Err(Error::RevisionConflict {
+            expected,
+            actual: project.project_revision,
+        });
+    }
+    if r.phase == "completed" {
+        let mut v = report(&r);
+        v["source_write_performed"] = json!(false);
+        return Ok(v);
+    }
+    apply(store, root, r, expected)
+}
+
+/// Read explicitly mapped source annotations; hosts decide whether to use the declared focus.
+pub fn read_organization(
+    store: &Store,
+    root: &Path,
+    source_id: Id,
+    mapping: &BTreeMap<String, String>,
+) -> Result<Value> {
+    let project = store.project_by_root(root)?;
+    let source = store.source(project.id, source_id)?;
+    if source.adapter != "yaml-ledger-v1" {
+        return Err(Error::Unsupported(
+            "organization mapping requires YAML".into(),
+        ));
+    }
+    let (_, _, snapshot) = inspect_registered_source(root, &source)?;
+    if source.freshness != Freshness::Fresh || source.fingerprint != snapshot.fingerprint {
+        return Err(Error::SourceStale(
+            "organization source changed; reindex before reading current annotations".into(),
+        ));
+    }
+    let fields = organization_fields(snapshot.text()?, mapping)?;
+    Ok(
+        json!({"ok":true,"read_only":true,"project_id":project.id,"project_revision":project.project_revision,"source_id":source.id,"source_revision":source.revision,"source_fingerprint":source.fingerprint,"mapping":mapping,"fields":fields,"selection_basis":"source annotations; no automatic claim, activation or completion"}),
+    )
+}

--- a/crates/awr-runtime/src/status_summary.rs
+++ b/crates/awr-runtime/src/status_summary.rs
@@ -1,0 +1,166 @@
+//! Bounded status projection. Detailed evidence and organization remain on demand.
+use crate::OrganizationReport;
+use awr_core::*;
+use awr_store::Store;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct StatusScope {
+    pub work: Vec<String>,
+    pub goal: Option<String>,
+    pub milestone: Option<String>,
+}
+impl StatusScope {
+    pub fn is_empty(&self) -> bool {
+        self.work.is_empty() && self.goal.is_none() && self.milestone.is_none()
+    }
+}
+fn short(s: &str) -> String {
+    public_summary(s, 240).unwrap_or_else(|_| SENSITIVE_CONTENT_WITHHELD.into())
+}
+fn brief(w: &Projected<WorkItem>) -> Value {
+    json!({"key":w.item.meta.external_key,"title":short(&w.item.title),"status":w.item.status,
+        "raw_status":short(&w.item.raw_status),"owner":w.item.owner,"next_action":short(&w.item.next_action),
+        "blocker":w.item.blocker.as_deref().map(short),"source_revision":w.item.meta.source_ref.source_revision,
+        "details":{"cli":["work","show",&w.item.meta.external_key],"mcp":"awr_work_get"}})
+}
+/// Scope uses explicit source associations. Omitted verification never becomes a completion claim.
+pub fn summarize_status(
+    store: &Store,
+    project: &Project,
+    scope: &StatusScope,
+    works: &[Projected<WorkItem>],
+    readiness: &ReadyReport,
+    organization: &OrganizationReport,
+) -> Result<Value> {
+    if scope.work.len() > 100 {
+        return Err(Error::InvalidInput(
+            "summary accepts at most 100 work keys".into(),
+        ));
+    }
+    for key in &scope.work {
+        if !works.iter().any(|w| &w.item.meta.external_key == key) {
+            return Err(Error::NotFound(format!("work {key}")));
+        }
+    }
+    let goal_keys = if let Some(goal) = &scope.goal {
+        if !store
+            .goals(project.id)?
+            .iter()
+            .any(|g| &g.item.meta.external_key == goal)
+        {
+            return Err(Error::NotFound(format!("goal {goal}")));
+        }
+        Some(
+            store
+                .work_goal_links(project.id)?
+                .into_iter()
+                .filter(|e| &e.to_key == goal)
+                .map(|e| e.from_key)
+                .collect::<BTreeSet<_>>(),
+        )
+    } else {
+        None
+    };
+    if let Some(milestone) = &scope.milestone {
+        store.plan(project.id, milestone)?;
+    }
+    let mut selected = works
+        .iter()
+        .filter(|w| {
+            (scope.work.is_empty() || scope.work.contains(&w.item.meta.external_key))
+                && goal_keys
+                    .as_ref()
+                    .is_none_or(|keys| keys.contains(&w.item.meta.external_key))
+                && scope
+                    .milestone
+                    .as_ref()
+                    .is_none_or(|m| w.item.milestone.as_ref() == Some(m))
+        })
+        .collect::<Vec<_>>();
+    selected.sort_by_key(|w| (&w.item.priority, &w.item.meta.external_key));
+    let keys = selected
+        .iter()
+        .map(|w| w.item.meta.external_key.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut counts = BTreeMap::<String, usize>::new();
+    for w in &selected {
+        *counts
+            .entry(
+                serde_json::to_value(w.item.status)?
+                    .as_str()
+                    .unwrap()
+                    .into(),
+            )
+            .or_default() += 1;
+    }
+    let current = selected
+        .iter()
+        .filter(|w| matches!(w.item.status, WorkStatus::Claimed | WorkStatus::InProgress))
+        .copied()
+        .collect::<Vec<_>>();
+    let ready = readiness
+        .ready
+        .iter()
+        .filter(|r| keys.contains(r.work.item.meta.external_key.as_str()))
+        .collect::<Vec<_>>();
+    let blocked = readiness
+        .blocked
+        .iter()
+        .filter(|r| keys.contains(r.work.item.meta.external_key.as_str()))
+        .collect::<Vec<_>>();
+    let focus = current
+        .iter()
+        .copied()
+        .find(|w| {
+            organization
+                .executable_work
+                .contains(&w.item.meta.external_key)
+        })
+        .or_else(|| {
+            ready.iter().map(|r| &r.work).find(|w| {
+                organization
+                    .executable_work
+                    .contains(&w.item.meta.external_key)
+            })
+        });
+    let sources = store.sources(project.id)?;
+    let runtime = store.inspect_runtime(project.id, now_millis()?)?;
+    let pending = runtime
+        .findings
+        .iter()
+        .filter(|f| f.code.contains("mutation") || f.code.contains("checkpoint"))
+        .collect::<Vec<_>>();
+    let gaps = organization
+        .gaps
+        .iter()
+        .filter(|g| {
+            g.target == "project"
+                || keys.contains(g.target.as_str())
+                || scope.goal.as_ref() == Some(&g.target)
+        })
+        .collect::<Vec<_>>();
+    let mut diagnostic_counts = BTreeMap::<String, usize>::new();
+    for r in &blocked {
+        for d in &r.diagnostics {
+            *diagnostic_counts.entry(d.code.clone()).or_default() += 1;
+        }
+    }
+    Ok(
+        json!({"view":"summary","schema_version":1,"project":project.name,"project_id":project.id,
+        "branch_id":readiness.branch_id,"scope":scope,"scope_combination":"intersection","total":selected.len(),"counts":counts,
+        "count_basis":"source status; acceptance and delivery are not inferred","project_work_total":works.len(),
+        "current":current.iter().take(5).map(|w|brief(w)).collect::<Vec<_>>(),"current_total":current.len(),
+        "ready_count":ready.len(),"blocked_count":blocked.len(),"suggested_work":focus.map(brief),
+        "next_action":focus.map(|w|short(&w.item.next_action)).unwrap_or_else(|| if selected.is_empty(){"No work in this selection; review its source scope.".into()}else{short(&organization.next_action)}),
+        "blockers":blocked.iter().take(5).map(|r|json!({"work":r.work.item.meta.external_key,"codes":r.diagnostics.iter().map(|d|&d.code).collect::<BTreeSet<_>>(),"blocker":r.work.item.blocker.as_deref().map(short)})).collect::<Vec<_>>(),"diagnostic_counts":diagnostic_counts,
+        "source_freshness":{"basis":"all registered sources in this snapshot","total":sources.len(),"fresh":sources.iter().filter(|s|s.freshness==Freshness::Fresh).count(),"not_fresh":sources.iter().filter(|s|s.freshness!=Freshness::Fresh).map(|s|json!({"id":s.id,"freshness":s.freshness})).take(5).collect::<Vec<_>>()},
+        "organization":{"project_state":organization.state,"project_gap_total":organization.gap_total,"project_business_execution_ready":organization.business_execution_ready,"selected_gaps":gaps.iter().take(5).map(|g|json!({"code":g.code,"target":g.target})).collect::<Vec<_>>(),"selected_gap_total":gaps.len()},
+        "pending_operations":{"basis":"registered runtime mutation and checkpoint findings, project-wide","total":pending.len(),"items":pending.iter().take(5).map(|f|json!({"code":f.code,"kind":f.object_kind,"id":f.object_id})).collect::<Vec<_>>(),"runtime_attention_total":runtime.findings.len()},
+        "omissions":{"current":current.len().saturating_sub(5),"blockers":blocked.len().saturating_sub(5),"selected_gaps":gaps.len().saturating_sub(5),"organization_scan_truncated":organization.truncated,"pending_operations":pending.len().saturating_sub(5),"outside_scope":works.len()-selected.len(),"source_details":sources.len(),"not_fresh_sources":sources.iter().filter(|s|s.freshness!=Freshness::Fresh).count().saturating_sub(5),"text_cap_characters":240,
+            "not_evaluated":["host-private or filesystem-only pending receipts","full evidence verification unless source_sha supplied"],"details":["status (full view)","work show KEY","source list","recovery inspect","host status REQUEST"]}}),
+    )
+}

--- a/crates/awr-source/src/indexer.rs
+++ b/crates/awr-source/src/indexer.rs
@@ -112,12 +112,26 @@ pub fn index_project(
     manifest: &Manifest,
     force: bool,
 ) -> Result<IndexReport> {
-    process_project(store, root, manifest, Some(force))
+    process_project(store, root, manifest, Some(force), None)
+}
+
+pub type PreviewSources = BTreeMap<String, Vec<(Locator, crate::SourceSnapshot)>>;
+
+/// Run the actual adapters and projection constraints only in an isolated memory store.
+/// Proposed intake files are supplied as bytes rather than materialized on disk.
+pub fn preview_index_project(
+    store: &mut Store,
+    root: &Path,
+    manifest: &Manifest,
+    captured: &PreviewSources,
+) -> Result<IndexReport> {
+    store.require_memory()?;
+    process_project(store, root, manifest, Some(true), Some(captured))
 }
 
 /// Refresh source registry and availability without parsing or promoting pending facts to fresh.
 pub fn scan_project(store: &mut Store, root: &Path, manifest: &Manifest) -> Result<IndexReport> {
-    process_project(store, root, manifest, None)
+    process_project(store, root, manifest, None, None)
 }
 
 fn process_project(
@@ -125,6 +139,7 @@ fn process_project(
     root: &Path,
     manifest: &Manifest,
     mode: Option<bool>,
+    captured: Option<&PreviewSources>,
 ) -> Result<IndexReport> {
     manifest.validate()?;
     let project = store.register_project(
@@ -161,7 +176,19 @@ fn process_project(
         let key = mapping_key(spec);
         desired.insert(key.clone());
         let adapter = source_adapter(&spec.adapter)?;
-        let discovered = adapter.discover(root, manifest, spec).and_then(|locators| {
+        let discovered = if let Some(captured) = captured {
+            Ok(captured
+                .get(&key)
+                .ok_or_else(|| {
+                    Error::InvalidInput("preview source inventory is incomplete".into())
+                })?
+                .iter()
+                .map(|(locator, _)| locator.clone())
+                .collect())
+        } else {
+            adapter.discover(root, manifest, spec)
+        }
+        .and_then(|locators| {
             locators
                 .into_iter()
                 .map(|locator| {
@@ -224,6 +251,12 @@ fn process_project(
                 &identity,
                 mode,
                 manifest.project.context_profile == crate::ContextProfile::Minimal,
+                captured.and_then(|all| all.get(&key)).and_then(|files| {
+                    files
+                        .iter()
+                        .find(|(path, _)| path.identity().ok() == locator.identity().ok())
+                        .map(|(_, snapshot)| snapshot)
+                }),
             );
             match outcome {
                 Ok((source, indexed, warnings)) => {
@@ -295,6 +328,7 @@ fn index_one(
     identity: &str,
     mode: Option<bool>,
     minimal_context: bool,
+    captured: Option<&crate::SourceSnapshot>,
 ) -> Result<(Source, Option<bool>, Vec<String>)> {
     let project = store.project_by_root(root)?;
     let source = store.register_source(
@@ -313,7 +347,22 @@ fn index_one(
     )?;
     let source = store.configure_source(&source, source_configuration(spec, minimal_context))?;
     let cap = crate::source_read_cap(&spec.adapter)?;
-    let observed = observe_source(store, &source, root, locator, cap)?;
+    let observed = if let Some(snapshot) = captured {
+        if snapshot.bytes.len() as u64 > cap {
+            return Err(Error::InvalidInput(
+                "proposed source exceeds its adapter read cap".into(),
+            ));
+        }
+        awr_core::ensure_public_bytes(&snapshot.bytes)?;
+        crate::SourceObservation {
+            source: store.mark_source_freshness(&source, Freshness::Stale)?,
+            changed: true,
+            snapshot: Some(snapshot.clone()),
+            error: None,
+        }
+    } else {
+        observe_source(store, &source, root, locator, cap)?
+    };
     if let Some(error) = observed.error {
         return Err(error);
     }
@@ -336,7 +385,8 @@ fn index_one(
     };
     let batch = adapter.parse(&snapshot, &context, spec)?;
     let warnings = batch.warnings.clone();
-    if matches!(locator, Locator::File(_))
+    if captured.is_none()
+        && matches!(locator, Locator::File(_))
         && locator.read(root, cap)?.fingerprint != snapshot.fingerprint
     {
         return Err(Error::SourceConflict(

--- a/crates/awr-source/src/indexer.rs
+++ b/crates/awr-source/src/indexer.rs
@@ -17,6 +17,8 @@ pub struct IndexIssue {
     pub locator: Option<String>,
     pub code: String,
     pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
 }
 #[derive(Debug, Clone, Serialize)]
 pub struct IndexedSource {
@@ -55,6 +57,7 @@ impl IndexReport {
             locator: locator.map(awr_core::safe_diagnostic),
             code: error.code().into(),
             message: error.report().message,
+            details: error.report().details,
         });
     }
     fn source(&mut self, source: Source, action: &str, warnings: Vec<String>) {

--- a/crates/awr-source/src/indexer.rs
+++ b/crates/awr-source/src/indexer.rs
@@ -112,6 +112,35 @@ pub fn index_project(
     manifest: &Manifest,
     force: bool,
 ) -> Result<IndexReport> {
+    let guard = store.lock_sources()?;
+    index_project_locked(store, root, manifest, force, &guard, None)
+}
+
+/// Used by a journaled relocation while holding the same lock as normal refreshes.
+pub fn index_project_locked(
+    store: &mut Store,
+    root: &Path,
+    manifest: &Manifest,
+    force: bool,
+    guard: &awr_store::SourceLock,
+    relocation: Option<&str>,
+) -> Result<IndexReport> {
+    store.check_source_lock(guard)?;
+    let pending = root.join(".awr/mutations/source-relocation.pending");
+    if pending.exists() {
+        let key = String::from_utf8(crate::read_source_capped(&pending, 256)?)
+            .map_err(|_| Error::InvalidInput("invalid relocation marker".into()))?;
+        if relocation != Some(key.as_str()) {
+            return Err(Error::SourceConflict("source relocation pending; inspect source relocate-status and explicitly recover it".into()));
+        }
+    }
+    if root.join(".awr/project.toml").exists()
+        && serde_json::to_value(Manifest::load(root)?)? != serde_json::to_value(manifest)?
+    {
+        return Err(Error::SourceConflict(
+            "source mapping changed while waiting for refresh".into(),
+        ));
+    }
     process_project(store, root, manifest, Some(force), None)
 }
 
@@ -131,6 +160,15 @@ pub fn preview_index_project(
 
 /// Refresh source registry and availability without parsing or promoting pending facts to fresh.
 pub fn scan_project(store: &mut Store, root: &Path, manifest: &Manifest) -> Result<IndexReport> {
+    let _guard = store.lock_sources()?;
+    if root
+        .join(".awr/mutations/source-relocation.pending")
+        .exists()
+    {
+        return Err(Error::SourceConflict(
+            "source relocation pending; inspect its receipt before scanning".into(),
+        ));
+    }
     process_project(store, root, manifest, None, None)
 }
 

--- a/crates/awr-source/src/indexer.rs
+++ b/crates/awr-source/src/indexer.rs
@@ -280,22 +280,30 @@ fn process_project(
             }
         };
         for (locator, identity) in files {
-            let outcome = index_one(
-                store,
-                root,
-                spec,
-                adapter.as_ref(),
-                &locator,
-                &identity,
-                mode,
-                manifest.project.context_profile == crate::ContextProfile::Minimal,
-                captured.and_then(|all| all.get(&key)).and_then(|files| {
-                    files
-                        .iter()
-                        .find(|(path, _)| path.identity().ok() == locator.identity().ok())
-                        .map(|(_, snapshot)| snapshot)
-                }),
-            );
+            let mut attempts = 0;
+            let outcome = loop {
+                attempts += 1;
+                let result = index_one(
+                    store,
+                    root,
+                    spec,
+                    adapter.as_ref(),
+                    &locator,
+                    &identity,
+                    mode,
+                    manifest.project.context_profile == crate::ContextProfile::Minimal,
+                    captured.and_then(|all| all.get(&key)).and_then(|files| {
+                        files
+                            .iter()
+                            .find(|(path, _)| path.identity().ok() == locator.identity().ok())
+                            .map(|(_, snapshot)| snapshot)
+                    }),
+                );
+                if matches!(result, Err(Error::RevisionConflict { .. })) && attempts < 4 {
+                    continue;
+                }
+                break result;
+            };
             match outcome {
                 Ok((source, indexed, warnings)) => {
                     seen.insert(source.id);

--- a/crates/awr-source/src/lib.rs
+++ b/crates/awr-source/src/lib.rs
@@ -63,3 +63,6 @@ pub use ledger_batch::*;
 
 mod adoption;
 pub use adoption::*;
+
+mod organization_edit;
+pub use organization_edit::{edit_organization_fields, organization_fields};

--- a/crates/awr-source/src/lib.rs
+++ b/crates/awr-source/src/lib.rs
@@ -11,6 +11,10 @@ mod manifest;
 mod markdown;
 mod markdown_ledger;
 mod mutation;
+mod query_snapshot;
+pub use query_snapshot::{
+    QuerySnapshot, recorded_snapshot, refresh_snapshot, source_state_fingerprint,
+};
 mod yaml_create;
 mod yaml_edit;
 mod yaml_ledger;

--- a/crates/awr-source/src/lib.rs
+++ b/crates/awr-source/src/lib.rs
@@ -25,8 +25,8 @@ pub use document::{
 };
 pub use freshness::{SourceObservation, observe_source};
 pub use indexer::{
-    IndexIssue, IndexReport, IndexedSource, index_project, scan_project, source_adapter,
-    source_configuration,
+    IndexIssue, IndexReport, IndexedSource, PreviewSources, index_project, preview_index_project,
+    scan_project, source_adapter, source_configuration,
 };
 pub use ledger_mapping::LedgerMapping;
 pub use limits::{MARKDOWN_READ_CAP, YAML_READ_CAP, source_read_cap};

--- a/crates/awr-source/src/lib.rs
+++ b/crates/awr-source/src/lib.rs
@@ -25,8 +25,8 @@ pub use document::{
 };
 pub use freshness::{SourceObservation, observe_source};
 pub use indexer::{
-    IndexIssue, IndexReport, IndexedSource, PreviewSources, index_project, preview_index_project,
-    scan_project, source_adapter, source_configuration,
+    IndexIssue, IndexReport, IndexedSource, PreviewSources, index_project, index_project_locked,
+    preview_index_project, scan_project, source_adapter, source_configuration,
 };
 pub use ledger_mapping::LedgerMapping;
 pub use limits::{MARKDOWN_READ_CAP, YAML_READ_CAP, source_read_cap};

--- a/crates/awr-source/src/locator.rs
+++ b/crates/awr-source/src/locator.rs
@@ -27,6 +27,32 @@ pub struct SourceSnapshot {
     pub bytes: Vec<u8>,
 }
 impl SourceSnapshot {
+    /// Validate retained source bytes without reading the original file or Git repository.
+    /// Git fingerprints bind the resolved locator as well as the blob content.
+    pub fn verify_fingerprint(&self) -> bool {
+        let expected = if let Some(git) = self.locator.strip_prefix("git://") {
+            let Some((commit, path)) = git.split_once(':') else {
+                return false;
+            };
+            if ![40, 64].contains(&commit.len())
+                || !commit.bytes().all(|b| b.is_ascii_hexdigit())
+                || relative(Path::new(path)).is_err()
+            {
+                return false;
+            }
+            let mut hash = Sha256::new();
+            hash.update(self.locator.as_bytes());
+            hash.update([0]);
+            hash.update(&self.bytes);
+            format!("sha256:{:x}", hash.finalize())
+        } else if self.locator.starts_with("file://") {
+            fingerprint(&self.bytes)
+        } else {
+            return false;
+        };
+        self.fingerprint == expected
+    }
+
     pub fn text(&self) -> Result<&str> {
         awr_core::ensure_public_bytes(&self.bytes)?;
         std::str::from_utf8(&self.bytes)

--- a/crates/awr-source/src/organization_edit.rs
+++ b/crates/awr-source/src/organization_edit.rs
@@ -1,0 +1,131 @@
+//! Explicit metadata fields outside projected entities; all other YAML bytes stay authoritative.
+use awr_core::{Error, Result};
+use serde_json::{Map, Value};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub fn organization_fields(text: &str, mapping: &BTreeMap<String, String>) -> Result<Value> {
+    let document: Value =
+        serde_yaml_ng::from_str(text).map_err(|e| Error::InvalidInput(e.to_string()))?;
+    let mut fields = Map::new();
+    let mut paths = BTreeSet::new();
+    if mapping.is_empty() || mapping.len() > 4 {
+        return Err(Error::InvalidInput("map 1..4 organization fields".into()));
+    }
+    for (name, pointer) in mapping {
+        if !["phase", "scope", "focus", "next_action"].contains(&name.as_str()) {
+            return Err(Error::MutationUnsupported(
+                "only phase, scope, focus and next_action metadata are supported".into(),
+            ));
+        }
+        let components = pointer
+            .strip_prefix('/')
+            .ok_or_else(|| Error::InvalidInput("organization fields require JSON pointers".into()))?
+            .split('/')
+            .collect::<Vec<_>>();
+        if components.len() < 2
+            || components.len() > 8
+            || components.iter().any(|p| {
+                p.is_empty() || p.contains('~') || p.chars().all(|c| c.is_ascii_digit()) || {
+                    let s = p.to_ascii_lowercase();
+                    s.contains("contract")
+                        || s.contains("release")
+                        || s.contains("count")
+                        || [
+                            "status",
+                            "verification",
+                            "acceptance",
+                            "evidence",
+                            "schema_version",
+                            "total",
+                        ]
+                        .contains(&s.as_str())
+                }
+            })
+            || !paths.insert(pointer)
+            || [
+                "project",
+                "work_items",
+                "milestones",
+                "plans",
+                "goals",
+                "decisions",
+                "rules",
+            ]
+            .contains(&components[0])
+        {
+            return Err(Error::MutationUnsupported("organization mapping must select distinct metadata leaves outside contracts, lifecycle, counts and entity collections".into()));
+        }
+        let parent = pointer.rsplit_once('/').unwrap().0;
+        // Mapping-only ancestry prevents using this route to patch array records.
+        let mut at = &document;
+        for part in &components[..components.len() - 1] {
+            at = at.as_object().and_then(|o| o.get(*part)).ok_or_else(|| {
+                Error::SourceConflict(format!(
+                    "metadata parent {parent} is missing or not a mapping"
+                ))
+            })?;
+        }
+        if !at.is_object() {
+            return Err(Error::MutationUnsupported(
+                "metadata parent must be a mapping".into(),
+            ));
+        }
+        fields.insert(
+            name.clone(),
+            document.pointer(pointer).cloned().unwrap_or(Value::Null),
+        );
+    }
+    if paths.iter().any(|a| {
+        paths
+            .iter()
+            .any(|b| a != b && b.starts_with(&format!("{a}/")))
+    }) {
+        return Err(Error::MutationUnsupported(
+            "overlapping organization pointers".into(),
+        ));
+    }
+    Ok(Value::Object(fields))
+}
+
+pub fn edit_organization_fields(
+    text: &str,
+    mapping: &BTreeMap<String, String>,
+    changes: &Map<String, Value>,
+) -> Result<(String, Value, Value)> {
+    let before = organization_fields(text, mapping)?;
+    if changes.is_empty() || changes.keys().any(|k| !mapping.contains_key(k)) {
+        return Err(Error::InvalidInput(
+            "every changed field requires its explicit mapping".into(),
+        ));
+    }
+    let mut groups = BTreeMap::<String, Map<String, Value>>::new();
+    let mut expected: Value =
+        serde_yaml_ng::from_str(text).map_err(|e| Error::InvalidInput(e.to_string()))?;
+    for (name, value) in changes {
+        let pointer = &mapping[name];
+        let (parent, leaf) = pointer.rsplit_once('/').unwrap();
+        groups
+            .entry(parent.into())
+            .or_default()
+            .insert(leaf.into(), value.clone());
+        expected
+            .pointer_mut(parent)
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .insert(leaf.into(), value.clone());
+    }
+    let mut after = text.to_owned();
+    for (parent, fields) in groups {
+        after = crate::yaml_edit::edit_fields(&after, &parent, &fields)?;
+    }
+    let actual: Value =
+        serde_yaml_ng::from_str(&after).map_err(|e| Error::InvalidInput(e.to_string()))?;
+    if actual != expected {
+        return Err(Error::SourceConflict(
+            "metadata edit changed unselected YAML values".into(),
+        ));
+    }
+    let after_fields = organization_fields(&after, mapping)?;
+    Ok((after, before, after_fields))
+}

--- a/crates/awr-source/src/query_snapshot.rs
+++ b/crates/awr-source/src/query_snapshot.rs
@@ -1,0 +1,77 @@
+use crate::{IndexReport, IndexedSource, Manifest, index_project_locked};
+use awr_core::{Freshness, Id, Result};
+use awr_store::Store;
+use serde_json::json;
+use std::path::Path;
+
+pub struct QuerySnapshot {
+    pub store: Store,
+    pub refresh: IndexReport,
+    pub source_state_fingerprint: String,
+}
+/// Runtime revision is deliberately excluded: a session event cannot change source identity.
+pub fn source_state_fingerprint(store: &Store, project: Id) -> Result<String> {
+    let sources=store.sources(project)?.into_iter().map(|s|json!({"id":s.id,"domain":s.domain,"role":s.role,"locator":s.locator,"adapter":s.adapter,"config":s.config,"revision":s.revision,"fingerprint":s.fingerprint,"freshness":s.freshness})).collect::<Vec<_>>();
+    Ok(crate::fingerprint(&serde_json::to_vec(
+        &json!({"version":1,"project_id":project,"sources":sources}),
+    )?))
+}
+/// Hold the same source transition guard through refresh and SQLite's coherent RAM copy.
+/// Runtime events may advance the snapshot beyond the source refresh interval.
+pub fn refresh_snapshot(origin: &mut Store, root: &Path) -> Result<QuerySnapshot> {
+    let guard = origin.lock_sources()?;
+    let manifest = Manifest::load(root)?;
+    let mut refresh = index_project_locked(origin, root, &manifest, false, &guard, None)?;
+    let store = origin.memory_snapshot(256 * 1024 * 1024)?;
+    refresh.project_revision = store.project(refresh.project_id)?.project_revision;
+    let source_state_fingerprint = source_state_fingerprint(&store, refresh.project_id)?;
+    Ok(QuerySnapshot {
+        store,
+        refresh,
+        source_state_fingerprint,
+    })
+}
+/// Last recorded facts, without reading business files or promoting their currentness.
+pub fn recorded_snapshot(root: &Path) -> Result<QuerySnapshot> {
+    let store = Store::read_snapshot(&root.join(".awr/state.db"), 256 * 1024 * 1024)?;
+    let project = store.project_by_root(root)?;
+    let sources = store.sources(project.id)?;
+    let pending = sources
+        .iter()
+        .filter(|s| s.freshness != Freshness::Fresh)
+        .count();
+    let refresh = IndexReport {
+        ok: pending == 0,
+        project_id: project.id,
+        project_revision: project.project_revision,
+        change_window: crate::indexer::SourceChangeWindow {
+            after_revision: project.project_revision,
+            through_revision: project.project_revision,
+        },
+        projection_complete: pending == 0,
+        indexed: 0,
+        unchanged: sources.len(),
+        retired: 0,
+        pending,
+        sources: sources
+            .into_iter()
+            .map(|s| {
+                Ok(IndexedSource {
+                    warnings: store.source_warnings(&s)?,
+                    source_id: s.id,
+                    locator: s.locator,
+                    action: "recorded".into(),
+                    source_revision: s.revision,
+                    freshness: s.freshness,
+                })
+            })
+            .collect::<Result<_>>()?,
+        issues: vec![],
+    };
+    let source_state_fingerprint = source_state_fingerprint(&store, project.id)?;
+    Ok(QuerySnapshot {
+        store,
+        refresh,
+        source_state_fingerprint,
+    })
+}

--- a/crates/awr-store/src/lib.rs
+++ b/crates/awr-store/src/lib.rs
@@ -13,6 +13,7 @@ mod handoff;
 mod mutation;
 mod mutation_apply;
 mod object_catalog;
+mod preview_snapshot;
 mod projection;
 mod query;
 mod reconcile;
@@ -192,7 +193,58 @@ impl Store {
 
     /// Create or reopen an AWR database. Refuse unrelated databases.
     pub fn open(path: &Path) -> Result<Self> {
-        let mut conn = Connection::open(path).map_err(db_error)?;
+        Self::initialize_connection(Connection::open(path).map_err(db_error)?, true)
+    }
+
+    /// An isolated current-schema store for semantic previews. No disk files are created.
+    pub fn memory() -> Result<Self> {
+        Self::initialize_connection(Connection::open_in_memory().map_err(db_error)?, false)
+    }
+
+    /// Copy and, if necessary, upgrade only a private in-memory copy of an owned database.
+    pub fn preview_snapshot(path: &Path, max_bytes: u64) -> Result<Self> {
+        // Opening even a read-only WAL database may create sidecars. Capture bounded,
+        // stable file images first and let SQLite recover only the private temporary copy.
+        let snapshot = preview_snapshot::Files::capture(path, max_bytes)?;
+        let conn =
+            Connection::open_with_flags(&snapshot.database, OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .map_err(db_error)?;
+        Self::configure(&conn)?;
+        let owner: i64 = conn
+            .pragma_query_value(None, "application_id", |r| r.get(0))
+            .map_err(db_error)?;
+        let version: i64 = conn
+            .pragma_query_value(None, "user_version", |r| r.get(0))
+            .map_err(db_error)?;
+        if owner != APPLICATION_ID || !(1..=SCHEMA_VERSION).contains(&version) {
+            return Err(Error::Storage(
+                "preview requires an owned, supported database".into(),
+            ));
+        }
+        schema::verify(&conn, version)?;
+        let copy = Self { conn }.memory_snapshot(max_bytes)?;
+        Self::initialize_connection(copy.conn, false)
+    }
+
+    pub fn require_memory(&self) -> Result<()> {
+        let file: String = self
+            .conn
+            .query_row(
+                "SELECT file FROM pragma_database_list WHERE name='main'",
+                [],
+                |r| r.get(0),
+            )
+            .map_err(db_error)?;
+        if file.is_empty() {
+            Ok(())
+        } else {
+            Err(Error::RuleViolation(
+                "semantic preview requires an in-memory store".into(),
+            ))
+        }
+    }
+
+    fn initialize_connection(mut conn: Connection, persistent: bool) -> Result<Self> {
         Self::configure(&conn)?;
         let application_id: i64 = conn
             .pragma_query_value(None, "application_id", |r| r.get(0))
@@ -229,7 +281,7 @@ impl Store {
         let mode: String = conn
             .pragma_query_value(None, "journal_mode", |r| r.get(0))
             .map_err(db_error)?;
-        if mode != "wal" {
+        if persistent && mode != "wal" {
             let actual: String = conn
                 .query_row("PRAGMA journal_mode=WAL", [], |r| r.get(0))
                 .map_err(db_error)?;

--- a/crates/awr-store/src/lib.rs
+++ b/crates/awr-store/src/lib.rs
@@ -22,6 +22,8 @@ mod schema;
 mod search;
 mod session;
 mod source_changes;
+mod source_lock;
+pub use source_lock::SourceLock;
 mod transaction;
 mod work;
 mod work_action;

--- a/crates/awr-store/src/lib.rs
+++ b/crates/awr-store/src/lib.rs
@@ -18,11 +18,13 @@ mod projection;
 mod query;
 mod reconcile;
 mod resume;
+mod runtime_lease;
 mod schema;
 mod search;
 mod session;
 mod source_changes;
 mod source_lock;
+pub use runtime_lease::{RuntimeLease, pending_path as restore_pending_path};
 pub use source_lock::SourceLock;
 mod transaction;
 mod work;
@@ -69,6 +71,7 @@ const DRAFT_WORK_SQL: &str = include_str!("../migrations/004_draft_work.sql");
 /// ```
 pub struct Store {
     pub(crate) conn: Connection,
+    runtime_lease: Option<RuntimeLease>,
 }
 
 #[cfg(test)]
@@ -142,11 +145,15 @@ impl Store {
             ));
         }
         Self::configure(&conn)?;
-        Ok(Self { conn })
+        Ok(Self {
+            conn,
+            runtime_lease: None,
+        })
     }
 
     /// Open the current schema for queries without creating or upgrading database state.
     pub fn open_readonly(path: &Path) -> Result<Self> {
+        let runtime_lease = RuntimeLease::shared(path, false)?;
         if !path.is_file() {
             return Err(Error::NotFound(format!("AWR database: {}", path.display())));
         }
@@ -164,13 +171,17 @@ impl Store {
                 "read queries require a current AWR database; use doctor to inspect it".into(),
             ));
         }
-        let store = Self { conn };
+        let store = Self {
+            conn,
+            runtime_lease,
+        };
         store.verify_catalog()?;
         Ok(store)
     }
 
     /// Open an existing current-schema database for domain writes without creating or migrating it.
     pub fn open_existing(path: &Path) -> Result<Self> {
+        let runtime_lease = RuntimeLease::shared(path, true)?;
         if !path.is_file() {
             return Err(Error::NotFound(format!("AWR database: {}", path.display())));
         }
@@ -188,14 +199,21 @@ impl Store {
                 "writes require an existing current AWR database; inspect it before repair".into(),
             ));
         }
-        let store = Self { conn };
+        let store = Self {
+            conn,
+            runtime_lease,
+        };
         store.verify_catalog()?;
         Ok(store)
     }
 
     /// Create or reopen an AWR database. Refuse unrelated databases.
     pub fn open(path: &Path) -> Result<Self> {
-        Self::initialize_connection(Connection::open(path).map_err(db_error)?, true)
+        let lease = RuntimeLease::shared(path, true)?;
+        let mut store =
+            Self::initialize_connection(Connection::open(path).map_err(db_error)?, true)?;
+        store.runtime_lease = lease;
+        Ok(store)
     }
 
     /// An isolated current-schema store for semantic previews. No disk files are created.
@@ -212,6 +230,19 @@ impl Store {
         Self::capture_snapshot(path, max_bytes, false)
     }
     fn capture_snapshot(path: &Path, max_bytes: u64, upgrade: bool) -> Result<Self> {
+        let _lease = RuntimeLease::shared(path, false)?;
+        Self::capture_snapshot_unleased(path, max_bytes, upgrade)
+    }
+    /// Offline inspection under an exclusive runtime lease, including pending restore recovery.
+    pub fn read_snapshot_with_lease(
+        path: &Path,
+        max_bytes: u64,
+        lease: &RuntimeLease,
+    ) -> Result<Self> {
+        lease.check_database(path)?;
+        Self::capture_snapshot_unleased(path, max_bytes, false)
+    }
+    fn capture_snapshot_unleased(path: &Path, max_bytes: u64, upgrade: bool) -> Result<Self> {
         // Opening even a read-only WAL database may create sidecars. Capture bounded,
         // stable file images first and let SQLite recover only the private temporary copy.
         let snapshot = preview_snapshot::Files::capture(path, max_bytes)?;
@@ -236,7 +267,11 @@ impl Store {
             ));
         }
         schema::verify(&conn, version)?;
-        let copy = Self { conn }.memory_snapshot(max_bytes)?;
+        let copy = Self {
+            conn,
+            runtime_lease: None,
+        }
+        .memory_snapshot(max_bytes)?;
         if upgrade {
             Self::initialize_connection(copy.conn, false)
         } else {
@@ -382,7 +417,10 @@ impl Store {
             conn.pragma_update(None, "foreign_keys", true)
                 .map_err(db_error)?;
         }
-        let store = Self { conn };
+        let store = Self {
+            conn,
+            runtime_lease: None,
+        };
         store.verify_catalog()?;
         Ok(store)
     }
@@ -404,13 +442,18 @@ impl Store {
 
     /// Inspect without creating, upgrading, or repairing the database.
     pub fn inspect(path: &Path) -> Result<DoctorReport> {
+        let _lease = RuntimeLease::shared(path, false)?;
         if !path.is_file() {
             return Err(Error::NotFound(format!("AWR database: {}", path.display())));
         }
         let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
             .map_err(db_error)?;
         Self::configure(&conn)?;
-        Self { conn }.doctor()
+        Self {
+            conn,
+            runtime_lease: None,
+        }
+        .doctor()
     }
 
     pub fn doctor(&self) -> Result<DoctorReport> {
@@ -490,5 +533,37 @@ impl Store {
             schema_issues,
             foreign_key_check_error,
         })
+    }
+}
+
+impl Store {
+    /// Export an already coherent RAM snapshot to a new SQLite file. No private SQL API escapes.
+    pub fn export_snapshot(&self, path: &Path) -> Result<()> {
+        self.require_memory()?;
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        drop(options.open(path)?);
+        let mut target = Connection::open(path).map_err(db_error)?;
+        {
+            let backup =
+                rusqlite::backup::Backup::new(&self.conn, &mut target).map_err(db_error)?;
+            if !matches!(
+                backup.step(-1).map_err(db_error)?,
+                rusqlite::backup::StepResult::Done
+            ) {
+                return Err(Error::Storage("snapshot export did not finish".into()));
+            }
+        }
+        target
+            .pragma_update(None, "journal_mode", "DELETE")
+            .map_err(db_error)?;
+        drop(target);
+        std::fs::File::open(path)?.sync_all()?;
+        Ok(())
     }
 }

--- a/crates/awr-store/src/lib.rs
+++ b/crates/awr-store/src/lib.rs
@@ -205,6 +205,13 @@ impl Store {
 
     /// Copy and, if necessary, upgrade only a private in-memory copy of an owned database.
     pub fn preview_snapshot(path: &Path, max_bytes: u64) -> Result<Self> {
+        Self::capture_snapshot(path, max_bytes, true)
+    }
+    /// Current-schema read snapshot with no project-file writes and no migration.
+    pub fn read_snapshot(path: &Path, max_bytes: u64) -> Result<Self> {
+        Self::capture_snapshot(path, max_bytes, false)
+    }
+    fn capture_snapshot(path: &Path, max_bytes: u64, upgrade: bool) -> Result<Self> {
         // Opening even a read-only WAL database may create sidecars. Capture bounded,
         // stable file images first and let SQLite recover only the private temporary copy.
         let snapshot = preview_snapshot::Files::capture(path, max_bytes)?;
@@ -223,9 +230,18 @@ impl Store {
                 "preview requires an owned, supported database".into(),
             ));
         }
+        if !upgrade && version != SCHEMA_VERSION {
+            return Err(Error::Storage(
+                "read snapshot requires the current schema; inspect and upgrade explicitly".into(),
+            ));
+        }
         schema::verify(&conn, version)?;
         let copy = Self { conn }.memory_snapshot(max_bytes)?;
-        Self::initialize_connection(copy.conn, false)
+        if upgrade {
+            Self::initialize_connection(copy.conn, false)
+        } else {
+            Ok(copy)
+        }
     }
 
     pub fn require_memory(&self) -> Result<()> {

--- a/crates/awr-store/src/lib.rs
+++ b/crates/awr-store/src/lib.rs
@@ -563,7 +563,11 @@ impl Store {
             .pragma_update(None, "journal_mode", "DELETE")
             .map_err(db_error)?;
         drop(target);
-        std::fs::File::open(path)?.sync_all()?;
+        // Windows FlushFileBuffers requires a handle opened for writing.
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)?
+            .sync_all()?;
         Ok(())
     }
 }

--- a/crates/awr-store/src/preview_snapshot.rs
+++ b/crates/awr-store/src/preview_snapshot.rs
@@ -1,0 +1,174 @@
+//! An optimistic, bounded capture; SQLite never opens the originating files.
+use awr_core::{Error, Id, Result};
+use std::{
+    fs,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+#[derive(PartialEq, Eq)]
+struct Stamp {
+    length: u64,
+    modified: SystemTime,
+    identity: (u64, u64),
+}
+fn stamp(path: &Path) -> Result<Option<Stamp>> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(value) => value,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    if !metadata.is_file() {
+        return Err(Error::RuleViolation(
+            "snapshot requires regular database files".into(),
+        ));
+    }
+    #[cfg(unix)]
+    let identity = {
+        use std::os::unix::fs::MetadataExt;
+        (metadata.dev(), metadata.ino())
+    };
+    #[cfg(not(unix))]
+    let identity = (0, 0);
+    Ok(Some(Stamp {
+        length: metadata.len(),
+        modified: metadata.modified()?,
+        identity,
+    }))
+}
+pub(super) struct Files {
+    pub database: PathBuf,
+    directory: PathBuf,
+}
+impl Drop for Files {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.directory);
+    }
+}
+impl Files {
+    pub fn capture(database: &Path, max_bytes: u64) -> Result<Self> {
+        let sidecar = |suffix: &str| {
+            let mut name = database.as_os_str().to_owned();
+            name.push(suffix);
+            PathBuf::from(name)
+        };
+        // A journal requires recovery and is not silently interpreted as a settled WAL view.
+        if stamp(&sidecar("-journal"))?.is_some() {
+            return Err(Error::SourceConflict(
+                "database has a rollback journal; retry after its writer finishes".into(),
+            ));
+        }
+        let paths = [database.to_path_buf(), sidecar("-wal")];
+        let before = paths.iter().map(|p| stamp(p)).collect::<Result<Vec<_>>>()?;
+        if before[0].is_none() {
+            return Err(Error::NotFound("AWR database".into()));
+        }
+        let size: u64 = before.iter().flatten().map(|s| s.length).sum();
+        if max_bytes == 0 || size > max_bytes {
+            return Err(Error::InvalidInput(format!(
+                "database and WAL exceed the {max_bytes} byte snapshot limit"
+            )));
+        }
+        let mut images = Vec::new();
+        for (path, metadata) in paths.iter().zip(&before) {
+            if let Some(metadata) = metadata {
+                let mut bytes = Vec::new();
+                fs::File::open(path)?
+                    .take(metadata.length + 1)
+                    .read_to_end(&mut bytes)?;
+                if bytes.len() as u64 != metadata.length {
+                    return Err(changed());
+                }
+                images.push(Some(bytes));
+            } else {
+                images.push(None);
+            }
+        }
+        // All input files must remain unchanged across both complete reads. An active
+        // writer is a retryable conflict, not a corrupt or permanently failed source.
+        for (path, image) in paths.iter().zip(&images) {
+            if let Some(image) = image {
+                let mut second = Vec::new();
+                fs::File::open(path)?
+                    .take(image.len() as u64 + 1)
+                    .read_to_end(&mut second)?;
+                if &second != image {
+                    return Err(changed());
+                }
+            }
+        }
+        let after = paths.iter().map(|p| stamp(p)).collect::<Result<Vec<_>>>()?;
+        if before != after || stamp(&sidecar("-journal"))?.is_some() {
+            return Err(changed());
+        }
+        let directory = std::env::temp_dir().join(format!("awr-preview-{}", Id::new()));
+        let mut builder = fs::DirBuilder::new();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            builder.mode(0o700);
+        }
+        builder.create(&directory)?;
+        let result = Self {
+            database: directory.join("state.db"),
+            directory,
+        };
+        for (name, image) in ["state.db", "state.db-wal"].iter().zip(images) {
+            if let Some(image) = image {
+                let mut options = fs::OpenOptions::new();
+                options.write(true).create_new(true);
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::OpenOptionsExt;
+                    options.mode(0o600);
+                }
+                options
+                    .open(result.directory.join(name))?
+                    .write_all(&image)?;
+            }
+        }
+        Ok(result)
+    }
+}
+fn changed() -> Error {
+    Error::SourceConflict("database changed during read-only capture; retry the preview".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Store;
+    #[test]
+    fn live_wal_is_included_without_touching_original_files() {
+        let directory = std::env::temp_dir().join(format!("awr-preview-test-{}", Id::new()));
+        fs::create_dir(&directory).unwrap();
+        let path = directory.join("state.db");
+        let store = Store::open(&path).unwrap();
+        store.conn.execute_batch("PRAGMA wal_autocheckpoint=0; CREATE TABLE fixture (value TEXT); INSERT INTO fixture VALUES('committed in WAL');").unwrap();
+        let files = || {
+            fs::read_dir(&directory)
+                .unwrap()
+                .map(|p| {
+                    let p = p.unwrap().path();
+                    (p.clone(), fs::read(p).unwrap())
+                })
+                .collect::<std::collections::BTreeMap<_, _>>()
+        };
+        assert!(store.require_memory().is_err());
+        let before = files();
+        let copy = Store::preview_snapshot(&path, 8 * 1024 * 1024).unwrap();
+        assert_eq!(
+            copy.conn
+                .query_row("SELECT value FROM fixture", [], |r| r.get::<_, String>(0))
+                .unwrap(),
+            "committed in WAL"
+        );
+        assert!(copy.require_memory().is_ok());
+        assert!(files() == before, "original database and sidecars changed");
+        assert!(Store::preview_snapshot(&path, 1).is_err());
+        drop(copy);
+        drop(store);
+        fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/crates/awr-store/src/projection.rs
+++ b/crates/awr-store/src/projection.rs
@@ -103,6 +103,7 @@ fn checked_source(conn: &Connection, expected: &Source) -> Result<Source> {
         .map_err(db_error)?
         .ok_or_else(|| Error::NotFound(format!("source {}", expected.id)))?;
     if current.revision != expected.revision
+        || current.locator != expected.locator
         || current.fingerprint != expected.fingerprint
         || current.config != expected.config
         || current.adapter != expected.adapter
@@ -132,6 +133,42 @@ fn validate_ref(value: &Value, source: &Source, fingerprint: &str) -> Result<()>
 }
 
 impl Store {
+    /// Explicit identity-preserving binding transition. Projection is refreshed separately;
+    /// the caller must hold the source lock across the matching manifest replacement.
+    pub fn relocate_source(
+        &mut self,
+        expected: &Source,
+        locator: &str,
+        config: Value,
+        guard: &crate::SourceLock,
+    ) -> Result<Source> {
+        self.check_source_lock(guard)?;
+        awr_core::ensure_public_value(&config)?;
+        awr_core::ensure_public_text(locator)?;
+        if !locator.starts_with("file://") || locator == expected.locator || !config.is_object() {
+            return Err(Error::InvalidInput(
+                "relocation requires a distinct file locator and source configuration".into(),
+            ));
+        }
+        let revision = self.project(expected.project_id)?.project_revision;
+        let mut event = EventDraft::new(
+            "source.relocated",
+            "Source binding relocated; identity and history retained",
+        );
+        event.payload = json!({"source_id":expected.id});
+        let (source, _) = self.runtime_transaction_with_event(expected.project_id, revision, event, |tx, _, event| {
+            let mut source = checked_source(tx, expected)?;
+            let collision: bool = tx.query_row("SELECT EXISTS(SELECT 1 FROM sources WHERE project_id=?1 AND locator=?2 AND id<>?3)", params![expected.project_id.to_string(), locator, expected.id.to_string()], |r| r.get(0)).map_err(db_error)?;
+            if collision { return Err(Error::SourceConflict("relocation target is already owned by a retained source".into())); }
+            let before = SourceState::from_source(&source, true);
+            tx.execute("UPDATE sources SET locator=?1,config_json=?2,freshness='stale',revision=revision+1 WHERE id=?3", params![locator, serde_json::to_string(&config)?, source.id.to_string()]).map_err(db_error)?;
+            source.locator = locator.into(); source.config = config; source.freshness = Freshness::Stale; source.revision += 1;
+            source_changes::annotate(event, Some(before), SourceState::from_source(&source, true), vec![])?;
+            Ok(source)
+        })?;
+        Ok(source)
+    }
+
     pub fn configure_source(&mut self, expected: &Source, config: Value) -> Result<Source> {
         awr_core::ensure_public_value(&config)?;
         if !config.is_object() {

--- a/crates/awr-store/src/runtime_lease.rs
+++ b/crates/awr-store/src/runtime_lease.rs
@@ -1,0 +1,98 @@
+//! Cooperative process lifetime lease for offline snapshot restore.
+use awr_core::{Error, Result};
+use std::{
+    fs::{File, OpenOptions},
+    path::{Path, PathBuf},
+};
+
+pub struct RuntimeLease {
+    file: File,
+    database: PathBuf,
+}
+impl Drop for RuntimeLease {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+fn sibling(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = path.as_os_str().to_owned();
+    name.push(suffix);
+    name.into()
+}
+pub fn pending_path(path: &Path) -> PathBuf {
+    sibling(path, "-restore.pending")
+}
+fn pending(path: &Path) -> Result<bool> {
+    match std::fs::symlink_metadata(pending_path(path)) {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e.into()),
+    }
+}
+impl RuntimeLease {
+    pub(crate) fn shared(path: &Path, create: bool) -> Result<Option<Self>> {
+        if pending(path)? {
+            return Err(Error::Storage("runtime restore is pending; inspect runtime restore-status and recover before opening AWR".into()));
+        }
+        let lease = Self::open(path, create, false)?;
+        if pending(path)? {
+            return Err(Error::Storage(
+                "runtime restore started while opening AWR; retry after recovery".into(),
+            ));
+        }
+        Ok(lease)
+    }
+    pub fn exclusive(path: &Path) -> Result<Self> {
+        Self::open(path, true, true)?
+            .ok_or_else(|| Error::Storage("runtime lease unavailable".into()))
+    }
+    fn open(path: &Path, create: bool, exclusive: bool) -> Result<Option<Self>> {
+        let lock = sibling(path, "-runtime.lock");
+        match std::fs::symlink_metadata(&lock) {
+            Ok(m) if !m.is_file() || m.file_type().is_symlink() => {
+                return Err(Error::RuleViolation(
+                    "runtime lease must be a regular file".into(),
+                ));
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound && !create => return Ok(None),
+            Err(e) if e.kind() != std::io::ErrorKind::NotFound => return Err(e.into()),
+            _ => (),
+        }
+        let mut options = OpenOptions::new();
+        options
+            .read(true)
+            .write(create)
+            .create(create)
+            .truncate(false);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options.open(&lock)?;
+        let result = if exclusive {
+            file.try_lock()
+        } else {
+            file.try_lock_shared()
+        };
+        result.map_err(|_| {
+            Error::Storage(
+                "runtime is in use or an offline restore is active; close AWR clients and retry"
+                    .into(),
+            )
+        })?;
+        Ok(Some(Self {
+            file,
+            database: path.to_owned(),
+        }))
+    }
+    pub fn check_database(&self, path: &Path) -> Result<()> {
+        if self.database == path {
+            Ok(())
+        } else {
+            Err(Error::RuleViolation(
+                "runtime lease belongs to another database".into(),
+            ))
+        }
+    }
+}

--- a/crates/awr-store/src/search.rs
+++ b/crates/awr-store/src/search.rs
@@ -7,8 +7,8 @@ use awr_core::{Error, Freshness, Id, Result, Revision, SourceRef};
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 use serde::{Deserialize, Serialize};
 
-// Secret policy 2 changes Basic credential/prose classification in derived text.
-const POLICY_VERSION: i64 = 5;
+// Rebuild derived summaries when content classification changes.
+const POLICY_VERSION: i64 = 6;
 const KINDS: &[&str] = &[
     "goal",
     "plan",

--- a/crates/awr-store/src/source_lock.rs
+++ b/crates/awr-store/src/source_lock.rs
@@ -1,0 +1,75 @@
+use crate::Store;
+use awr_core::{Error, Result};
+use std::{
+    fs::{File, OpenOptions},
+    time::{Duration, Instant},
+};
+
+pub struct SourceLock {
+    database: String,
+    _file: Option<File>,
+}
+impl Store {
+    fn database_path(&self) -> Result<String> {
+        self.conn
+            .query_row(
+                "SELECT file FROM pragma_database_list WHERE name='main'",
+                [],
+                |r| r.get(0),
+            )
+            .map_err(crate::db_error)
+    }
+    /// Serialize source/configuration transitions across processes, with a bounded wait.
+    pub fn lock_sources(&self) -> Result<SourceLock> {
+        let database = self.database_path()?;
+        if database.is_empty() {
+            return Ok(SourceLock {
+                database,
+                _file: None,
+            });
+        }
+        let path = format!("{database}-sources.lock");
+        if std::fs::symlink_metadata(&path).is_ok_and(|m| !m.is_file()) {
+            return Err(Error::RuleViolation(
+                "source lock must be a regular file".into(),
+            ));
+        }
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+        let start = Instant::now();
+        loop {
+            match file.try_lock() {
+                Ok(()) => {
+                    return Ok(SourceLock {
+                        database,
+                        _file: Some(file),
+                    });
+                }
+                Err(std::fs::TryLockError::WouldBlock)
+                    if start.elapsed() < Duration::from_secs(5) =>
+                {
+                    std::thread::sleep(Duration::from_millis(10))
+                }
+                Err(std::fs::TryLockError::WouldBlock) => {
+                    return Err(Error::SourceConflict(
+                        "source transition is busy; retry after the current operation".into(),
+                    ));
+                }
+                Err(std::fs::TryLockError::Error(e)) => return Err(e.into()),
+            }
+        }
+    }
+    pub fn check_source_lock(&self, guard: &SourceLock) -> Result<()> {
+        if self.database_path()? == guard.database {
+            Ok(())
+        } else {
+            Err(Error::RuleViolation(
+                "source lock belongs to another database".into(),
+            ))
+        }
+    }
+}

--- a/docs/reference/database-recovery.md
+++ b/docs/reference/database-recovery.md
@@ -42,6 +42,12 @@ distinct from the migration transaction. Doctor never invokes that upgrade path.
 
 ## Backup and recovery
 
+The native [`runtime` snapshot commands](runtime-snapshots.md) provide coherent
+backups, integrity checks, same-root matching restore previews and explicit offline
+database restoration. They retain source/configuration copies for verification,
+preserve added files and refuse source drift. The broader manual recovery inventory
+below also covers external files and schema upgrades outside automatic restore.
+
 For a recoverable project snapshot, retain all of the following together:
 
 - A coherent SQLite backup of `.awr/state.db`, made with SQLite's backup API or

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -117,6 +117,38 @@ A failed projection does not mean the configuration was unwritten; inspect the
 receipt and current configuration before acting. Identical configuration returns
 `no_change`. Configuration setup is separate from task/document source editing.
 
+## Read a coherent query snapshot
+
+Status, ready work, work details, object catalogs, search, and context compilation
+refresh through a shared source transition guard before reading one SQLite snapshot
+in RAM. The lock waits at most five seconds. Source projection steps retry only
+optimistic runtime revision conflicts, at most four attempts; source/permission/parse
+failures remain failures. A pending relocation is explicitly recoverable, not a reason
+to silently reuse stale facts. Runtime write commands retain their expected-revision
+checks against the live database.
+
+Query responses include version 1 `snapshot` metadata: the coherent query revision,
+a `source_state_fingerprint` derived from retained source IDs, revisions, fingerprints and
+parsing configuration, and the source refresh revision. Runtime-only events advance
+the project revision without changing the source state fingerprint. A response is a snapshot at
+its recorded revision; later events do not make its internally consistent facts false.
+Context hashes already bind their source and runtime snapshot identities.
+
+`status --cached`, `ready --cached`, `work show <key> --cached`, `object list <kind>
+--cached` and `search --cached` read the last recorded projections without opening
+business files or writing project files. They explicitly return `read_only: true`,
+`source_refresh_performed: false`, `freshness_basis: last_recorded_source_state` and
+`snapshot.source_currentness_verified: false`. Cached facts do not establish current
+progress. The temporary capture is bounded to 256 MiB and may reject an active writer;
+retry after it settles. It never ignores WAL data or upgrades the live schema.
+
+MCP read operations remain read-only and still require source files to match indexed
+facts. They return their coherent revision/source state fingerprint with no source refresh revision.
+A later runtime event alone does not invalidate that read; source drift still rejects it.
+CLI refresh reads can update the projection cache, so `read_only` remains false for
+the overall operation even though the query itself uses RAM. Negotiate this behavior
+with capability `query.coherent_snapshot`.
+
 ## Relocate one source while retaining its identity
 
 ```text

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -750,3 +750,35 @@ Counts describe source states; they do not certify acceptance or releases. Full
 organization evidence assessment runs only against an explicitly supplied
 `source_sha`, as before. Snapshot and cached-currentness metadata retain the query
 contract above. A summary reduces transport size, not the source verification scope.
+
+### Explicit project organization metadata
+
+`organization show --source SOURCE_ID --mapping fields.json` reads source annotations.
+A mapping is an object from `phase`, `scope`, `focus`, and/or `next_action` to exact
+JSON pointers, for example `{"phase":"/current/stage","focus":"/current/work"}`.
+Parents must already be YAML mappings. Escaped pointer segments, array ancestors,
+overlapping paths, entity collections, lifecycle, release, contract and count fields
+are outside this finite writer. Unmapped values and surrounding YAML bytes remain
+untouched. Hosts can consume the returned focus explicitly; reading it never starts,
+claims, activates, reopens or completes work.
+
+`organization preview --input change.json` is a read-only full preflight. The input
+has `version: 1`, `request_key`, `actor: {host, subject, origin}`, `reason`,
+`source_id`, `source_fingerprint`, `mapping`, and `values`. Actor origins reuse the
+host contract (`human`, `ai_accepted`, `delegated_agent`); they record provenance,
+not permission. Values use a phase plan key, a scope array of exact work keys, a
+nonterminal focus work key, and next-action text. Null can clear optional metadata.
+Unknown references, focus/phase or focus/scope conflicts, stale sources and attempts
+to alter projected work, dependencies, status, acceptance or evidence are rejected.
+The preview binds every changed field, source/configuration fingerprints and project
+revision. No project-specific completion formula or denominator is embedded in AWR.
+
+Apply with `organization change --input change.json --expected-preview HASH
+--expected-revision N`. Inspect with `organization status --key KEY`; recover an
+interruption with `organization recover --key KEY --expected-revision N` after
+reviewing its receipt. Recovery accepts only the recorded before/after source bytes
+and original configuration, and never overwrites external edits. The source write
+and subsequent projection refresh are separate durable steps. If refresh fails,
+the retained receipt identifies the possible saved source; source history records
+the refreshed fingerprint. Repeated completed requests return the historical receipt
+without applying the metadata again. Private receipts live under `.awr/mutations`.

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -117,6 +117,42 @@ A failed projection does not mean the configuration was unwritten; inspect the
 receipt and current configuration before acting. Identical configuration returns
 `no_change`. Configuration setup is separate from task/document source editing.
 
+## Relocate one source while retaining its identity
+
+```text
+awr source relocate --source <source-id> --to plans/work-ledger.yaml --json
+awr source relocate --source <source-id> --to plans/work-ledger.yaml --accept --expected-preview <fingerprint> --json
+awr source relocate-status <fingerprint> --json
+awr source relocate-recover <fingerprint> --json
+```
+
+Version 1 relocates one explicit relative file mapping inside the same project.
+The destination must already contain the exact indexed bytes. The original may be
+present or already moved by the user; AWR does not move, delete or overwrite either
+business file. Change content separately. The preview binds the retained source ID,
+source revision/configuration, both paths, destination bytes and exact before/after
+manifest text. Adapters must produce the same object keys and IDs in the semantic
+preflight. Path-derived keys and directory/Git mappings are explicitly unsupported;
+YAML ledgers with stable explicit keys are supported. An identical hash alone never
+merges source identities. Any destination owned by another retained source conflicts.
+
+Acceptance retains source/object identities and runtime sessions, claims, checkpoints,
+dependencies and evidence. It appends `source.relocated` with before/after locators;
+`source history`, `event show --full` and `source changes` expose the history. Old
+checkpoint references remain immutable. Current projection references use the new
+location after reindexing. Manifest formatting changes are included in the exact
+preview and require that fingerprint.
+
+The SQLite binding and manifest rename are individually durable, not a cross-file
+transaction. A source transition lock coordinates refresh/configuration writers;
+an interrupted relocation leaves a pending marker that prevents ordinary refreshes
+from inventing a replacement source. Read-only status reports the journal and actual
+bindings. Explicit recovery accepts only the recorded before/after manifest and
+source states and unchanged target bytes, then completes the missing steps. Changed
+user files remain untouched. A repeated completed request returns its existing receipt
+and observations without applying it again. Preserve mutation journals in matching
+runtime backups; do not delete a pending marker to bypass recovery.
+
 ## Traverse the complete catalog
 
 ```text

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -722,7 +722,7 @@ A single reviewed fingerprint covers all targets. Every target is preflighted be
 
 ## Embed and upgrade the native host payload
 
-Version `0.3.1` exposes the host integration capabilities with schema 4. Use the immutable host payload produced by `scripts/release/build_host_bundle.py`; it includes both native executables, exact capability metadata, file/archive SHA256 values, source/version/platform identity and licenses. Invoke the bundled binary by absolute path with an explicit project root. The native runtime does not require Node, Python, Rust or PATH setup. Development-time packaging and upgrade fixtures run separately.
+Version `0.3.2` exposes the host integration capabilities with schema 4. Use the immutable host payload produced by `scripts/release/build_host_bundle.py`; it includes both native executables, exact capability metadata, file/archive SHA256 values, source/version/platform identity and licenses. Invoke the bundled binary by absolute path with an explicit project root. The native runtime does not require Node, Python, Rust or PATH setup. Development-time packaging and upgrade fixtures run separately.
 
 Follow the [matched upgrade and rollback procedure](../release/DISTRIBUTIONS.md#matched-upgrade-and-rollback-checklist). Preserve all runtime history and source authority, validate old-schema migration with IDs/record inventories, retain read-only legacy APP records, and switch to one AWR writer. A rollback restores a matching program/database/configuration/source set while keeping new user files and the superseded runtime snapshot. Old programs must reject newer databases before writing; host signing, full APP integration and other deployment platforms require their own evidence.
 

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -69,18 +69,32 @@ text for the manifest, `.gitignore` and generated intake files. Runtime database
 WAL and temporary staging effects are listed separately. This preview performs no
 project writes; an explicitly requested `--write-draft` still writes its output file.
 
+The version 1 `preview.semantic` report parses the exact captured source bytes through
+the normal adapters and projection constraints in private RAM. Existing database and WAL
+files are captured with bounded repeated byte/identity/mtime checks, then opened by
+SQLite in an owner-only temporary directory and copied into RAM. The temporary copy
+is removed after use; SQLite never opens the project database during preflight.
+Concurrent writes or rollback journals reject capture for a later retry. Compatible
+migrations happen only in RAM. It returns
+`can_apply`, `can_execute`, organization gaps and their total/truncation, plus stable
+source identity/revision/configuration bindings. A generated preview is not evidence
+that it can be applied. `can_apply: true` permits intake; unresolved goals/references
+can still make `can_execute: false`. Neither flag proves business acceptance. The
+snapshot is bounded to 256 MiB; larger databases return a preflight issue.
+
 Pass that fingerprint as `init --accept --expected-preview <fingerprint>` with the
 same input/mapping arguments. Changed sources, mapping semantics, existing manifest
 bytes or ignore contents reject the old preview. Existing clients may omit the new
-flag and retain the legacy behavior. A draft file's original inventory fingerprint
+flag; semantic preflight still applies. A draft file's original inventory fingerprint
 is still checked; editing a draft requires previewing that edited draft before
 acceptance. Multiple source candidates remain an explicit ambiguity.
 
 Repeated initialization keeps the existing manifest, project/work identities,
 events, sessions and checkpoints. Non-Git projects are supported. Preview can read
 a read-only project, but initialization requiring runtime writes is rejected there.
-Source failures remain in the result: acceptance can create a partial index with a
-nonzero `SourceStale` result, preserving usable source records. It must not be shown
+Malformed sources and predictable identity conflicts now return `SourceStale` before
+configuration or runtime writes. Failures arising after writes start can still leave a
+partial index; retain the nonzero result and inspect the reported effects. It must not be shown
 as a fully successful import. Initializing multiple files is not a cross-file atomic
 transaction; interrupted staging may require inspection before retry.
 

--- a/docs/reference/host-contract.md
+++ b/docs/reference/host-contract.md
@@ -725,3 +725,28 @@ A single reviewed fingerprint covers all targets. Every target is preflighted be
 Version `0.3.1` exposes the host integration capabilities with schema 4. Use the immutable host payload produced by `scripts/release/build_host_bundle.py`; it includes both native executables, exact capability metadata, file/archive SHA256 values, source/version/platform identity and licenses. Invoke the bundled binary by absolute path with an explicit project root. The native runtime does not require Node, Python, Rust or PATH setup. Development-time packaging and upgrade fixtures run separately.
 
 Follow the [matched upgrade and rollback procedure](../release/DISTRIBUTIONS.md#matched-upgrade-and-rollback-checklist). Preserve all runtime history and source authority, validate old-schema migration with IDs/record inventories, retain read-only legacy APP records, and switch to one AWR writer. A rollback restores a matching program/database/configuration/source set while keeping new user files and the superseded runtime snapshot. Old programs must reject newer databases before writing; host signing, full APP integration and other deployment platforms require their own evidence.
+
+### Compact scoped status (version 1)
+
+`awr status --view summary [--work KEY ...] [--goal KEY] [--milestone KEY]`
+returns compact JSON under `--json`. The same selectors are available in
+`awr_project_status` as `view: "summary"`, `work: ["KEY"]`, `goal`, and `milestone`.
+Selectors intersect exact source-declared associations; unknown references are errors.
+No selectors means all projected work. The default full view remains compatible;
+selectors on that view are rejected rather than ignored.
+
+The summary includes source status counts, current work, the next action, readiness
+and blocking codes, all-source freshness, project organization gaps and registered
+pending mutation/checkpoint findings. Pending findings are project-wide, even for a
+narrow scope. Lists show at most five entries and carry total/omitted counts; text
+uses a 240-character public summary. `omissions` identifies excluded work, truncated
+organization scans, and details left for `work show`, `source list`, full `status`,
+`recovery inspect`, or a specific operation's status command. Filesystem-only and
+host-private journals are outside the snapshot's pending inventory and explicitly
+listed as not evaluated. Zero registered pending findings is not a claim that an
+external host has no uncertain operations.
+
+Counts describe source states; they do not certify acceptance or releases. Full
+organization evidence assessment runs only against an explicitly supplied
+`source_sha`, as before. Snapshot and cached-currentness metadata retain the query
+contract above. A summary reduces transport size, not the source verification scope.

--- a/docs/reference/runtime-snapshots.md
+++ b/docs/reference/runtime-snapshots.md
@@ -44,6 +44,11 @@ The bundle contains:
 - `sources/<source-id>.bin`: exact registered source content, including supported
   Git locators and explicitly authorized external sources.
 
+Each source retains its observed locator separately from its registration locator.
+A Git source binds the resolved immutable commit and original blob bytes; its
+source fingerprint differs from the raw payload checksum. Advancing a configured
+Git ref invalidates matching restore even when its blob content stays identical.
+
 External artifacts, unregistered business files and host state outside `.awr`
 need their own backup. A restored artifact registration does not restore an
 excluded file. Bundles can contain private work, so keep them in private storage;

--- a/docs/reference/runtime-snapshots.md
+++ b/docs/reference/runtime-snapshots.md
@@ -1,0 +1,126 @@
+# Matched runtime snapshots
+
+The native CLI exposes `runtime.matched_snapshot` through `awr capabilities`.
+These commands bind the executing CLI bytes, schema, project identity and root,
+configuration, registered source bytes and retained runtime history. They never
+rewrite a host's `runtime-binding.json` or switch its executable pin. A development
+build and a published build can report the same version while having different
+binary hashes; the hashes determine restore compatibility.
+
+```sh
+awr --project /absolute/project --json runtime binding
+awr --project /absolute/project --json runtime backup \
+  --output /absolute/backups/new-snapshot \
+  --companion /absolute/bin/awr-mcp
+awr --json runtime check --backup /absolute/backups/new-snapshot
+awr --project /absolute/project --json runtime restore-preview \
+  --backup /absolute/backups/new-snapshot
+```
+
+Create the output's parent first. The output must be new and outside `.awr`.
+`--companion` is optional: it retains and hashes the explicitly selected executable;
+it does not infer protocol or version compatibility. Optional `--source-sha` records
+a caller assertion; it is not a build attestation. Retain the release's verified
+build manifest separately when commit-to-program provenance is required.
+
+`binding`, `check` and `restore-preview` are read only. The backup command writes
+only its new output directory. It refuses stale source content, changed mappings,
+unindexed directory members and damaged databases. It validates source inventory
+in a RAM copy without refreshing the original project's projections. A coherent
+SQLite image includes committed WAL history. Sources and persistent runtime files
+are compared again before sealing; concurrent file changes require a fresh retry.
+This is an optimistic file consistency check, not a filesystem-wide transaction.
+
+The bundle contains:
+
+- `snapshot.json`: versioned identities, revisions, source bindings, payload sizes,
+  hashes and the manifest fingerprint.
+- `program/awr` and optional `program/awr-mcp` (with `.exe` on Windows): retained
+  executable bytes for the original platform.
+- `runtime/state.db`: a standalone SQLite backup made from a coherent RAM image.
+- Other persistent `.awr` files, including managed artifacts, host binding files
+  and mutation/checkpoint journals. Database sidecars, `.lock` files and the
+  transient restore marker are excluded.
+- `sources/<source-id>.bin`: exact registered source content, including supported
+  Git locators and explicitly authorized external sources.
+
+External artifacts, unregistered business files and host state outside `.awr`
+need their own backup. A restored artifact registration does not restore an
+excluded file. Bundles can contain private work, so keep them in private storage;
+they are not release assets. On Unix, new directories are owner-only, data files
+are mode 0600 and executable copies are mode 0700. Limits are 256 MiB per file,
+1 GiB combined and 10,000 payloads. An interrupted or rejected backup without a
+valid final manifest is unsealed and cannot be restored. Existing output paths
+are never reused automatically.
+
+`check` verifies manifest integrity, all listed payload bytes, SQLite integrity,
+schema, project identity, history revision and registered source bindings. It does
+not need the original project to exist. Fingerprints use `sha256:` followed by
+hexadecimal SHA-256; the manifest digest covers compact JSON with recursively
+sorted object keys and an empty `fingerprint` field. Digests establish integrity,
+not authorship; only use backups whose provenance you trust.
+
+## Preview and restore
+
+Automatic restore replaces only `.awr/state.db`. It requires the original canonical
+project root, current schema and exact executing CLI bytes. If a companion was
+retained, its original path must still contain the matching bytes. Every registered
+source and every known persistent runtime/configuration file must still match the
+backup. Changed or missing known files are rejected instead of overwritten. A
+source relocation, changed configuration or schema migration needs its separate
+reviewed recovery procedure.
+
+Additional files remain in place, including files added inside `.awr`. The preview
+lists those additional runtime files. Database history after the restore revision
+will be displaced; the exact database, WAL, SHM and journal bytes being replaced
+are retained under `.awr/restores/<id>/rollback/`. Newly created business files
+are not scanned, deleted or overwritten. They may be unregistered after a history
+restore and need explicit review.
+
+The current database must have a verifiable matching AWR identity. A wholly absent
+database with no sidecars is supported when the configuration, sources and known
+runtime files still match. An existing unreadable, foreign or unsupported database
+is refused: preserve and diagnose it separately. This command is not an automatic
+repair of arbitrary corruption or a cross-root migration tool.
+
+Stop all AWR clients, hosts and execution supervisors before taking the restore
+preview. Then pass its exact `fingerprint`:
+
+```sh
+awr --project /absolute/project --json runtime restore \
+  --backup /absolute/backups/new-snapshot \
+  --expected-preview 'sha256:<reviewed-preview-hash>' --offline
+```
+
+`--offline` acknowledges that **all** clients are stopped, including older AWR
+versions. New native clients hold a shared runtime lease; restoration requires an
+exclusive lease and fails if they remain open. Older versions do not participate
+in this lock, so the flag is an operator assertion, not proof of their absence.
+Target changes invalidate the preview. Restoration retains rollback bytes and a
+durable receipt before replacing the database, validates the installed history,
+then removes the pending marker. Normal opens refuse a pending restore.
+
+## An interrupted restore
+
+```sh
+awr --project /absolute/project --json runtime restore-status
+awr --project /absolute/project --json runtime restore-recover --offline
+awr --project /absolute/project --json runtime restore-status --id <restore-id>
+```
+
+Status works without opening SQLite. Recovery resumes only the recorded request
+from its exact before/after database state, matching backup and matching sources,
+configuration and known runtime files. An interrupted sidecar removal is accepted
+only if remaining sidecars match their recorded bytes. External database changes
+leave the marker in place and require inspection; recovery never guesses a new
+baseline. If replacement already completed, it finalizes the receipt/marker only.
+A completed restore is never replayed over later history. Retain all journal and
+rollback files while investigating a refusal.
+
+After success, restart clients, inspect `doctor`, and compile fresh context before
+work. Restored claims retain their original lease times, and host-side request
+receipts may describe history that was displaced. Do not automatically replay
+those requests. The local CLI tests cover history identity, checkpoints/evidence,
+source drift, preserved additions, runtime leases, missing databases and simulated
+interruption before/after replacement. They do not establish machine power-loss,
+native application acceptance or execution-supervisor recovery on other platforms.

--- a/docs/reference/secret-boundaries.md
+++ b/docs/reference/secret-boundaries.md
@@ -1,14 +1,14 @@
 # 秘密数据边界
 
-当前使用 `awr-core` 的秘密策略 3。组件合同 `tests/security/payloads/contract.json` 1.5.0 保持 32 个条件，覆盖无凭据结构定义、Bearer 普通文字和伪装夹带检查。原始来源仍由项目维护者负责；AWR 不改写或删除包含敏感值的源文件。
+当前使用 `awr-core` 的秘密策略 4。组件合同 `tests/security/payloads/contract.json` 1.6.0 保持 32 个条件，覆盖无凭据结构定义、公开命令说明、授权叙述、Bearer 普通文字和伪装夹带检查。原始来源仍由项目维护者负责；AWR 不改写或删除包含敏感值的源文件。
 
-写入前检查原始文本和解析后的结构。覆盖来源文件及直接解析、Manifest、直接投影与来源配置、提案 patch、所有事件、checkpoint 的 digest/列表、证据元数据和产物元数据。拒绝返回固定 `RuleViolation`，不附带命中的值、键或片段。来源读取失败会保留旧投影并报告非新鲜状态；直接运行态写入被拒绝时不提交记录和事件。
+写入前检查原始文本和解析后的结构。覆盖来源文件及直接解析、Manifest、直接投影与来源配置、提案 patch、所有事件、checkpoint 的 digest/列表、证据元数据和产物元数据。拒绝保留 `RuleViolation`，并提供 `details.policy_version`、`details.category` 和 `details.next_action`；分类为 `credential`、`labelled_value`、`environment_dump` 或 `private_prompt`，不附带命中的值、键或片段。来源索引问题保留这些分类，CLI/MCP 使用同一合同。来源读取失败会保留旧投影并报告非新鲜状态；直接运行态写入被拒绝时不提交记录和事件。
 
 识别范围包括：
 
 - API key、access/refresh/id token、client secret、password/passwd/pwd、authorization，以及中文密码、令牌、密钥等标签后的值；支持常见前缀变量名。
 - 显式 `private_prompt` 字段、私有提示词标签和独立的私有 prompt 标题块。
-- `.env` 风格的大写变量赋值、`export` 赋值、明确标为 env/environment 的对象、列表或多行块。普通的 `environment: candidate` 业务标签可以使用。
+- `.env` 风格的独立大写变量赋值、`export` 赋值、明确标为 env/environment 的对象、列表或多行块。普通的 `environment: candidate` 业务标签可以使用。
 - 具有足够长度的常见 OpenAI、GitHub、Slack 凭据前缀，AWS access key、JWT、Bearer/Basic 凭据、PEM 私钥头，以及含用户名和密码的 URL。
 
 Basic 候选值需能按标准 Base64 解码，并包含用户名和密码之间的冒号，依据 [RFC 7617 第 2 节](https://www.rfc-editor.org/rfc/rfc7617#section-2)。检测也接受省略填充符的形式，不设置会漏掉短用户名/密码的长度下限。普通的 “basic source-intake” 或 “basic authentication” 不因此被当作凭据；带有 `authorization` 等敏感标签的值仍按标签规则检查。
@@ -21,11 +21,15 @@ Bearer 的普通协议讨论（例如 `Bearer authentication`）可以保留。`
 
 可以保留安全主题的普通讨论、空值和明确占位符，例如 `[redacted]`、`<redacted>`、`[withheld]`、`***`、`${EXAMPLE_API_KEY}`。实际值应从来源中移除，只留下必要的引用。讨论密码保护、token 预算或 API key 管理不会因这些词本身被删除。
 
+公开配置的命令说明也可以保留，例如 `PROJECT_ROOT=/public/project EXPECTED_ITEMS=42 cargo test --offline`，以及叙述或注释中的 `EXPECTED_ITEMS=42`。识别范围限于简单的无引号变量前缀加可识别命令词；不执行命令，不按项目名或某个变量名豁免。独立赋值、只有若干赋值的环境转储、`export` 和明确的 environment 对象继续拒绝。所有位置的敏感键赋值和可识别凭据仍独立检查；把实际密钥放在命令前缀中不能使其通过。
+
+`Completed native authorization: the user confirmed this operation.` 这类叙述也可保留：标签前有普通文字，后面是多词文字或带明确标点的中文句子。独立的 authorization 字段、HTTP Header、不透明单值，以及跟随 Bearer/Basic 的值继续拒绝。不确定内容保留拒绝，不提供全局关闭检查或任意字符串白名单。需要明确表达公开配置时可以使用普通结构字段，授权过程可以记在 summary 等叙述字段；这不是对任意未标记私有文字的自动分类承诺。
+
 产物在创建受管文件前，读取完整且最多 64 MiB 的快照，完成检查，再写入同一份字节并计算摘要。扫描不使用可能漏掉跨块内容的滑动窗口；为此使用有明确上限的内存缓冲。显式产物/证据正文读取仍受 16 MiB 限制，并在大小、摘要和秘密检查全部通过后返回。正文为有效 JSON 时也检查解码内容。元数据登记不构成对外部文件正文的验证。
 
 对旧数据的输出保护：
 
-- FTS 策略为 5，首次读取时重建旧缓存，包括旧策略下误删的普通认证说明和结构定义。来源解析配置版本为 2，重索引时重新解析旧适配器投影；来源映射变更同样使缓存失效。摘要检查完整字段后才取短文本；敏感摘要标为 `[redacted]`。身份、关联工作或来源引用含敏感值时，整条搜索文档不进入索引。查询参数也经过检查。
+- FTS 策略为 6，首次读取时重建旧缓存，包括旧策略下误删的普通认证说明、公开配置和结构定义。失败来源重索引时重新读取原始内容；来源映射和适配器配置变更同样使缓存失效。摘要检查完整字段后才取短文本；敏感摘要标为 `[redacted]`。身份、关联工作或来源引用含敏感值时，整条搜索文档不进入索引。查询参数也经过检查。
 - L0、L1、硬规则/关联事实及 delta 检查实际选中的输出。选中的必需事实包含敏感值时返回 `ContextIncomplete`，不返回看似完整的包、哈希或渲染文本。原本不进入 Context 的正文仍然被排除；例如 delta 只使用 checkpoint 的基线和身份，不返回 digest。
 - CLI 的敏感参数在参数解析报错前拒绝；证据、完成输入、分支关闭输入及 Manifest 的结构错误不回显字段内容。CLI 和 MCP 共用安全错误报告；MCP 同时保护结构化结果、文本副本与读取输出。
 

--- a/docs/release/0.3.2.md
+++ b/docs/release/0.3.2.md
@@ -1,0 +1,68 @@
+# AWR 0.3.2
+
+0.3.2 improves project intake, source continuity, daily work management and recovery.
+The native CLI and MCP packages retain all four supported platforms, including
+Intel Mac, and database schema 4.
+
+```sh
+npm install -g @originoneai/agent-work-runtime@0.3.2
+# or, in a Python virtual environment
+python -m pip install agent-work-runtime==0.3.2
+awr --version
+awr-mcp --version
+```
+
+## Changes
+
+- Public configuration and authorization notes can be recorded without being
+  mistaken for secret values. Secret-value checks still apply.
+- Intake validates source semantics before writing project configuration, sources
+  or runtime state. Rejected mappings return diagnostic issues without leaving a
+  partially initialized project.
+- Explicit source relocation preserves source identity and history when a
+  supported single-file source moves without content changes, with recovery for
+  interrupted operations.
+- CLI and MCP reads coordinate source refreshes and return coherent query
+  snapshots. Cached reads identify their historical basis.
+- Compact status summaries support work, goal and milestone filters through the
+  CLI and `awr_project_status` MCP tool.
+- The public host workflow example provides pinned-binary session, context,
+  checkpoint, evidence and completion operations, including explicit handling of
+  uncertain write outcomes.
+- Organization commands preview and maintain explicitly mapped project phase,
+  scope, focus and next-action fields without changing task completion.
+- Runtime commands create and check matched program/configuration/source/database
+  snapshots and perform previewed offline database restoration with recovery.
+  Git source identities include the resolved commit, even when blob bytes match.
+
+See the [host contract](../reference/host-contract.md),
+[host workflow example](../../examples/host-app/README.md) and
+[runtime snapshot contract](../reference/runtime-snapshots.md) for supported
+operations and exact recovery boundaries.
+
+## Compatibility and upgrade
+
+| Target | Minimum baseline |
+| --- | --- |
+| macOS Apple Silicon arm64 | macOS 15 |
+| macOS Intel x64 | macOS 15 |
+| Linux x64 GNU | glibc 2.39 |
+| Windows x64 | Native verification on Windows Server 2025 |
+
+npm launchers require Node 22.14+; Python launchers require Python 3.9+.
+Keep npm optional dependencies enabled. Native executables run without either
+launcher runtime; the optional host workflow example requires Python 3.11+.
+
+No schema migration is required from 0.3.1. Keep the original project root,
+authoritative sources, runtime history and previous executable when upgrading.
+Retain a matching backup before switching the pinned program; follow the
+[upgrade and rollback procedure](DISTRIBUTIONS.md#matched-upgrade-and-rollback-checklist).
+Native snapshot restoration requires offline clients and matching source,
+configuration, project and program identities. It restores the database and
+retains displaced bytes; it does not overwrite changed source files or restore
+host-managed data outside `.awr`.
+
+Archives carry source identity, binary hashes, Apache-2.0 and dependency notices.
+The release manifest and `SHA256SUMS` bind the package files. Native platform and
+installation checks do not replace host-application integration or real-agent
+business acceptance.

--- a/docs/release/DISTRIBUTIONS.md
+++ b/docs/release/DISTRIBUTIONS.md
@@ -1,13 +1,13 @@
 # Native npm and PyPI distributions
 
-AWR 0.3.1 is a stable package release. npm uses the `latest` channel and PyPI uses
-`0.3.1` without a prerelease suffix. Both install the same Rust CLI and MCP server;
+AWR 0.3.2 is a stable package release. npm uses the `latest` channel and PyPI uses
+`0.3.2` without a prerelease suffix. Both install the same Rust CLI and MCP server;
 no separate JavaScript or Python SDK is included.
 
 ```sh
-npm install -g @originoneai/agent-work-runtime@0.3.1
+npm install -g @originoneai/agent-work-runtime@0.3.2
 # or, in a virtual environment
-python -m pip install agent-work-runtime==0.3.1
+python -m pip install agent-work-runtime==0.3.2
 awr --version
 awr-mcp --version
 ```
@@ -70,9 +70,9 @@ packages, checksums and aggregate manifest. Raw execution records stay local or 
 isolated CI artifacts and are not committed to the repository.
 
 
-## Pinned host payload (0.3.1)
+## Pinned host payload (0.3.2)
 
-AWR `0.3.1` uses database schema 4. Host applications can bundle the same native CLI and MCP server without the registry launchers. A locally built payload has its own recorded source and artifact identity. The matching macOS arm64 or Intel x64 payload can be embedded directly in an application; runtime users need no Node/Python/Rust installation and no PATH changes. The build/verification machine still needs its development tools. The host is responsible for application signing, notarization and updating its bundled binary.
+AWR `0.3.2` uses database schema 4. Host applications can bundle the same native CLI and MCP server without the registry launchers. A locally built payload has its own recorded source and artifact identity. The matching macOS arm64 or Intel x64 payload can be embedded directly in an application; runtime users need no Node/Python/Rust installation and no PATH changes. The build/verification machine still needs its development tools. The host is responsible for application signing, notarization and updating its bundled binary.
 
 From clean committed source:
 
@@ -86,11 +86,11 @@ Invoke the executable by its absolute application-resource path with `--project 
 
 ## Matched upgrade and rollback checklist
 
-Development builds expose a native `runtime.matched_snapshot` capability for
+AWR 0.3.2 exposes a native `runtime.matched_snapshot` capability for
 `runtime binding`, `backup`, `check`, `restore-preview`, `restore`, `restore-status`
 and `restore-recover`. See the [snapshot contract](../reference/runtime-snapshots.md)
 for exact program/configuration/source matching and offline history restoration.
-This does not change published 0.3.1 packages. Cross-schema downgrade and host files
+Cross-schema downgrade and host files
 outside `.awr` still require the broader matched inventory below.
 
 Use the same project directory and identity. Arbitrary relocation, cloud synchronization and long-lived dual writers are outside this contract.

--- a/docs/release/DISTRIBUTIONS.md
+++ b/docs/release/DISTRIBUTIONS.md
@@ -86,6 +86,13 @@ Invoke the executable by its absolute application-resource path with `--project 
 
 ## Matched upgrade and rollback checklist
 
+Development builds expose a native `runtime.matched_snapshot` capability for
+`runtime binding`, `backup`, `check`, `restore-preview`, `restore`, `restore-status`
+and `restore-recover`. See the [snapshot contract](../reference/runtime-snapshots.md)
+for exact program/configuration/source matching and offline history restoration.
+This does not change published 0.3.1 packages. Cross-schema downgrade and host files
+outside `.awr` still require the broader matched inventory below.
+
 Use the same project directory and identity. Arbitrary relocation, cloud synchronization and long-lived dual writers are outside this contract.
 
 1. Quiesce host/CLI/MCP writers and execution supervisors. Record the one application owner that will resume writes. Negotiate the candidate's capabilities/schema before opening the existing database; retain the previous executable and its source/version/hash. Check the current database's integrity and foreign keys with its matching program.

--- a/examples/host-app/README.md
+++ b/examples/host-app/README.md
@@ -42,3 +42,52 @@ command-specific contract in [host-contract](../../docs/reference/host-contract.
 path containing spaces, with no TTY. It requires Python 3.11+ on the development/CI
 machine. The test also checks binary pin rejection, partial errors, and unknown
 timeout outcomes without replaying commands.
+
+## Explicit work workflow
+
+`workflow.py` is a reusable thin caller for ordinary engineering work. It uses the
+same `Host` pin checks, argv, public domain commands, and private receipts. It adds
+an OS-locked, atomically saved workflow state with a pinned executable checksum,
+program version, canonical project root and expected project ID. Python 3.11+ is
+needed only for this optional example; the native runtime is unchanged.
+
+Every invocation supplies `--binary`, `--sha256`, `--version`, `--project`,
+`--project-id`, and `--state /private/path/workflow/state.json`. Keep that directory
+ignored and outside registered sources. The individual commands are:
+
+1. `begin --work KEY --agent NAME --provider NAME --model NAME --expected-revision N`
+   starts and claims one session. `adopt --session ID --work KEY` attaches an existing
+   active session to a new workflow without duplicating the runtime session.
+2. `context` returns the full actual context pack and records its immutable receipt.
+   Deliver and consume `work_context.rendered_context`, then call
+   `ack --consumed-hash HASH`. A hash without the matching intact delivery is rejected.
+   The acknowledgement is explicitly a caller attestation; software cannot prove
+   model comprehension. The example never acknowledges context on the caller's behalf.
+3. `checkpoint --consumed-hash HASH --digest TEXT --next-action TEXT --expected-revision N`
+   uses only the acknowledged delivery. A new `context` invalidates the old acknowledgement.
+4. `evidence --input DRAFT.json --expected-revision N` records evidence for the selected
+   work through the existing evidence contract. Commands in evidence are not executed.
+5. `finish --input COMPLETION.json --reason TEXT --expected-revision N` runs the domain
+   completion gates, persists the completed-work phase, then ends that exact session.
+   Source completion and session end are separate durable operations, not an atomic batch.
+
+The class exposes the same methods for embedding. Start from an initialized project
+and reviewed source work; this wrapper does not silently activate or rewrite a task.
+Revisions remain explicit and are returned after each operation. Workflow state is
+operation continuity, not a replacement for source work state or an AWR acceptance record.
+
+Before any write, a pending operation is durably saved. A crash, timeout, malformed
+response or domain error leaves it for inspection; writes stop and are never retried
+automatically. `inspect [--session ID --work KEY]` uses actual public session, work
+and recovery queries and returns an inspection checksum. Read both the invocation
+receipt and observed state. `reconcile --inspection-sha256 HASH --reason TEXT`
+records an explicit operator decision and observed phase, without asserting that the
+uncertain command succeeded. For an unknown begin, identify its actual session and
+pass `--session` and `--work` to inspect/reconcile. Unbound outcomes are not guessed.
+A completed work/session is never automatically reopened or duplicated.
+
+The regression simulates losing a response *after a real checkpoint was saved*,
+then inspects and reconciles without replay. It also covers stale revisions, wrong
+pins, delivery tampering, adoption and a complete synthetic evidence/finish flow.
+This is a public CLI workflow, not restoration of a private native client or E4
+business acceptance.

--- a/examples/host-app/test_workflow.py
+++ b/examples/host-app/test_workflow.py
@@ -1,0 +1,101 @@
+import json
+import os
+from pathlib import Path
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+from host import Host, CommandFailed, Result, digest
+from workflow import Workflow
+
+
+class WorkflowTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix='awr 工作流 ')
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name).resolve()
+        self.binary = Path(os.environ['AWR_TEST_BINARY']).resolve()
+        self.version = os.environ['AWR_TEST_VERSION']
+        (self.root/'map.toml').write_text("[project]\nname='Guide'\ncontext_profile='minimal'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='work.yaml'\nadapter='yaml-ledger-v1'\n")
+        (self.root/'work.yaml').write_text('goals:\n- id: G\n  title: Deliver a useful guide\n  status: active\nwork_items:\n- id: W\n  title: Draft the guide\n  status: in_progress\n  goal: G\n  next_action: Review examples\n  acceptance: [Reviewed guide]\n')
+        host = Host(self.binary, digest(self.binary), self.root, self.root/'init-receipts')
+        host.ok('init','--manifest','map.toml','--accept')
+        self.pid = host.ok('status')['project_id']
+        self.wf = self.open_workflow('workflow/state.json')
+
+    def open_workflow(self, state):
+        return Workflow(self.binary,digest(self.binary),self.version,self.root,self.pid,self.root/state)
+
+    def revision(self):
+        return self.wf.host.ok('session','list')['project_revision']
+
+    def begin(self):
+        value = self.wf.begin('W','writer','fixture','no-model',self.revision())
+        self.session = value['session']['id']
+        context = self.wf.context()
+        # Synthetic host consumes the actual rendered pack and validates its work/criterion.
+        self.assertIn('Reviewed guide',context['work_context']['rendered_context'])
+        self.assertEqual(context['work_context']['identity']['work_item_key'],'W')
+        return context['work_context']['context_hash']
+
+    def test_full_lifecycle_requires_consumption_and_preserves_real_receipts(self):
+        context_hash = self.begin()
+        with self.assertRaises(ValueError):
+            self.wf.checkpoint(context_hash,'Reviewed draft','Deliver guide',self.revision())
+        with self.assertRaises(ValueError): self.wf.acknowledge('0'*64)
+        self.wf.acknowledge(context_hash)
+        checkpoint = self.wf.checkpoint(context_hash,'Reviewed draft','Deliver guide',self.revision())
+        source_sha = 'a'*40
+        report = dict(version=1,work_item='W',source_sha=source_sha,command='Inspect the guide fixture',scope=['W'],verified_at=time.time_ns()//1000000,
+                      checks=[dict(name='Guide reviewed',passed=True,details='Checked the synthetic guide artifact',criteria=['Reviewed guide'])])
+        path = self.root/'report.json';path.write_text(json.dumps(report))
+        draft = dict(external_key='GUIDE-E',work_item_key='W',evidence_type='completion_report',level='locally_verified',summary='Synthetic guide reviewed',locator='report.json',sha256=digest(path),source_sha=source_sha,command=report['command'],scope=['W'],branch_id=None,verified_at=report['verified_at'])
+        self.wf.evidence(draft,self.revision())
+        done = self.wf.finish(dict(version=1,source_sha=source_sha,acceptance=[dict(criterion='Reviewed guide',evidence=['GUIDE-E'])]),'Reviewed synthetic evidence',self.revision())
+        self.assertEqual(done['session']['status'],'ended')
+        self.assertEqual(self.wf.state['phase'],'ended')
+        self.assertEqual(self.wf.host.ok('work','show','W')['work']['status'],'completed')
+        self.assertEqual(self.wf.state['checkpoint'],checkpoint['checkpoint']['id'])
+        self.assertEqual(len(self.wf.state['history']),5)
+        with self.assertRaises(ValueError): self.wf.begin('W','other','fixture','none',self.revision())
+
+    def test_lost_checkpoint_receipt_requires_inspection_and_never_replays(self):
+        context_hash = self.begin();self.wf.acknowledge(context_hash)
+        original = self.wf.host.call
+        def lose(*args, **kwargs):
+            result = original(*args,**kwargs)  # Real side effect happened; caller loses its answer.
+            result.require()
+            return Result(None,b'',b'',result.receipt,True)
+        revision = self.revision()
+        with patch.object(self.wf.host,'call',side_effect=lose) as call:
+            with self.assertRaises(CommandFailed): self.wf.checkpoint(context_hash,'Review complete','Deliver guide',revision)
+            self.assertEqual(call.call_count,1)  # Exactly one attempted checkpoint, with a real saved effect.
+        self.assertEqual(self.wf.state['pending']['outcome'],'unknown')
+        reopened = self.open_workflow('workflow/state.json')
+        with self.assertRaises(ValueError): reopened.checkpoint(context_hash,'Duplicate','Deliver',self.revision())
+        view = reopened.inspect();before = self.revision()
+        self.assertIsNotNone(view['recovery']['checkpoint'])
+        resumed = reopened.reconcile(view['inspection']['sha256'],'Observed the saved checkpoint; continue without replay')
+        self.assertFalse(resumed['side_effects_replayed']);self.assertEqual(self.revision(),before)
+        self.assertEqual(reopened.state['history'][-1]['resolution'],'operator_reconciled')
+
+    def test_stale_revision_pin_and_context_tampering_are_rejected(self):
+        h = self.begin();self.wf.acknowledge(h)
+        with self.assertRaises(CommandFailed) as failure:
+            self.wf.checkpoint(h,'Review','Next',0)
+        self.assertEqual(failure.exception.result.error['code'],'RevisionConflict')
+        observed = self.wf.inspect()
+        self.wf.reconcile(observed['inspection']['sha256'],'Revision rejection observed; no operation replayed')
+        original = self.wf.state['context']['output']
+        Path(original).write_text('{}')
+        with self.assertRaises(ValueError):self.wf.checkpoint(h,'Review','Next',self.revision())
+        with self.assertRaises(ValueError):Workflow(self.binary,'0'*64,self.version,self.root,self.pid,self.root/'bad/state.json')
+        with self.assertRaises(ValueError):Workflow(self.binary,digest(self.binary),'99.0.0',self.root,self.pid,self.root/'version/state.json')
+
+    def test_existing_session_adoption_retains_identity(self):
+        self.begin();other=self.open_workflow('other/state.json')
+        adopted=other.adopt(self.session,'W')
+        self.assertEqual(adopted['session']['id'],self.session)
+        self.assertIsNone(other.state['context'])
+        with self.assertRaises(ValueError):other.acknowledge('a'*64)

--- a/examples/host-app/workflow.py
+++ b/examples/host-app/workflow.py
@@ -15,7 +15,8 @@ from host import Host, CommandFailed, digest, protected_file
 def atomic_json(path, value):
     temporary = protected_file(path.parent, '.tmp', json.dumps(value, ensure_ascii=False, indent=2).encode())
     try:
-        with temporary.open('rb') as stream:
+        # Windows fsync requires a writable descriptor; do not truncate the payload.
+        with temporary.open('r+b') as stream:
             os.fsync(stream.fileno())
         os.replace(temporary, path)
         if os.name == 'posix':

--- a/examples/host-app/workflow.py
+++ b/examples/host-app/workflow.py
@@ -1,0 +1,306 @@
+"""Explicit AWR work lifecycle over the pinned public CLI (Python 3.11+)."""
+import argparse
+from contextlib import contextmanager
+from functools import wraps
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+import uuid
+
+from host import Host, CommandFailed, digest, protected_file
+
+
+def atomic_json(path, value):
+    temporary = protected_file(path.parent, '.tmp', json.dumps(value, ensure_ascii=False, indent=2).encode())
+    try:
+        with temporary.open('rb') as stream:
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        if os.name == 'posix':
+            fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def serialized(method):
+    @wraps(method)
+    def wrapped(self, *args, **kwargs):
+        with self.guard():
+            self.state = json.loads(self.path.read_text())
+            if self.state['binding'] != self.binding:
+                raise ValueError('Workflow program/project binding changed')
+            return method(self, *args, **kwargs)
+    return wrapped
+
+
+class Workflow:
+    """Caller-driven protocol: deliver context, consume it, acknowledge, then save.
+
+    An acknowledgement is a caller attestation, not proof of model comprehension.
+    No method executes report commands or automatically retries uncertain writes.
+    """
+    def __init__(self, binary, sha256, version, project, project_id, state_path):
+        self.path = Path(state_path).absolute()
+        if self.path.is_symlink():
+            raise ValueError('Workflow state must not be a symlink')
+        self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.binding = dict(binary=str(Path(binary).resolve(strict=True)), sha256=sha256,
+                            version=version, project=str(Path(project).resolve(strict=True)),
+                            project_id=project_id)
+        if digest(self.binding['binary']) != sha256:
+            raise ValueError('Executable differs from the trusted pinned checksum')
+        self.host = Host(binary, sha256, project,
+                         self.path.parent / 'receipts' / str(uuid.uuid4()))
+        self.host.discover(version, ['session.checkpoint', 'context.compile', 'evidence.read_write', 'completion.engineering'])
+        with self.guard():
+            if self.path.exists():
+                self.state = json.loads(self.path.read_text())
+                if self.state.get('version') != 1 or self.state['binding'] != self.binding:
+                    raise ValueError('Workflow program/project binding differs; use its original pin')
+            else:
+                status = self.host.ok('status')
+                if status['project_id'] != project_id:
+                    raise ValueError('Project identity differs from the selected binding')
+                self.state = dict(version=1, binding=self.binding, session=None, work=None,
+                                  phase='new', context=None, pending=None, history=[])
+                self.save()
+
+    @contextmanager
+    def guard(self):
+        """OS lock releases on process exit; the durable pending record survives."""
+        lock = self.path.with_suffix(self.path.suffix + '.lock')
+        fd = os.open(lock, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            if os.name == 'posix':
+                import fcntl
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            else:
+                import msvcrt
+                if os.fstat(fd).st_size == 0:
+                    os.write(fd, b'0')
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            yield
+        finally:
+            os.close(fd)
+
+    def save(self):
+        atomic_json(self.path, self.state)
+
+    def available(self):
+        if self.state['pending']:
+            raise ValueError('Unknown or failed operation remains; inspect and explicitly reconcile first')
+
+    def active(self):
+        self.available()
+        if self.state['phase'] != 'active' or not self.state['session']:
+            raise ValueError('An active, explicitly selected session is required')
+
+    def perform(self, operation, args, value=None):
+        self.available()
+        self.state['pending'] = dict(id=str(uuid.uuid4()), operation=operation, args=args,
+                                     receipts=str(self.host.receipts), outcome='pending')
+        self.save()  # Before invoking any possible side effect.
+        result = self.host.call(*args) if value is None else self.host.input(args, value)
+        self.state['pending'].update(receipt=str(result.receipt),
+                                     outcome='unknown' if result.outcome_unknown else 'returned',
+                                     exit_code=result.exit_code)
+        self.save()
+        return result.require()  # Error/timeout retains the pending operation.
+
+    def completed(self, value, **updates):
+        self.state['history'].append(self.state['pending'])
+        self.state.update(updates, pending=None, last_revision=value['project_revision'])
+        self.save()
+        return value
+
+    def session_identity(self, session, work):
+        value = self.host.ok('session', 'show', session)
+        item = self.host.ok('work', 'show', work)
+        if value['session']['work_item_id'] != item['work']['id']:
+            raise ValueError('Selected session belongs to another work item')
+        if value['session']['project_id'] != self.binding['project_id']:
+            raise ValueError('Selected session belongs to another project')
+        return value, item
+
+    @serialized
+    def begin(self, work, agent, provider, model, expected_revision):
+        self.available()
+        if self.state['phase'] != 'new':
+            raise ValueError('Workflow already has a session; inspect or adopt it explicitly')
+        value = self.perform('begin', ['session', 'start', '--work', work, '--agent', agent,
+            '--provider', provider, '--model', model, '--claim', '--expected-revision', str(expected_revision)])
+        return self.completed(value, session=value['session']['id'], work=work, phase='active')
+
+    @serialized
+    def adopt(self, session, work):
+        self.available()
+        if self.state['phase'] != 'new':
+            raise ValueError('Adoption requires a new workflow state')
+        value, _ = self.session_identity(session, work)
+        if value['session']['status'] != 'active':
+            raise ValueError('Only an active session can be adopted')
+        self.state.update(session=session, work=work, phase='active', last_revision=value['project_revision'])
+        self.save()
+        return value
+
+    @serialized
+    def context(self):
+        self.active()
+        self.state['context'] = None
+        self.save()
+        result = self.host.call('context', 'compile', '--session', self.state['session'], '--work', self.state['work'])
+        value = result.require()
+        if not value['completeness']['complete'] or not value.get('work_context'):
+            raise ValueError('Context is incomplete; do not execute')
+        receipt = json.loads(result.receipt.read_text())
+        output = result.receipt.parent / receipt['stdout']
+        self.state['context'] = dict(hash=value['work_context']['context_hash'], output=str(output),
+                                    sha256=digest(output), revision=value['project_revision'], acknowledged=False)
+        self.save()
+        return value  # Full rendered context must actually reach the caller.
+
+    def delivered(self, consumed_hash):
+        context = self.state.get('context')
+        if not context or context['hash'] != consumed_hash or digest(context['output']) != context['sha256']:
+            raise ValueError('Hash does not identify this workflow\'s intact delivered context')
+        value = json.loads(Path(context['output']).read_text())
+        if value['session_id'] != self.state['session'] or value['work_context']['context_hash'] != consumed_hash:
+            raise ValueError('Delivered context/session mismatch')
+        return context
+
+    @serialized
+    def acknowledge(self, consumed_hash):
+        self.active()
+        context = self.delivered(consumed_hash)
+        context['acknowledged'] = True
+        context['acknowledgement_basis'] = 'caller attests that this exact context was consumed'
+        self.save()
+        return context
+
+    @serialized
+    def checkpoint(self, consumed_hash, digest_text, next_action, expected_revision):
+        self.active()
+        if not self.delivered(consumed_hash)['acknowledged']:
+            raise ValueError('Explicit consumption acknowledgement is required before checkpointing')
+        value = self.perform('checkpoint', ['session', 'checkpoint', '--session', self.state['session'],
+            '--context-hash', consumed_hash, '--digest', digest_text, '--next-action', next_action,
+            '--expected-revision', str(expected_revision)])
+        return self.completed(value, checkpoint=value['checkpoint']['id'])
+
+    @serialized
+    def evidence(self, draft, expected_revision):
+        self.active()
+        if draft.get('work_item_key') != self.state['work']:
+            raise ValueError('Evidence must reference the selected work item')
+        value = self.perform('evidence', ['evidence', 'add', '--expected-revision', str(expected_revision)], draft)
+        return self.completed(value)
+
+    @serialized
+    def finish(self, completion, reason, expected_revision):
+        self.available()
+        if self.state['phase'] == 'active':
+            context = self.state.get('context')
+            if not context or not self.delivered(context['hash'])['acknowledged']:
+                raise ValueError('Consume and acknowledge context before completing work')
+            value = self.perform('complete', ['work', 'complete', self.state['work'], '--session', self.state['session'],
+                '--reason', reason, '--expected-revision', str(expected_revision)], completion)
+            self.completed(value, phase='work_completed')
+            expected_revision = value['project_revision']
+        if self.state['phase'] != 'work_completed':
+            raise ValueError('Work must be completed before finishing its session')
+        value = self.perform('end', ['session', 'end', '--session', self.state['session'],
+                                   '--expected-revision', str(expected_revision)])
+        return self.completed(value, phase='ended')
+
+    @serialized
+    def inspect(self, session=None, work=None):
+        # These public reads preserve source files; CLI projection refresh may write cache.
+        sid, key = session or self.state['session'], work or self.state['work']
+        value = dict(binding=self.binding, phase=self.state['phase'], pending=self.state['pending'],
+                     session=None, work=None, recovery=None, side_effects_replayed=False)
+        if sid and key:
+            value['session'], value['work'] = self.session_identity(sid, key)
+            value['recovery'] = self.host.ok('recovery', 'inspect', '--session', sid)
+        else:
+            value['sessions'] = self.host.ok('session', 'list')
+        output = protected_file(self.host.receipts, '.inspection.json', json.dumps(value, ensure_ascii=False).encode())
+        self.state['inspection'] = dict(path=str(output), sha256=digest(output), pending_id=(self.state['pending'] or {}).get('id'))
+        self.save()
+        return dict(value, inspection=self.state['inspection'])
+
+    @serialized
+    def reconcile(self, inspection_sha256, reason, session=None, work=None):
+        """Explicit recovery decision after inspecting receipts; never replays a command."""
+        pending, observed = self.state['pending'], self.state.get('inspection')
+        if not pending or not observed or observed['pending_id'] != pending['id'] or observed['sha256'] != inspection_sha256:
+            raise ValueError('Inspect this exact pending operation before reconciliation')
+        if not reason.strip() or digest(observed['path']) != inspection_sha256:
+            raise ValueError('An intact inspection and explicit reconciliation reason are required')
+        sid, key = session or self.state['session'], work or self.state['work']
+        if not sid or not key:
+            raise ValueError('Recover a specific observed session; unbound begin outcomes need explicit adoption')
+        value, item = self.session_identity(sid, key)
+        phase = 'ended' if value['session']['status'] != 'active' else ('work_completed' if item['work']['status'] == 'completed' else 'active')
+        # This records an operator decision, not inferred success of the uncertain command.
+        self.state['history'].append(dict(pending, resolution='operator_reconciled', reason=reason, inspection=observed))
+        if sid != self.state['session']:
+            self.state['context'] = None
+        self.state.update(pending=None, session=sid, work=key, phase=phase, last_revision=value['project_revision'])
+        self.save()
+        return dict(phase=phase, project_revision=value['project_revision'], side_effects_replayed=False)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    for key in ('binary', 'sha256', 'version', 'project', 'project-id', 'state'):
+        p.add_argument('--'+key, required=True)
+    sub = p.add_subparsers(dest='command', required=True)
+    begin = sub.add_parser('begin')
+    for key in ('work','agent','provider','model'):
+        begin.add_argument('--'+key, required=True)
+    begin.add_argument('--expected-revision', type=int, required=True)
+    adopt = sub.add_parser('adopt')
+    for key in ('session','work'):
+        adopt.add_argument('--'+key, required=True)
+    sub.add_parser('context')
+    ack = sub.add_parser('ack')
+    ack.add_argument('--consumed-hash', required=True)
+    checkpoint = sub.add_parser('checkpoint')
+    for key in ('consumed-hash','digest','next-action'):
+        checkpoint.add_argument('--'+key, required=True)
+    checkpoint.add_argument('--expected-revision', type=int, required=True)
+    evidence = sub.add_parser('evidence')
+    evidence.add_argument('--input', required=True)
+    evidence.add_argument('--expected-revision', type=int, required=True)
+    finish = sub.add_parser('finish')
+    finish.add_argument('--input', required=True)
+    finish.add_argument('--reason', required=True)
+    finish.add_argument('--expected-revision', type=int, required=True)
+    inspect = sub.add_parser('inspect')
+    inspect.add_argument('--session'); inspect.add_argument('--work')
+    reconcile = sub.add_parser('reconcile')
+    reconcile.add_argument('--inspection-sha256', required=True)
+    reconcile.add_argument('--reason', required=True)
+    reconcile.add_argument('--session'); reconcile.add_argument('--work')
+    args = vars(p.parse_args()); command = args.pop('command')
+    wf = Workflow(args.pop('binary'),args.pop('sha256'),args.pop('version'),args.pop('project'),args.pop('project_id'),args.pop('state'))
+    if 'input' in args:
+        args['draft' if command == 'evidence' else 'completion'] = json.loads(Path(args.pop('input')).read_text())
+    if command == 'checkpoint': args['digest_text'] = args.pop('digest')
+    value = getattr(wf, 'acknowledge' if command == 'ack' else command)(**args)
+    print(json.dumps(value, ensure_ascii=False, indent=2))
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except (ValueError, OSError, CommandFailed) as error:
+        print(json.dumps({'ok':False,'error':str(error),'automatic_retry':False}), file=sys.stderr)
+        sys.exit(1)

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -2,11 +2,11 @@
 
 Persistent work state and minimal context for long-running AI agents.
 
-AWR 0.3.1 installs the native Rust `awr` CLI and `awr-mcp` stdio server.
+AWR 0.3.2 installs the native Rust `awr` CLI and `awr-mcp` stdio server.
 Context compilation runs locally without an AI model call.
 
 ```sh
-npm install -g @originoneai/agent-work-runtime@0.3.1
+npm install -g @originoneai/agent-work-runtime@0.3.2
 awr --version
 awr --help
 awr-mcp --help
@@ -15,8 +15,8 @@ awr-mcp --help
 Without a global installation, select the command explicitly:
 
 ```sh
-npx --package=@originoneai/agent-work-runtime@0.3.1 awr --help
-npx --package=@originoneai/agent-work-runtime@0.3.1 awr-mcp --project /absolute/project
+npx --package=@originoneai/agent-work-runtime@0.3.2 awr --help
+npx --package=@originoneai/agent-work-runtime@0.3.2 awr-mcp --project /absolute/project
 ```
 
 The project must be initialized before starting its MCP server. Follow the

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@originoneai/agent-work-runtime",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Persistent work state and minimal context for long-running AI agents",
   "license": "Apache-2.0",
   "repository": {
@@ -24,9 +24,9 @@
     "tag": "latest"
   },
   "optionalDependencies": {
-    "@originoneai/agent-work-runtime-darwin-arm64": "0.3.1",
-    "@originoneai/agent-work-runtime-darwin-x64": "0.3.1",
-    "@originoneai/agent-work-runtime-linux-x64-gnu": "0.3.1",
-    "@originoneai/agent-work-runtime-win32-x64": "0.3.1"
+    "@originoneai/agent-work-runtime-darwin-arm64": "0.3.2",
+    "@originoneai/agent-work-runtime-darwin-x64": "0.3.2",
+    "@originoneai/agent-work-runtime-linux-x64-gnu": "0.3.2",
+    "@originoneai/agent-work-runtime-win32-x64": "0.3.2"
   }
 }

--- a/packaging/python/README.md
+++ b/packaging/python/README.md
@@ -2,17 +2,17 @@
 
 Persistent work state and minimal context for long-running AI agents.
 
-AWR 0.3.1 includes the native Rust `awr` CLI and `awr-mcp` stdio server.
+AWR 0.3.2 includes the native Rust `awr` CLI and `awr-mcp` stdio server.
 It provides command-line tools; context compilation runs locally.
 
 ```sh
-python -m pip install agent-work-runtime==0.3.1
+python -m pip install agent-work-runtime==0.3.2
 awr --version
 awr --help
 awr-mcp --help
 ```
 
-For an isolated application installation, use `pipx install agent-work-runtime==0.3.1` or `uv tool install agent-work-runtime==0.3.1`.
+For an isolated application installation, use `pipx install agent-work-runtime==0.3.2` or `uv tool install agent-work-runtime==0.3.2`.
 
 The project must be initialized before running
 `awr-mcp --project /absolute/project`. Follow the

--- a/tests/platform/native_cli.py
+++ b/tests/platform/native_cli.py
@@ -130,15 +130,15 @@ def main():
         denied.mkdir()
         (denied / 'project.toml').write_text("[project]\nname='Denied source'\n[[sources]]\ndomain='ledger'\nrole='primary'\npath='" + locator + "'\nadapter='yaml-ledger-v1'\n", encoding='utf-8')
         rejected = run('09-denied-' + label, 'init', '--manifest', 'project.toml', '--accept', accepted=False, root=denied)
-        index = rejected['stdout_report']['index']
-        require(rejected['code'] == 'SourceStale' and not index['ok'] and index['indexed'] == 0
-                and not index['sources'] and index['issues'], 'Outside source did not report its rejection')
-        # Init keeps a diagnosable project mapping even when a source is rejected.
-        # That empty runtime is not adoption: no source or work projection may exist.
-        with closing(sqlite3.connect((denied / '.awr/state.db').as_uri() + '?mode=ro', uri=True)) as db:
-            require(db.execute('SELECT count(*) FROM sources').fetchone()[0] == 0
-                    and db.execute('SELECT count(*) FROM work_items').fetchone()[0] == 0,
-                    'Denied outside source was adopted')
+        details = rejected['details']
+        require(rejected['code'] == 'SourceStale' and details['can_apply'] is False
+                and details['source_issues'], 'Outside source did not report its rejection')
+        require(all(details[field] is False for field in
+                    ['configuration_write_performed', 'runtime_write_performed',
+                     'source_write_performed', 'intake_staged']),
+                'Rejected preflight reported a write')
+        # Preflight rejects invalid sources before creating configuration or a database.
+        require(not (denied / '.awr').exists(), 'Denied outside source created runtime state')
         require(digest(outside) == outside_hash, 'Denied outside source was changed')
     report['conditions']['outside_source_rejected'] = True
     status = run('10-status', 'status')

--- a/tests/security/payloads/contract.json
+++ b/tests/security/payloads/contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract_id": "awr-security-payloads",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "work_item": "AWR-SEC-002",
   "target_cases": 32,
   "evidence_level": "local_component_and_cli",
@@ -180,6 +180,6 @@
       "expected": "reject_or_withhold_sensitive_fixture_values_and_keep_ordinary_business_text_usable"
     }
   ],
-  "secret_policy_version": 3,
+  "secret_policy_version": 4,
   "secret_policy_reference": "docs/reference/secret-boundaries.md"
 }

--- a/tests/security/payloads/secrets.rs
+++ b/tests/security/payloads/secrets.rs
@@ -574,7 +574,7 @@ fn legacy_search_redacts_summaries_omits_sensitive_identity_and_rebuilds_the_old
             },
         )
         .unwrap();
-    assert_eq!(report.index_policy_version, 5);
+    assert_eq!(report.index_policy_version, 6);
     let hit = report.hits.iter().find(|h| h.external_key == "W").unwrap();
     assert_eq!(hit.summary, "[redacted]");
     assert!(!serde_json::to_string(&report).unwrap().contains(SENTINEL));

--- a/tests/security/payloads/verify_secrets.py
+++ b/tests/security/payloads/verify_secrets.py
@@ -32,11 +32,11 @@ def main():
               "stage_passed": False, "item_completed": False, "e4_completed": 0, "runs": []}
     commands = [
         (["cargo", "test", "-p", "awr-core", "--lib", "secrets::tests", "--locked"],
-         r"test result: ok\. (\d+) passed; 0 failed; 0 ignored", 9),
+         r"test result: ok\. (\d+) passed; 0 failed; 0 ignored", 11),
         (["cargo", "test", "-p", "awr-runtime", "--test", "security_secrets", "--locked", "--", "--nocapture"],
          r"test result: ok\. (\d+) passed; 0 failed; 0 ignored", 11),
         ([sys.executable, "crates/awr-mcp/tests/security_secrets.py", "--awr", "target/debug/awr", "--mcp", "target/debug/awr-mcp"],
-         r"Ran (\d+) tests", 3),
+         r"Ran (\d+) tests", 4),
     ]
     observed = set()
     for index, (command, pattern, expected_count) in enumerate(commands, 1):


### PR DESCRIPTION
AWR 0.3.2 makes common project intake, source maintenance, work continuity and recovery operations available to hosts through explicit source-first contracts.

- Validate complete intake semantics before writes and distinguish public configuration prose from secret values.
- Preserve source identity across reviewed relocations and coordinate coherent CLI/MCP reads.
- Add compact work/goal/milestone status and a pinned host workflow for context acknowledgement, checkpoints, evidence and completion.
- Maintain mapped organization fields through previewed changes and recover interrupted writes.
- Add matched runtime snapshots, checks and offline restore/recovery, including resolved Git source identity.
- Update package versions, installation documentation and release notes to 0.3.2 while retaining all four native targets and schema 4.

The platform intake fixture now checks that rejected traversal and absolute-path sources leave no runtime directory or configuration writes. This follows the new preflight behavior and replaces its obsolete expectation of an empty initialized database. The updated fixture passes all 9 conditions locally. Version consistency, 4 release unit tests, 6 launcher tests and the staged public-tree check pass.

Windows verification also found read-only flush handles in database snapshot export and the host workflow journal. Both now use writable handles without truncating the already-written bytes. The existing snapshot and host lifecycle suites exercise these paths on every native platform.

The final source revision passed the complete native and distribution checks on macOS ARM, macOS Intel, Linux and Windows. Each native platform passed all 11 contract gates; macOS/Linux passed 441 Rust test functions and Windows passed its 423 applicable functions. The separate process-death recovery route, CLI/MCP parity, native lifecycle and all four package installation receipts passed. These checks cover runtime contracts and package installation; host-application and real-agent business acceptance remain separate.
